### PR TITLE
CMake build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,103 @@
+cmake_minimum_required(VERSION 3.15)
+
+# Include Guard
+set(CONFIGURED_ONCE TRUE CACHE INTERNAL
+    "A flag showing, that CMake has configured at least once.")
+
+# Prevent in-source builds
+if(${CMAKE_BINARY_DIR} STREQUAL ${CMAKE_SOURCE_DIR})
+    message(FATAL ERROR "Source folder cannot be safely used as build folder!")
+endif()
+
+##########################################################
+# oncvpsp
+##########################################################
+project(oncvpsp
+    VERSION 4.0.1
+    DESCRIPTION "Optimized norm-conserving Vanderbilt pseudopotentials"
+    LANGUAGES Fortran C)
+
+##########################################################
+# Build types
+##########################################################
+if (NOT CMAKE_BUILD_TYPE)
+  set (CMAKE_BUILD_TYPE RELEASE CACHE STRING
+      "Choose the type of build, options are: None Debug Release."
+      FORCE)
+endif (NOT CMAKE_BUILD_TYPE)
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+    message(STATUS "Building in debug mode")
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -g -O0 -Wall -fcheck=all -fbacktrace -ffpe-trap=invalid,zero,overflow")
+endif (CMAKE_BUILD_TYPE STREQUAL "Debug")
+if (CMAKE_BUILD_TYPE STREQUAL "Release")
+    message(STATUS "Building in release mode")
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -O3 -ffast-math -funroll-loops -DNDEBUG")
+endif (CMAKE_BUILD_TYPE STREQUAL "Release")
+
+##########################################################
+# Define the paths for static libraries and executables
+##########################################################
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
+    CACHE
+    PATH "Single output directory for building all libraries."
+)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
+    CACHE
+    PATH "Single output directory for building all libraries."
+)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+    CACHE
+    PATH "Single output directory for building all executables."
+)
+set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/modules
+    CACHE
+    PATH "Single output directory for building all Fortran modules."
+)
+
+###########################################################
+# Common variables
+###########################################################
+set(COMMON_LIBRARIES "")
+set(COMMON_INCLUDE_DIRECTORIES "")
+
+###########################################################
+# LAPACK
+###########################################################
+find_package(LAPACK REQUIRED HINTS ${LAPACK_ROOT} ${BLAS_ROOT})
+if (LAPACK_FOUND)
+    message(STATUS "LAPACK found.")
+    message(STATUS "  LAPACK libraries: ${LAPACK_LIBRARIES}")
+    message(STATUS "  LAPACK linker flags: ${LAPACK_LINKER_FLAGS}")
+else ()
+    message(FATAL ERROR "Failed to find LAPACK.")
+endif()
+list(APPEND COMMON_LIBRARIES ${LAPACK_LIBRARIES})
+
+###########################################################
+# LIBXC
+###########################################################
+find_package(Libxc COMPONENTS Fortran)
+if (Libxc_FOUND)
+    message(STATUS "Libxc version ${Libxc_VERSION} found.")
+    if (${Libxc_VERSION} VERSION_GREATER_EQUAL 5 AND ${Libxc_VERSION} VERSION_LESS 7)
+        set(LIBXC_LIBRARIES Libxc::xcf03)
+        list(APPEND COMMON_LIBRARIES ${LIBXC_LIBRARIES})
+        message(STATUS "  Libxc libraries: ${LIBXC_LIBRARIES}")
+    else()
+        message(STATUS "Only Libxc major versions 5 and 6 are supported. Setting Libxc_FOUND to FALSE.")
+        set(Libxc_FOUND FALSE)
+    endif()
+endif()
+
+###########################################################
+# CMake Configuration
+###########################################################
+# Save compile commands to `compile_commands.json` file
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+link_directories(${CMAKE_LIBRARY_PATH} ${COMMON_INCLUDE_DIRECTORIES})
+include_directories(${CMAKE_INCLUDE_PATH} ${COMMON_INCLUDE_DIRECTORIES})
+
+###########################################################
+# Subdirectories
+###########################################################
+add_subdirectory(src)

--- a/README.md
+++ b/README.md
@@ -2,47 +2,61 @@
 
 Pseudopotential development
 
-The official repository of the oncvpsp Fortran code to generate  
+The official repository of the oncvpsp Fortran code to generate
 optimized norm-conserving Vanderbilt pseudopotentials.
 
 ## Installation and usage
 
+### With CMake
+1. make a `build` directory in the root of the repository like `/path/to/oncvpsp/build`
+2. `cd` into the `build` directory
+3. run `cmake ..` from the `build` directory
+  a. to enable Libxc, pass the flag `-DLibxc_ROOT=/path/to/libxc`
+  b. to provide a path to LAPACK/BLAS, pass the flag(s) `-DLAPACK_ROOT=/path/to/lapack`, `-DBLAS_ROOT=/path/to/blas` (which might be the same as LAPACK!)
+  c. to change the build type (debug vs. release), pass the flag `-DCMAKE_BUILD_TYPE="Debug"` or `-DCMAKE_BUILD_TYPE="Release"`
+  d. to set the installation directory, pass the flag `-DCMAKE_INSTALL_PREFIX=/path/to/installation`
+4. run `make all >& make.log` (builds the executable targets `oncvpsp`, `oncvpsp_nr`, and `oncvpsp_r`)
+5. `cd ..` to go back to the root of the repository
+6. in the root of the repository run `set_path` to set up the test scripts
+7. `cd tests/data && ./TEST.sh` to run the tests
+
+### With make
 1. edit make.inc (or copy it from older oncvpsp-3*)
 
 2. make all >& make.log
 
 3. cd tests/data; evaluate TEST.report
-   
+
 The code provided here is intended for a Linux or Unix system with a Fortran 95 compiler.
-Your system must have lapack and blas installed to compile ONCVPSP, and 
+Your system must have lapack and blas installed to compile ONCVPSP, and
 gnuplot installed and in your $PATH to run it as recommended.  If these are
 not already on your system, they are available from <www.netlib.org/lapack>
-and <www.gnuplot.info>. As of release 3.2.3 and beyond, libxc is supported 
-for versions at least to libxc-2.2.1, available 
+and <www.gnuplot.info>. As of release 3.2.3 and beyond, libxc is supported
+for versions at least to libxc-2.2.1, available
 [here](http://www.tddft.org/programs/octopus/wiki/index.php/Libxc).
 
 To take advantage of the improved graphics in release 3.1.1, gnuplot
 version 4.6 (or later) is required (see [release_notes.md](doc/release_notes.md)
 for a workaround if this is not available).
 
-To compile, edit makefile.inc in this directory appropriately for your 
+To compile, edit makefile.inc in this directory appropriately for your
 libraries, compiler, and optimization flags. In the main directory,
 
     make all >& make.log
 
-and the executables oncvpsp.x and oncvpsp_nr.x should be created in src. 
+and the executables oncvpsp.x and oncvpsp_nr.x should be created in src.
 As of version 2.0.1, the relativistic executable oncvpsp_r.x is also made.
-I have most recently been using gfortran-4.7.2, but most of the code has 
+I have most recently been using gfortran-4.7.2, but most of the code has
 been successfully compiled using an old ifort compiler.
 
-Make runs *./set_path* script. This sets the correct path for your installation 
+Make runs *./set_path* script. This sets the correct path for your installation
 in the various shell scripts in scripts, and duplicates them in the tests directory.
 
-Make then runs *tests/data/Test.sh* testing a full set of features (as of 
-3.2.1). For each *<prefix>.dat* file, this produces a *<prefix>.out* file.  
+Make then runs *tests/data/Test.sh* testing a full set of features (as of
+3.2.1). For each *<prefix>.dat* file, this produces a *<prefix>.out* file.
 This is compared with *tests/ref/<prefix>.out* using the *fldiff* utility from
 Abinit, and produces *<prefix>.diff*, and summary lines from all  diffs
-are collected in TEST.report.  If a reported summary error appears to be 
+are collected in TEST.report.  If a reported summary error appears to be
 non-trivial, look at the *<prefix>.diff*.
 
 If *tests/compare.sh* fails, check the first line of *scripts/fldiff.pl*
@@ -54,8 +68,8 @@ follow the steps outlined in [users_guide](doc/users_guide.md).
 
 oncvpsp.x is designed to be run by the script run.sh found in tests.
 You will probably want to create a new directory in the oncvpsp main
-directory for your own psp input data and results.  The input should be 
-named *<prefix>.dat*, and the output will be *<prefix>.out*. The command 
+directory for your own psp input data and results.  The input should be
+named *<prefix>.dat*, and the output will be *<prefix>.out*. The command
 in your new directory
 
     ../scripts/run.sh <prefix>
@@ -72,11 +86,11 @@ will do the obvious, and the command
     ../scripts/extract.sh <prefix> <pspdirectory>
 
 will cause an ABINIT-readable pseudopotential file in the psp8 format, or a
-PWSCF-readable pseudopotential in the UPF format to be created in the 
-*~/<pspdirectory>*.  The plotting and pseudopotential data are all saved in the 
+PWSCF-readable pseudopotential in the UPF format to be created in the
+*~/<pspdirectory>*.  The plotting and pseudopotential data are all saved in the
 *<prefix>.out* file.  The last input datum on the first data line determines
 which format is produced by ONCVPSP.  A copy of the input data is also
-saved at the head of the *<prefix>.out* file.  The remaining text above the 
+saved at the head of the *<prefix>.out* file.  The remaining text above the
 "DATA FOR PLOTTING" line reports a variety of consistency checks, information
 about the pseudo wave functions, diagnostic checks, and convergence
 information (now also plotted).
@@ -107,9 +121,9 @@ Please see the files in doc directory for details on the code, input file format
 * [Support](./SUPPORT.md).
 * [Release Notes](./doc/release_notes.md)
 
-## How to cite oncvpsp 
+## How to cite oncvpsp
 
-If you use oncvpsp in your research, please consider citing the 
+If you use oncvpsp in your research, please consider citing the
 [following work](https://journals.aps.org/prb/abstract/10.1103/PhysRevB.88.085117):
 
 > Optimized norm-conserving Vanderbilt pseudopotentials

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -4,6 +4,7 @@
 #uses the scalar-relativistic all-electron atom calculation
 
 PREFIX=/Users/mverstra/CODES/ONCVPSP/GITHUB_VERSION/oncvpsp
+BIN_DIR=/Users/mverstra/CODES/ONCVPSP/GITHUB_VERSION/oncvpsp/src
 
 INFILE=$1.dat
 
@@ -15,7 +16,7 @@ PLOTFILE=$1.plot
 
 TEMP=$$.tmp
 
-$PREFIX/src/oncvpsp.x <$INFILE >$OUTFILE  #Edit if your executable is
+$BIN_DIR/oncvpsp.x <$INFILE >$OUTFILE  #Edit if your executable is
                                             #in another directory
 
 grep GHOST $OUTFILE

--- a/scripts/run_nr.sh
+++ b/scripts/run_nr.sh
@@ -4,6 +4,7 @@
 #uses the non-relativistic all-electron atom calculation
 
 PREFIX=/Users/mverstra/CODES/ONCVPSP/GITHUB_VERSION/oncvpsp
+BIN_DIR=/Users/mverstra/CODES/ONCVPSP/GITHUB_VERSION/oncvpsp/src
 
 INFILE=$1.dat
 
@@ -15,7 +16,7 @@ PLOTFILE=$1_nr.plot
 
 TEMP=$$.tmp
 
-$PREFIX/src/oncvpspnr.x <$INFILE >$OUTFILE
+$BIN_DIR/oncvpspnr.x <$INFILE >$OUTFILE
 
 grep GHOST $OUTFILE
 

--- a/scripts/run_r.sh
+++ b/scripts/run_r.sh
@@ -5,6 +5,7 @@
 #uses the fully-relativistic all-electron atom calculation
 
 PREFIX=/Users/mverstra/CODES/ONCVPSP/GITHUB_VERSION/oncvpsp
+BIN_DIR=/Users/mverstra/CODES/ONCVPSP/GITHUB_VERSION/oncvpsp/src
 
 INFILE=$1.dat
 
@@ -16,7 +17,7 @@ PLOTFILE=$1_r.plot
 
 TEMP=$$.tmp
 
-$PREFIX/src/oncvpspr.x <$INFILE >$OUTFILE  #Edit if your executable is
+$BIN_DIR/oncvpspr.x <$INFILE >$OUTFILE  #Edit if your executable is
                                             #in another directory
 
 awk 'BEGIN{out=0};/GNUSCRIPT/{out=0}; {if(out == 1) {print}};\

--- a/set_path
+++ b/set_path
@@ -1,45 +1,65 @@
 #!/bin/sh
 #edits various shell scripts to provide full path to executables
 
+if [ -f $(pwd)/src/oncvpsp.x ]
+then
+    echo "oncvpsp.x found in src/ from a make build"
+    NEW_BIN_DIR=`pwd`/src/
+elif [ -f $(pwd)/build/bin/oncvpsp.x ]
+then
+    echo "oncvpsp.x found in build/bin/ from a CMake build"
+    NEW_BIN_DIR=`pwd`/build/bin/
+else
+    echo "oncvpsp.x not found in src/ or build/bin/"
+    exit 1
+fi
 NEW_PREFIX=`pwd`
 
 cp scripts/extract.sh scripts/replot.sh tests/
 
-TMP=$$.tmp
+TMP1=$$.tmp
+TMP2=$$.tmp2
 
-sed -e /PREFIX=/s:PREFIX=.*$:PREFIX=$NEW_PREFIX: scripts/run.sh >$TMP
-cp $TMP tests/run.sh
-cp $TMP scripts/run.sh
+sed -e /PREFIX=/s:PREFIX=.*$:PREFIX=$NEW_PREFIX: scripts/run.sh >$TMP1
+sed -e /BIN_DIR=/s:BIN_DIR=.*$:BIN_DIR=$NEW_BIN_DIR: $TMP1 >$TMP2
+cp $TMP2 tests/run.sh
+cp $TMP2 scripts/run.sh
 
-sed -e /PREFIX=/s:PREFIX=.*$:PREFIX=$NEW_PREFIX: scripts/run_nr.sh >$TMP
-cp $TMP tests/run_nr.sh
-cp $TMP scripts/run_nr.sh
+sed -e /PREFIX=/s:PREFIX=.*$:PREFIX=$NEW_PREFIX: scripts/run_nr.sh >$TMP1
+sed -e /BIN_DIR=/s:BIN_DIR=.*$:BIN_DIR=$NEW_BIN_DIR: $TMP1 >$TMP2
+cp $TMP2 tests/run_nr.sh
+cp $TMP2 scripts/run_nr.sh
 
-sed -e /PREFIX=/s:PREFIX=.*$:PREFIX=$NEW_PREFIX: scripts/run_r.sh >$TMP
-cp $TMP tests/run_r.sh
-cp $TMP scripts/run_r.sh
+sed -e /PREFIX=/s:PREFIX=.*$:PREFIX=$NEW_PREFIX: scripts/run_r.sh >$TMP1
+sed -e /BIN_DIR=/s:BIN_DIR=.*$:BIN_DIR=$NEW_BIN_DIR: $TMP1 >$TMP2
+cp $TMP2 tests/run_r.sh
+cp $TMP2 scripts/run_r.sh
 
-sed -e /PREFIX=/s:PREFIX=.*$:PREFIX=$NEW_PREFIX: scripts/run_nr.sh >$TMP
-cp $TMP tests/multirun_nr.sh
-cp $TMP scripts/run_nr.sh
+sed -e /PREFIX=/s:PREFIX=.*$:PREFIX=$NEW_PREFIX: scripts/run_nr.sh >$TMP1
+sed -e /BIN_DIR=/s:BIN_DIR=.*$:BIN_DIR=$NEW_BIN_DIR: $TMP1 >$TMP2
+cp $TMP2 tests/multirun_nr.sh
+cp $TMP2 scripts/run_nr.sh
 
-sed -e /PREFIX=/s:PREFIX=.*$:PREFIX=$NEW_PREFIX: scripts/run_r.sh >$TMP
-cp $TMP tests/multirun_r.sh
-cp $TMP scripts/run_r.sh
+sed -e /PREFIX=/s:PREFIX=.*$:PREFIX=$NEW_PREFIX: scripts/run_r.sh >$TMP1
+sed -e /BIN_DIR=/s:BIN_DIR=.*$:BIN_DIR=$NEW_BIN_DIR: $TMP1 >$TMP2
+cp $TMP2 tests/multirun_r.sh
+cp $TMP2 scripts/run_r.sh
 
-sed -e /PREFIX=/s:PREFIX=.*$:PREFIX=$NEW_PREFIX: scripts/compare.sh >$TMP
-cp $TMP tests/compare.sh
-cp $TMP scripts/compare.sh
+sed -e /PREFIX=/s:PREFIX=.*$:PREFIX=$NEW_PREFIX: scripts/compare.sh >$TMP1
+sed -e /BIN_DIR=/s:BIN_DIR=.*$:BIN_DIR=$NEW_BIN_DIR: $TMP1 >$TMP2
+cp $TMP2 tests/compare.sh
+cp $TMP2 scripts/compare.sh
 
-sed -e /PREFIX=/s:PREFIX=.*$:PREFIX=$NEW_PREFIX: scripts/compare_r.sh >$TMP
-cp $TMP tests/compare_r.sh
-cp $TMP scripts/compare_r.sh
+sed -e /PREFIX=/s:PREFIX=.*$:PREFIX=$NEW_PREFIX: scripts/compare_r.sh >$TMP1
+sed -e /BIN_DIR=/s:BIN_DIR=.*$:BIN_DIR=$NEW_BIN_DIR: $TMP1 >$TMP2
+cp $TMP2 tests/compare_r.sh
+cp $TMP2 scripts/compare_r.sh
 
-sed -e /PREFIX=/s:PREFIX=.*$:PREFIX=$NEW_PREFIX: scripts/compare_psml.sh >$TMP
-cp $TMP tests/compare_psml.sh
-cp $TMP scripts/compare_psml.sh
+sed -e /PREFIX=/s:PREFIX=.*$:PREFIX=$NEW_PREFIX: scripts/compare_psml.sh >$TMP1
+sed -e /BIN_DIR=/s:BIN_DIR=.*$:BIN_DIR=$NEW_BIN_DIR: $TMP1 >$TMP2
+cp $TMP2 tests/compare_psml.sh
+cp $TMP2 scripts/compare_psml.sh
 
 chmod u+x tests/*sh
 
-rm $TMP
-
+rm $TMP1 $TMP2

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,146 @@
+###########################################################
+# ONCVPSP library
+###########################################################
+set(src_liboncvpsp
+    aeo.f90
+    check_data.f90
+    const_basis.f90
+    der2exc.f90
+    dpnint.f90
+    eresid.f90
+    exc_off_pbe.f
+    exchdl.f90
+    excpzca.f90
+    excwig.f90
+    gg1cc.f90
+    gp1cc.f90
+    gpp1cc.f90
+    ldiracfb.f90
+    ldiracfs.f90
+    lschfb.f90
+    lschfs.f90
+    lschkb.f90
+    lschpb.f90
+    lschps.f90
+    lschpsbar.f90
+    lschpse.f90
+    lschvkbb.f90
+    lschvkbbe.f90
+    lschvkbs.f90
+    m_libxc_list.F90
+    m_psmlout.f90
+    modcore.f90
+    modcore2.f90
+    modcore3.f90
+    optimize.f90
+    pspot.f90
+    qroots.f90
+    run_ghosts.f90
+    run_optimize.f90
+    sbf_basis_con.f90
+    sbf_basis.f90
+    sbf_rc_der.f90
+    sbf8.f90
+    tfapot.f90
+    vkboutwf.f90
+    vkbphsft.f90
+    vout.f90
+    vpinteg.f90
+    vploc.f90
+    vrel.f90
+    wf_rc_der.f90
+)
+if (Libxc_FOUND)
+    list(APPEND src_liboncvpsp functionals.F90 exc_libxc.f90)
+else ()
+    list(APPEND src_liboncvpsp exc_libxc_stub.f90)
+endif ()
+add_library(liboncvpsp STATIC ${src_liboncvpsp})
+add_dependencies(liboncvpsp wxml)
+target_link_libraries(liboncvpsp wxml ${COMMON_LIBRARIES})
+
+###########################################################
+# ONCVPSP non- and scalar-relativistic library
+###########################################################
+set(src_liboncvpsp_nr_sr
+    fphsft.f90
+    fpovlp.f90
+    gnu_script.f90
+    linout.f90
+    psatom.f90
+    relatom.f90
+    run_config.f90
+    run_diag.f90
+    run_phsft.f90
+    run_plot.f90
+    run_vkb.f90
+    sratom.f90
+    upfout.f90
+    wellstate.f90
+)
+add_library(liboncvpsp_nr_sr STATIC ${src_liboncvpsp_nr_sr})
+add_dependencies(liboncvpsp_nr_sr liboncvpsp wxml)
+target_link_libraries(liboncvpsp_nr_sr liboncvpsp wxml ${COMMON_LIBRARIES})
+
+###########################################################
+# ONCVPSP relativistic library
+###########################################################
+set(src_liboncvpsp_r
+    fphsft_r.f90
+    fpovlp.f90
+    gnu_script_r.f90
+    linout_r.f90
+    psatom_r.f90
+    relatom.f90
+    renorm_r.f90
+    run_config_r.f90
+    run_diag_r.f90
+    run_diag_sr_so_r.f90
+    run_phsft_r.f90
+    run_plot_r.f90
+    run_vkb_r.f90
+    sr_so_r.f90
+    upfout_r.f90
+    wellstate_r.f90
+)
+add_library(liboncvpsp_r STATIC ${src_liboncvpsp_r})
+add_dependencies(liboncvpsp_r liboncvpsp wxml)
+target_link_libraries(liboncvpsp_r liboncvpsp wxml ${COMMON_LIBRARIES})
+
+###########################################################
+# oncvpsp.x
+###########################################################
+add_executable(oncvpsp oncvpsp.f90)
+add_dependencies(oncvpsp liboncvpsp_nr_sr)
+target_link_libraries(oncvpsp liboncvpsp_nr_sr)
+set_target_properties(oncvpsp
+    PROPERTIES
+        OUTPUT_NAME oncvpsp.x
+)
+
+##########################################################
+# oncvpspnr.x
+##########################################################
+add_executable(oncvpspnr oncvpsp_nr.f90)
+add_dependencies(oncvpspnr liboncvpsp_nr_sr)
+target_link_libraries(oncvpspnr liboncvpsp_nr_sr)
+set_target_properties(oncvpspnr
+    PROPERTIES
+        OUTPUT_NAME oncvpspnr.x
+)
+
+##########################################################
+# oncvpspr.x
+##########################################################
+add_executable(oncvpspr oncvpsp_r.f90)
+add_dependencies(oncvpspr liboncvpsp_r)
+target_link_libraries(oncvpspr liboncvpsp_r)
+set_target_properties(oncvpspr
+    PROPERTIES
+        OUTPUT_NAME oncvpspr.x
+)
+
+###########################################################
+# Subdirectories
+###########################################################
+add_subdirectory(xmlf90-wxml)

--- a/src/xmlf90-wxml/CMakeLists.txt
+++ b/src/xmlf90-wxml/CMakeLists.txt
@@ -1,0 +1,13 @@
+set(src_wxml
+    xmlf90_wxml.f90
+    m_wxml_buffer.f90
+    m_wxml_core.f90
+    m_wxml_dictionary.f90
+    m_wxml_elstack.f90
+    m_wxml_text.f90
+)
+
+###########################################################
+# xmlf90-wxml library
+###########################################################
+add_library(wxml STATIC ${src_wxml})


### PR DESCRIPTION
To make it easier to build ONCVPSP and so that it could be easily incorporated into other projects.

Libxc and LAPACK dependencies can be automatically searched for or manually configured with the `-DLibxc_ROOT`, `-DLAPACK_ROOT`, and `-DBLAS_ROOT` flags.

Building without Libxc is supported; if it is not found, `exc_libxc_stub.f90` is built.

Instructions for building with CMake are included in the README.