### PR TITLE
Add pre-commit hooks including fortitude linter, findent formatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,53 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-added-large-files
+        args: ["--maxkb=5000"]
+      - id: end-of-file-fixer
+        exclude: |
+          (?x)^(
+            (scripts|tests|doc|extern|build)/.*|
+            .*\.md|
+            .*COPYING|
+            .*LICENSE|
+          )$
+      - id: check-case-conflict
+        exclude: (scripts|tests|doc|extern|build)/.*
+      - id: mixed-line-ending
+        exclude: (scripts|tests|doc|extern|build)/.*
+      - id: trailing-whitespace
+        exclude: |
+          (?x)^(
+            (scripts|tests|doc|extern|build)/.*|
+            .*\.md|
+            .*COPYING|
+            .*LICENSE|
+          )$
+  - repo: https://github.com/commitizen-tools/commitizen
+    rev: v4.9.1
+    hooks:
+      - id: commitizen
+        stages: [commit-msg]
+  - repo: https://github.com/PlasmaFAIR/fortitude-pre-commit
+    rev: v0.7.5
+    hooks:
+      - id: fortitude
+        args: ["--fix"]
+        exclude: (scripts|tests|doc|extern|build)/.*
+  - repo: https://github.com/zmoon/findent-pre-commit
+    rev: 527f61f770f504abd87f97932b510b8dce07ab3a
+    hooks:
+      - id: wfindent-pypi
+        args:
+          [
+            -ofree,
+            -i3,
+            --refactor_end,
+            --indent_contains=restart,
+            --indent-continuation=default,
+            --indent_ampersand,
+            --align_paren,
+          ]
+        additional_dependencies: [findent==4.3.1]
+        exclude: (scripts|tests|doc|extern|build)/.*

--- a/Makefile
+++ b/Makefile
@@ -19,4 +19,3 @@ test:
 clean:
 	cd src ; $(MAKE) clean ; rm *.x; cd xmlf90-wxml/ ; $(MAKE) clean
 	cd tests/data ; /bin/rm -f *.out *.diff TEST.report
-

--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ optimized norm-conserving Vanderbilt pseudopotentials.
 
 3. cd tests/data; evaluate TEST.report
 
+### Developing ONCVPSP
+1. install `pre-commit` using your package manager of preference
+2. from the repository root, run `pre-commit install`
+3. before every commit, `pre-commit` will automatically run and use various tools to ensure code quality and style standards are met.
+
+The key tools run by `pre-commit` are `findent` for code formatting and `fortitude` for code linting. `findent` is configured directly in `.pre-commit-config.yaml`, while `fortitude` is configured in `fortitude.toml`.
+
 The code provided here is intended for a Linux or Unix system with a Fortran 95 compiler.
 Your system must have lapack and blas installed to compile ONCVPSP, and
 gnuplot installed and in your $PATH to run it as recommended.  If these are

--- a/fortitude.toml
+++ b/fortitude.toml
@@ -1,0 +1,19 @@
+[check]
+# E - Error
+# C - correctness
+# S - Style
+select = ["E", "C", "S"]
+ignore = [
+    "C001", # missing-implicit-none
+    "C003", # missing-external
+    "C021", # no-real-suffix
+    "C061", # missing-intent
+    "C071", # assumed-size
+    "C072", # assumed-size-character-intent
+    "C081", # initialisation-in-declaration
+    "C092", # procedure-not-in-module
+    "C121", # use-missing-only
+    "C131", # missing-accessibility-statement
+    "C132", # default-public-accessibility
+]
+line-length = 132

--- a/make.inc
+++ b/make.inc
@@ -3,27 +3,27 @@
 #
 # Copyright (c) 1989-2014 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 # University
- 
+
 ##### Edit the following lines to correspond to your compilers ####
 
-F77        = /opt/homebrew/bin/gfortran	
-F90        = /opt/homebrew/bin/gfortran	
-CC         = /opt/homebrew/bin/gcc	
-FCCPP      = /opt/homebrew/bin/cpp-13
+F77        = /opt/homebrew/bin/gfortran
+F90        = /opt/homebrew/bin/gfortran
+CC         = /opt/homebrew/bin/gcc
+FCCPP      = /opt/homebrew/bin/cpp-15
 
 FLINKER     = $(F90)
 
-FCCPPFLAGS = -ansi 
+FCCPPFLAGS = -ansi -mmacosx-version-min=26.0
 
 ##### Edit the following optimization flags for your system ####
 
 
-FFLAGS     = -O3 -fallow-argument-mismatch -ffast-math -funroll-loops
-CFLAGS     = -O3
+FFLAGS     = -O3 -fallow-argument-mismatch -ffast-math -funroll-loops -mmacosx-version-min=26.0
+CFLAGS     = -O3 -mmacosx-version-min=26.0
 
 ##### Edit the following LAPACK and BLAS library paths for your system ####
 
-LIBS = -L/Users/mverstra/CODES/LAPACK/ -llapack -lblas
+LIBS = -L/Users/azadoks/.local/share/lapack-3.12.1/ -llapack -lblas
 
 ##### Edit the following for to use libxc if available #####
 
@@ -38,8 +38,7 @@ OBJS_LIBXC =	exc_libxc_stub.o
 #FCCPPFLAGS += -I/Users/mverstra/CODES/LIBXC/5.1.7/include
 #OBJS_LIBXC =    functionals.o exc_libxc.o
 
-LIBS += -L/Users/mverstra/CODES/LIBXC/6.0.0/lib -lxcf03 -lxc
-FFLAGS += -I/Users/mverstra/CODES/LIBXC/6.0.0/include
-FCCPPFLAGS += -I/Users/mverstra/CODES/LIBXC/6.0.0/include
-OBJS_LIBXC =	functionals.o exc_libxc.o 
-
+LIBS += -L/Users/azadoks/.local/share/libxc-6.2.2/lib -lxcf03 -lxc
+FFLAGS += -I/Users/azadoks/.local/share/libxc-6.2.2/include
+FCCPPFLAGS += -I/Users/azadoks/.local/share/libxc-6.2.2/include
+OBJS_LIBXC =	functionals.o exc_libxc.o

--- a/src/Makefile
+++ b/src/Makefile
@@ -55,7 +55,7 @@ oncvpspnr:	$(OBJS_OPSPNR)
 oncvpspr:	$(OBJS_OPSPR)
 		$(FLINKER) -o oncvpspr.x $(OBJS_OPSPR) $(LIBS) $(WXML_LIB)
 
-.SUFFIXES: 
+.SUFFIXES:
 .SUFFIXES: .c .o .f .f90 .F90
 
 .F90.o:
@@ -73,4 +73,3 @@ oncvpspr:	$(OBJS_OPSPR)
 
 clean:
 	 /bin/rm -f *.o  *.d  *.mod *.log *_cpp.f90
-

--- a/src/aeo.f90
+++ b/src/aeo.f90
@@ -2,17 +2,17 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
@@ -20,50 +20,49 @@
 ! outward and inward integration, Abramowitz and
 ! Stegun, p. 896
 
- function aeo(yy,jj)
+function aeo(yy,jj)
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
- real(dp) :: aeo,yy(*)
- integer :: jj
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
+   real(dp) :: aeo,yy(*)
+   integer :: jj
 
- aeo=(4.16666666667d-2)*(55.0d0*yy(jj)-59.0d0*yy(jj-1) &
-& +37.0d0*yy(jj-2)-9.0d0*yy(jj-3))
- return
- end function aeo
+   aeo=(4.16666666667d-2)*(55.0d0*yy(jj)-59.0d0*yy(jj-1) &
+   & +37.0d0*yy(jj-2)-9.0d0*yy(jj-3))
+   return
+end function aeo
 
- function aio(yy,jj)
+function aio(yy,jj)
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
- real(dp) :: aio,yy(*)
- integer :: jj
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
+   real(dp) :: aio,yy(*)
+   integer :: jj
 
- aio=(4.16666666667d-2)*(9.0d0*yy(jj+1)+19.0d0*yy(jj) &
-& -5.0d0*yy(jj-1)+yy(jj-2))
- return
- end function aio
+   aio=(4.16666666667d-2)*(9.0d0*yy(jj+1)+19.0d0*yy(jj) &
+   & -5.0d0*yy(jj-1)+yy(jj-2))
+   return
+end function aio
 
- function aei(yy,jj)
+function aei(yy,jj)
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
- real(dp) :: aei,yy(*)
- integer :: jj
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
+   real(dp) :: aei,yy(*)
+   integer :: jj
 
- aei=-(4.16666666667d-2)*(55.0d0*yy(jj)-59.0d0*yy(jj+1) &
-& +37.0d0*yy(jj+2)-9.0d0*yy(jj+3))
- return
- end function aei
+   aei=-(4.16666666667d-2)*(55.0d0*yy(jj)-59.0d0*yy(jj+1) &
+   & +37.0d0*yy(jj+2)-9.0d0*yy(jj+3))
+   return
+end function aei
 
- function aii(yy,jj)
+function aii(yy,jj)
 
- integer, parameter :: dp=kind(1.0d0)
- real(dp) :: aii,yy(*)
- integer :: jj
+   integer, parameter :: dp=kind(1.0d0)
+   real(dp) :: aii,yy(*)
+   integer :: jj
 
- aii=-(4.16666666667d-2)*(9.0d0*yy(jj-1)+19.0d0*yy(jj) &
-& -5.0d0*yy(jj+1)+yy(jj+2))
- return
- end function aii
-
+   aii=-(4.16666666667d-2)*(9.0d0*yy(jj-1)+19.0d0*yy(jj) &
+   & -5.0d0*yy(jj+1)+yy(jj+2))
+   return
+end function aii

--- a/src/check_data.f90
+++ b/src/check_data.f90
@@ -2,21 +2,21 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- subroutine check_data(atsym,zz,fcfact,rcfact,epsh1,epsh2,depsh,rlmax,drl, &
+subroutine check_data(atsym,zz,fcfact,rcfact,epsh1,epsh2,depsh,rlmax,drl, &
 &                      fa,facnf, &
 &                      rc,ep,qcut,debl,nc,nv,iexc,lmax,lloc,lpopt,icmod, &
 &                      ncnf,na,la,nvcnf,nacnf,lacnf,ncon,nbas,nproj,psfile)
@@ -26,240 +26,239 @@
 !*cnf variables are arrays of the basis atomic configuration variables
 !to be used for the test configurations
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 ! Input variables
- character*2 :: atsym
- character*4 :: psfile
+   character(len=2) :: atsym
+   character(len=4) :: psfile
 
- real(dp) :: zz,fcfact,rcfact,epsh1,epsh2,depsh,rlmax,drl
- real(dp) :: fa(30),facnf(30,5),rc(6),ep(6),qcut(6),cfloc(5),debl(5)
+   real(dp) :: zz,fcfact,rcfact,epsh1,epsh2,depsh,rlmax,drl
+   real(dp) :: fa(30),facnf(30,5),rc(6),ep(6),qcut(6),cfloc(5),debl(5)
 
- integer :: nc,nv,iexc,lmax,lloc,lpopt,icmod,ncnf
- integer :: na(30),la(30),nvcnf(5),nacnf(30,5),lacnf(30,5)
- integer :: ncon(6),nbas(6),nproj(6)
+   integer :: nc,nv,iexc,lmax,lloc,lpopt,icmod,ncnf
+   integer :: na(30),la(30),nvcnf(5),nacnf(30,5),lacnf(30,5)
+   integer :: ncon(6),nbas(6),nproj(6)
 
 ! Local variables
- integer :: ierr,ii,jj,l1
+   integer :: ierr,ii,jj,l1
 
- logical :: occ
+   logical :: occ
 
- real(dp) :: sf,rcmax
+   real(dp) :: sf,rcmax
 
- ierr=0
+   ierr=0
 
- if(trim(atsym)=='') then
-  write(6,'(a)') 'test_data: must have non-blank atsym'
-  ierr=ierr+1
- end if
+   if(trim(atsym)=='') then
+      write(6,'(a)') 'test_data: must have non-blank atsym'
+      ierr=ierr+1
+   end if
 
- if(trim(psfile)/='psp8' .and. trim(psfile)/='upf' &
-&   .and. trim(psfile)/='both') then
-  write(6,'(a)') 'test_data: psfile must == psp8 or upf or both'
-  ierr=ierr+1
- end if
+   if(trim(psfile)/='psp8' .and. trim(psfile)/='upf' &
+   &   .and. trim(psfile)/='both') then
+      write(6,'(a)') 'test_data: psfile must == psp8 or upf or both'
+      ierr=ierr+1
+   end if
 
- if(zz<=0.0d0) then
-  write(6,'(a)') 'test_data: must have positive atomic number z'
-  ierr=ierr+1
- end if
+   if(zz<=0.0d0) then
+      write(6,'(a)') 'test_data: must have positive atomic number z'
+      ierr=ierr+1
+   end if
 
- if(nc+nv<=0 .or. nc+nv>30) then
-  write(6,'(a)') 'test_data: must have 1 <= nc+nv <=30'
-  ierr=ierr+1
- end if
+   if(nc+nv<=0 .or. nc+nv>30) then
+      write(6,'(a)') 'test_data: must have 1 <= nc+nv <=30'
+      ierr=ierr+1
+   end if
 
- if(iexc==0 .or. iexc>4) then
-  write(6,'(a)') 'test_data: must have iexc <=4, iexc /= 0.'
-  write(6,'(a)') '  negative values for libxc'
-  ierr=ierr+1
- end if
+   if(iexc==0 .or. iexc>4) then
+      write(6,'(a)') 'test_data: must have iexc <=4, iexc /= 0.'
+      write(6,'(a)') '  negative values for libxc'
+      ierr=ierr+1
+   end if
 
- sf=0.0d0
- do ii=1,nc+nv
-  sf=sf+fa(ii)
-  if(la(ii)<0 .or. la(ii)>3) then
-   write(6,'(a,a,i4)') 'test_data: must have 0<= l <=3,', &
-&   ' reference configuration line',ii
-   ierr=ierr+1
-  end if
-  if(na(ii)<=la(ii)) then
-   write(6,'(a,i4)') 'test_data: l > n, reference configuration line',ii
-   ierr=ierr+1
-  end if
-  if(fa(ii)<=0.0d0) then
-   write(6,'(a,i4)') 'test_data: f <= 0.0, reference configuration line',ii
-   ierr=ierr+1
-  end if
- end do
-
- if(sf>zz) then
-  write(6,'(a)') 'test_data: reference configuration is negative ion'
-  ierr=ierr+1
- end if
-
- if(lmax<0 .or. lmax>3) then
-  write(6,'(a)') 'test_data: 0 <= lmax <= 3'
-  ierr=ierr+1
- end if
-
- do l1=1,lmax+1
-  if(rc(l1)<=0.0d0) then
-   write(6,'(a,i4)') 'test_data: must have rc>0.0, l=',l1-1
-   ierr=ierr+1
-  end if
-  if(ep(l1)<=0.0d0) then
-   occ=.false.
-   do ii=nc+1,nc+nv
-    if(la(ii)==l1-1) then
-     occ=.true.
-    end if
+   sf=0.0d0
+   do ii=1,nc+nv
+      sf=sf+fa(ii)
+      if(la(ii)<0 .or. la(ii)>3) then
+         write(6,'(a,a,i4)') 'test_data: must have 0<= l <=3,', &
+         &   ' reference configuration line',ii
+         ierr=ierr+1
+      end if
+      if(na(ii)<=la(ii)) then
+         write(6,'(a,i4)') 'test_data: l > n, reference configuration line',ii
+         ierr=ierr+1
+      end if
+      if(fa(ii)<=0.0d0) then
+         write(6,'(a,i4)') 'test_data: f <= 0.0, reference configuration line',ii
+         ierr=ierr+1
+      end if
    end do
+
+   if(sf>zz) then
+      write(6,'(a)') 'test_data: reference configuration is negative ion'
+      ierr=ierr+1
+   end if
+
+   if(lmax<0 .or. lmax>3) then
+      write(6,'(a)') 'test_data: 0 <= lmax <= 3'
+      ierr=ierr+1
+   end if
+
+   do l1=1,lmax+1
+      if(rc(l1)<=0.0d0) then
+         write(6,'(a,i4)') 'test_data: must have rc>0.0, l=',l1-1
+         ierr=ierr+1
+      end if
+      if(ep(l1)<=0.0d0) then
+         occ=.false.
+         do ii=nc+1,nc+nv
+            if(la(ii)==l1-1) then
+               occ=.true.
+            end if
+         end do
 !   if(.not. occ) then
 !     write(6,'(a,a,i4)') 'test_data: must have ep>0.0 for scattering state', &
 !&     ' l=',l1-1
 !     ierr=ierr+1
 !   end if
-  end if
+      end if
 
-  if(ncon(l1)<3 .or. ncon(l1)>5) then
-   write(6,'(a,i4)') 'test_data: must have 3 <= ncon <= 5, l=',l1-1
-   ierr=ierr+1
-  end if
-  if(nproj(l1)==2) then
-   if(nbas(l1)<ncon(l1)+3 .or. nbas(l1)>ncon(l1)+5) then
-    write(6,'(a,i4/a)') 'test_data: must have ncon+3 <= nbas <= ncon+5, l=',&
-&    l1-1,' for nproj=2'
-    ierr=ierr+1
-   end if
-  else
-   if(nbas(l1)<ncon(l1)+2 .or. nbas(l1)>ncon(l1)+5) then
-    write(6,'(a,i4)') 'test_data: must have ncon+2 <= nbas <= ncon+5, l=',l1-1
-    ierr=ierr+1
-   end if
-  end if
-  if(qcut(l1)<=0.0d0) then
-   write(6,'(a,i4)') 'test_data: must have qcut>0.0, l=',l1-1
-   ierr=ierr+1
-  end if
- end do
-
- if(lloc==4) then
-  if(lpopt<1 .or. lpopt>5) then
-    write(6,'(a)') 'test_data: must have 1 <= lpopt <= 5'
-    ierr=ierr+1
-  end if
-  if(rc(5)<=0.0d0) then
-    write(6,'(a)') 'test_data: for lloc==4, must have rc > 0.0'
-    ierr=ierr+1
-  end if
- else if(lloc<0 .or. lloc>lmax) then
-  write(6,'(a)') 'test_data: must have 0 <= lloc <= lmax or lloc == 4'
-  ierr=ierr+1
- end if
-
- do l1=1,lmax+1
-  if(rc(l1)<rc(lloc+1)) then
-    write(6,'(a,i2,a)') 'test_data: rc < rc(lloc) for l =',l1-1,&
-&         '.  Not allowed.'
-    ierr=ierr+1
-  end if
- end do
-
- do l1=1,lmax+1
-  if(nproj(l1)==0 .and. (lloc==4 .or. lloc==l1-1)) then
-   cycle
-  else if(nproj(l1)<1 .or. nproj(l1)>5) then
-   write(6,'(a,i4,a)') 'test_data: must have nproj in [1,5] (0 OK lloc=4 or', &
-&        l1-1,')'
-   ierr=ierr+1
-  end if
-  if(debl(l1)<0.0d0) then
-   write(6,'(a,i4)') 'test_data: must have debl>0.0)',l1-1
-   ierr=ierr+1
-  end if
- end do
-
- if(icmod<0 .or. icmod>4) then
-  write(6,'(a)') 'test_data: must have 0<= icmod <=4'
-  ierr=ierr+1
- end if
-
- if((icmod==1 .or. icmod==3) .and. fcfact<=0.0d0) then
-  write(6,'(a)') 'test_data: must have fcfact>0.0 for icmod= 1 or 3'
-  ierr=ierr+1
- end if
-
- if((icmod==3) .and. rcfact<=0.0d0) then
-  write(6,'(a)') 'test_data: must have rcfact>0.0 for icmod= 3'
-  ierr=ierr+1
- end if
-
- if(epsh2<epsh1) then
-  write(6,'(a)') 'test_data: must have epsh2 > epsh1'
-  ierr=ierr+1
- end if
- if(depsh<0.0d0) then
-  write(6,'(a)') 'test_data: must have depsh>0.0'
-  ierr=ierr+1
- end if
- 
- rcmax=0.0d0
- do l1=1,lmax+1
-  rcmax=max(rcmax,rc(l1))
- end do
- if(lloc==4) then
-  rcmax=max(rcmax,rc(5))
- end if
-
- if(rlmax<rcmax) then
-  write(6,'(a)') 'test_data: must have rlmax>rcmax'
-  ierr=ierr+1
- end if
-
- if(drl<=0.0d0) then
-  write(6,'(a)') 'test_data: must have drl > 0.0'
-  ierr=ierr+1
- end if
-
- if(ncnf<0 .or. ncnf>4)then
-  write(6,'(a)') 'test_data: must have 0 <= ncnf <= 4, skipping config. checks'
-  ierr=ierr+1
- else
-  do jj=2,ncnf+1
-   sf=0.0d0
-   do ii=1,nc+nvcnf(jj)
-    sf=sf+facnf(ii,jj)
-    if(lacnf(ii,jj)<0 .or. lacnf(ii,jj)>3) then
-     write(6,'(a,a,i4,a,i4)') 'test_data: must have 0<= l <=3,', &
-&     ' test configuration',jj-1, ' line',ii-nc
-     ierr=ierr+1
-    end if
-    if(nacnf(ii,jj)<=lacnf(ii,jj)) then
-     write(6,'(a,a,i4,a,i4)') 'test_data: l > n,', &
-&     ' test configuration',jj-1, ' line',ii-nc
-     ierr=ierr+1
-    end if
-    if(facnf(ii,jj)<0.0d0) then
-     write(6,'(a,a,i4,a,i4)') 'test_data: f < 0.0,', &
-&     ' test configuration',jj-1, ' line',ii-nc
-     ierr=ierr+1
-    end if
+      if(ncon(l1)<3 .or. ncon(l1)>5) then
+         write(6,'(a,i4)') 'test_data: must have 3 <= ncon <= 5, l=',l1-1
+         ierr=ierr+1
+      end if
+      if(nproj(l1)==2) then
+         if(nbas(l1)<ncon(l1)+3 .or. nbas(l1)>ncon(l1)+5) then
+            write(6,'(a,i4/a)') 'test_data: must have ncon+3 <= nbas <= ncon+5, l=',&
+            &    l1-1,' for nproj=2'
+            ierr=ierr+1
+         end if
+      else
+         if(nbas(l1)<ncon(l1)+2 .or. nbas(l1)>ncon(l1)+5) then
+            write(6,'(a,i4)') 'test_data: must have ncon+2 <= nbas <= ncon+5, l=',l1-1
+            ierr=ierr+1
+         end if
+      end if
+      if(qcut(l1)<=0.0d0) then
+         write(6,'(a,i4)') 'test_data: must have qcut>0.0, l=',l1-1
+         ierr=ierr+1
+      end if
    end do
-  
-   if(sf>zz) then
-    write(6,'(a,i4)') 'test_data: negative ion, test configuration',jj-1
-    ierr=ierr+1
+
+   if(lloc==4) then
+      if(lpopt<1 .or. lpopt>5) then
+         write(6,'(a)') 'test_data: must have 1 <= lpopt <= 5'
+         ierr=ierr+1
+      end if
+      if(rc(5)<=0.0d0) then
+         write(6,'(a)') 'test_data: for lloc==4, must have rc > 0.0'
+         ierr=ierr+1
+      end if
+   else if(lloc<0 .or. lloc>lmax) then
+      write(6,'(a)') 'test_data: must have 0 <= lloc <= lmax or lloc == 4'
+      ierr=ierr+1
    end if
-  end do
- end if
- 
- if(ierr>0) then
-  write(6,'(a,i4,a)') 'ERROR: test_data found',ierr,' ERROR; stopping'
-  stop
- end if
 
- return
- end subroutine check_data
+   do l1=1,lmax+1
+      if(rc(l1)<rc(lloc+1)) then
+         write(6,'(a,i2,a)') 'test_data: rc < rc(lloc) for l =',l1-1,&
+         &         '.  Not allowed.'
+         ierr=ierr+1
+      end if
+   end do
 
+   do l1=1,lmax+1
+      if(nproj(l1)==0 .and. (lloc==4 .or. lloc==l1-1)) then
+         cycle
+      else if(nproj(l1)<1 .or. nproj(l1)>5) then
+         write(6,'(a,i4,a)') 'test_data: must have nproj in [1,5] (0 OK lloc=4 or', &
+         &        l1-1,')'
+         ierr=ierr+1
+      end if
+      if(debl(l1)<0.0d0) then
+         write(6,'(a,i4)') 'test_data: must have debl>0.0)',l1-1
+         ierr=ierr+1
+      end if
+   end do
+
+   if(icmod<0 .or. icmod>4) then
+      write(6,'(a)') 'test_data: must have 0<= icmod <=4'
+      ierr=ierr+1
+   end if
+
+   if((icmod==1 .or. icmod==3) .and. fcfact<=0.0d0) then
+      write(6,'(a)') 'test_data: must have fcfact>0.0 for icmod= 1 or 3'
+      ierr=ierr+1
+   end if
+
+   if((icmod==3) .and. rcfact<=0.0d0) then
+      write(6,'(a)') 'test_data: must have rcfact>0.0 for icmod= 3'
+      ierr=ierr+1
+   end if
+
+   if(epsh2<epsh1) then
+      write(6,'(a)') 'test_data: must have epsh2 > epsh1'
+      ierr=ierr+1
+   end if
+   if(depsh<0.0d0) then
+      write(6,'(a)') 'test_data: must have depsh>0.0'
+      ierr=ierr+1
+   end if
+
+   rcmax=0.0d0
+   do l1=1,lmax+1
+      rcmax=max(rcmax,rc(l1))
+   end do
+   if(lloc==4) then
+      rcmax=max(rcmax,rc(5))
+   end if
+
+   if(rlmax<rcmax) then
+      write(6,'(a)') 'test_data: must have rlmax>rcmax'
+      ierr=ierr+1
+   end if
+
+   if(drl<=0.0d0) then
+      write(6,'(a)') 'test_data: must have drl > 0.0'
+      ierr=ierr+1
+   end if
+
+   if(ncnf<0 .or. ncnf>4)then
+      write(6,'(a)') 'test_data: must have 0 <= ncnf <= 4, skipping config. checks'
+      ierr=ierr+1
+   else
+      do jj=2,ncnf+1
+         sf=0.0d0
+         do ii=1,nc+nvcnf(jj)
+            sf=sf+facnf(ii,jj)
+            if(lacnf(ii,jj)<0 .or. lacnf(ii,jj)>3) then
+               write(6,'(a,a,i4,a,i4)') 'test_data: must have 0<= l <=3,', &
+               &     ' test configuration',jj-1, ' line',ii-nc
+               ierr=ierr+1
+            end if
+            if(nacnf(ii,jj)<=lacnf(ii,jj)) then
+               write(6,'(a,a,i4,a,i4)') 'test_data: l > n,', &
+               &     ' test configuration',jj-1, ' line',ii-nc
+               ierr=ierr+1
+            end if
+            if(facnf(ii,jj)<0.0d0) then
+               write(6,'(a,a,i4,a,i4)') 'test_data: f < 0.0,', &
+               &     ' test configuration',jj-1, ' line',ii-nc
+               ierr=ierr+1
+            end if
+         end do
+
+         if(sf>zz) then
+            write(6,'(a,i4)') 'test_data: negative ion, test configuration',jj-1
+            ierr=ierr+1
+         end if
+      end do
+   end if
+
+   if(ierr>0) then
+      write(6,'(a,i4,a)') 'ERROR: test_data found',ierr,' ERROR; stopping'
+      stop
+   end if
+
+   return
+end subroutine check_data

--- a/src/const_basis.f90
+++ b/src/const_basis.f90
@@ -2,23 +2,23 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
 !calculates basis for residual energy minimization
 
- subroutine const_basis(nbas,ncon,cons,orbasis,orbasis_der,&
+subroutine const_basis(nbas,ncon,cons,orbasis,orbasis_der,&
 &                       pswf0_or,pswfnull_or, &
 &                       pswf0_sb,pswfnull_sb,ps0norm)
 
@@ -26,7 +26,7 @@
 !nbas  number of orthogonalized sbf basis functions
 !cons  constraints (value at rc and derivatives up to 4th)
 !orbasis  coefficients of sbfs in orthogonal basis
-!orbasis_der  values and derivatives of orthogonalized sbf basis 
+!orbasis_der  values and derivatives of orthogonalized sbf basis
 !              functions at rc (constraint matrix)
 !pswf0_sb  linear combination of sbfs that matches cons at rc
 !pswfnull_sb  nbas-ncon linear combinations of sbfs satisfying value and ncon-1
@@ -35,42 +35,42 @@
 !          the pswf0 combination (which is not normalized)
 !ps0norm  charge contained in ps0 inside rc
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !input variables
- integer :: ncon,nbas
- real(dp) :: orbasis(nbas,nbas),orbasis_der(ncon,nbas),cons(ncon)
+   integer :: ncon,nbas
+   real(dp) :: orbasis(nbas,nbas),orbasis_der(ncon,nbas),cons(ncon)
 
 !Output variables
- real(dp) :: pswf0_or(nbas),pswfnull_or(nbas,nbas-ncon)
- real(dp) :: pswf0_sb(nbas),pswfnull_sb(nbas,nbas-ncon)
- real(dp) :: ps0norm
+   real(dp) :: pswf0_or(nbas),pswfnull_or(nbas,nbas-ncon)
+   real(dp) :: pswf0_sb(nbas),pswfnull_sb(nbas,nbas-ncon)
+   real(dp) :: ps0norm
 
 !Local variables
- real(dp) :: usvd(10,10),ss(10),work(100),con_tst(10)
- real(dp), allocatable :: amat(:,:),vt(:,:)
- real(dp) :: sn
- real(dp), parameter :: eps=1.d-8
- integer :: ii,jj,kk,info
+   real(dp) :: usvd(10,10),ss(10),work(100),con_tst(10)
+   real(dp), allocatable :: amat(:,:),vt(:,:)
+   real(dp) :: sn
+   real(dp), parameter :: eps=1.d-8
+   integer :: ii,jj,kk,info
 
 
 !DGESVD( JOBU, JOBVT, M, N, A, LDA, S, U, LDU, VT, LDVT,
 !     $                   WORK, LWORK, INFO )
- allocate(amat(10,nbas),vt(nbas,nbas))
+   allocate(amat(10,nbas),vt(nbas,nbas))
 
 !save orbasis_der from overwrite
- amat(:,:)=0.0d0
- amat(1:ncon,:)=orbasis_der(1:ncon,:) 
+   amat(:,:)=0.0d0
+   amat(1:ncon,:)=orbasis_der(1:ncon,:)
 
 !singular value decomposition of constraint matrix
- call dgesvd('A','A',ncon,nbas,amat,10,ss,usvd,10,vt,nbas, &
-&             work,64,info)
+   call dgesvd('A','A',ncon,nbas,amat,10,ss,usvd,10,vt,nbas, &
+   &             work,64,info)
 
- if(info /= 0) then
-  write(6,'(/a,i4)') 'const_basis: ERTOR const_basis: dgesvd info = ',info
-  stop
- end if
+   if(info /= 0) then
+      write(6,'(/a,i4)') 'const_basis: ERTOR const_basis: dgesvd info = ',info
+      stop
+   end if
 
 !write(6,'(/a,6d12.4)') 'singular values',(ss(ii),ii=1,ncon)
 
@@ -85,76 +85,76 @@
 !end do
 
 !operate on constraint vector with usvd^transpose
- work(:)=0.0d0
- do ii=1,ncon
-  work(ii)=0.0d0
-  do jj=1,ncon
-   work(ii)=work(ii)+usvd(jj,ii)*cons(jj)
-  end do
- end do
+   work(:)=0.0d0
+   do ii=1,ncon
+      work(ii)=0.0d0
+      do jj=1,ncon
+         work(ii)=work(ii)+usvd(jj,ii)*cons(jj)
+      end do
+   end do
 
 !scale work with inverse transpose of singular value "matrix" ss
- do ii=1,ncon
-  if(abs(ss(ii))>eps) then
-   work(ii)=work(ii)/ss(ii)
-  end if
- end do
+   do ii=1,ncon
+      if(abs(ss(ii))>eps) then
+         work(ii)=work(ii)/ss(ii)
+      end if
+   end do
 
 !form coefficient vector for basic matching pseudo wave function
 !null vectors (with ss=0) can be added to improve kinetic residual
 !convergence without changing match at rc
- do ii=1,nbas
-  pswf0_or(ii)=0.0d0
-  do jj=1,ncon
-   pswf0_or(ii)=pswf0_or(ii)+work(jj)*vt(jj,ii)
-  end do
- end do
+   do ii=1,nbas
+      pswf0_or(ii)=0.0d0
+      do jj=1,ncon
+         pswf0_or(ii)=pswf0_or(ii)+work(jj)*vt(jj,ii)
+      end do
+   end do
 
 !copy coefficient vectors spanning null space of constraint matrix
 !note that vt (transpose) rows become columns of pswfnull
 !write(6,'(/)')
- do jj=1,nbas-ncon
-  sn=0.0d0
-  do ii=1,nbas
-   pswfnull_or(ii,jj)=vt(ncon+jj,ii)
-   sn=sn+pswfnull_or(ii,jj)**2
-  end do
- end do
+   do jj=1,nbas-ncon
+      sn=0.0d0
+      do ii=1,nbas
+         pswfnull_or(ii,jj)=vt(ncon+jj,ii)
+         sn=sn+pswfnull_or(ii,jj)**2
+      end do
+   end do
 
 
 !now, test result
- do ii=1,ncon
-  con_tst(ii)=0.0d0
-  do jj=1,nbas
-   con_tst(ii)=con_tst(ii)+orbasis_der(ii,jj)*pswf0_or(jj)
-  end do
- end do
+   do ii=1,ncon
+      con_tst(ii)=0.0d0
+      do jj=1,nbas
+         con_tst(ii)=con_tst(ii)+orbasis_der(ii,jj)*pswf0_or(jj)
+      end do
+   end do
 
- write(6,'(/a)') '    Constraint consistency test'
- write(6,'(a)') '      pswf0 val/der aewf val/der     diff'
- do ii=1,ncon
-  write(6,'(4x,2f14.8,1p,d12.2)') con_tst(ii),cons(ii),con_tst(ii)-cons(ii)
- end do
+   write(6,'(/a)') '    Constraint consistency test'
+   write(6,'(a)') '      pswf0 val/der aewf val/der     diff'
+   do ii=1,ncon
+      write(6,'(4x,2f14.8,1p,d12.2)') con_tst(ii),cons(ii),con_tst(ii)-cons(ii)
+   end do
 
 !calculate charge contained in ps0 inside rc
- ps0norm=0.0d0
- do ii=1,nbas
-  ps0norm=ps0norm+pswf0_or(ii)**2
- end do
+   ps0norm=0.0d0
+   do ii=1,nbas
+      ps0norm=ps0norm+pswf0_or(ii)**2
+   end do
 
 !convert ps0 and psnull in orthogonal representation to sbf represention
- 
- pswf0_sb(:)=0.0d0
- pswfnull_sb(:,:)=0.0d0
- do jj=1,nbas
-  do kk=1,nbas
-   pswf0_sb(jj)     =pswf0_sb(jj)     +orbasis(jj,kk)*pswf0_or(kk)
-   do ii=1,nbas-ncon
-    pswfnull_sb(jj,ii)=pswfnull_sb(jj,ii)+orbasis(jj,kk)*pswfnull_or(kk,ii)
-   end do
-  end do
- end do
 
- deallocate(amat,vt)
- return
- end subroutine const_basis
+   pswf0_sb(:)=0.0d0
+   pswfnull_sb(:,:)=0.0d0
+   do jj=1,nbas
+      do kk=1,nbas
+         pswf0_sb(jj)     =pswf0_sb(jj)     +orbasis(jj,kk)*pswf0_or(kk)
+         do ii=1,nbas-ncon
+            pswfnull_sb(jj,ii)=pswfnull_sb(jj,ii)+orbasis(jj,kk)*pswfnull_or(kk,ii)
+         end do
+      end do
+   end do
+
+   deallocate(amat,vt)
+   return
+end subroutine const_basis

--- a/src/der2exc.f90
+++ b/src/der2exc.f90
@@ -2,25 +2,25 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
 ! computes the 2nd derivative of the contribution to the exchange-
 ! correlation energy from the region where the valence pseudo wave functions
-! differ from the all-electron wave functions 
+! differ from the all-electron wave functions
 !
- subroutine der2exc(rhotot,rhoc,rho,rr,d2exc,d2ref,d2mdiff, &
+subroutine der2exc(rhotot,rhoc,rho,rr,d2exc,d2ref,d2mdiff, &
 &                   zion,iexc,nc,nv,la,ircut,mmax)
 
 ! rhotot  total valence charge, all-electron of pseudo
@@ -38,67 +38,67 @@
 ! ircut  maximum-radius for which all-electron and pseudo charges differ
 ! mmax  dimensiion of log grid
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 ! Input variables
- real(dp) :: rhotot(mmax),rhoc(mmax),rho(mmax,nv),rr(mmax)
- real(dp) :: d2ref(nv,nv)
- real(dp) :: zion
- integer :: la(nv+nc)
- integer :: iexc,nc,nv,ircut,mmax
+   real(dp) :: rhotot(mmax),rhoc(mmax),rho(mmax,nv),rr(mmax)
+   real(dp) :: d2ref(nv,nv)
+   real(dp) :: zion
+   integer :: la(nv+nc)
+   integer :: iexc,nc,nv,ircut,mmax
 
 ! Output variables
- real(dp) :: d2exc(nv,nv)
- real(dp) :: d2mdiff
- 
+   real(dp) :: d2exc(nv,nv)
+   real(dp) :: d2mdiff
+
 ! Local variables
- real(dp) :: hh,eeel,eexc,ss
- real(dp), allocatable :: vo(:),vxct(:),rhot(:),dvxc(:,:)
- integer :: ii,jj,kk,l1
+   real(dp) :: hh,eeel,eexc,ss
+   real(dp), allocatable :: vo(:),vxct(:),rhot(:),dvxc(:,:)
+   integer :: ii,jj,kk,l1
 
- allocate(vo(mmax),vxct(mmax),rhot(mmax),dvxc(mmax,nv))
+   allocate(vo(mmax),vxct(mmax),rhot(mmax),dvxc(mmax,nv))
 
- hh=0.15d0
+   hh=0.15d0
 
- do kk=1,nv
-   dvxc(:,kk)=0.0d0
+   do kk=1,nv
+      dvxc(:,kk)=0.0d0
 
-   rhot(:)=rhotot(:)-2.d0*hh*rho(:,kk)
-   call vout(1,rhot,rhoc,vo,vxct,zion,eeel,eexc,rr,mmax,iexc)
-   dvxc(:,kk)=dvxc(:,kk)+( 2.0d0/(24.0d0*hh))*vxct(:)
+      rhot(:)=rhotot(:)-2.d0*hh*rho(:,kk)
+      call vout(1,rhot,rhoc,vo,vxct,zion,eeel,eexc,rr,mmax,iexc)
+      dvxc(:,kk)=dvxc(:,kk)+( 2.0d0/(24.0d0*hh))*vxct(:)
 
-   rhot(:)=rhotot(:)     -hh*rho(:,kk)
-   call vout(1,rhot,rhoc,vo,vxct,zion,eeel,eexc,rr,mmax,iexc)
-   dvxc(:,kk)=dvxc(:,kk)+(-16.0d0/(24.0d0*hh))*vxct(:)
+      rhot(:)=rhotot(:)     -hh*rho(:,kk)
+      call vout(1,rhot,rhoc,vo,vxct,zion,eeel,eexc,rr,mmax,iexc)
+      dvxc(:,kk)=dvxc(:,kk)+(-16.0d0/(24.0d0*hh))*vxct(:)
 
-   rhot(:)=rhotot(:)     +hh*rho(:,kk)
-   call vout(1,rhot,rhoc,vo,vxct,zion,eeel,eexc,rr,mmax,iexc)
-   dvxc(:,kk)=dvxc(:,kk)+( 16.0d0/(24.0d0*hh))*vxct(:)
+      rhot(:)=rhotot(:)     +hh*rho(:,kk)
+      call vout(1,rhot,rhoc,vo,vxct,zion,eeel,eexc,rr,mmax,iexc)
+      dvxc(:,kk)=dvxc(:,kk)+( 16.0d0/(24.0d0*hh))*vxct(:)
 
-   rhot(:)=rhotot(:)-2.d0*hh*rho(:,kk)
-   call vout(1,rhot,rhoc,vo,vxct,zion,eeel,eexc,rr,mmax,iexc)
-   dvxc(:,kk)=dvxc(:,kk)+(-2.0d0/(24.0d0*hh))*vxct(:)
+      rhot(:)=rhotot(:)-2.d0*hh*rho(:,kk)
+      call vout(1,rhot,rhoc,vo,vxct,zion,eeel,eexc,rr,mmax,iexc)
+      dvxc(:,kk)=dvxc(:,kk)+(-2.0d0/(24.0d0*hh))*vxct(:)
 
- end do !kk
+   end do  !kk
 
 ! compute Exc 2nd-derivative wrt occupation numbers matrix
 
- do kk=1,nv
-     l1=la(nc+kk)+1
-     rhot(:)=rho(:,kk)*rr(:)**2
-   do jj=1,nv
-     call vpinteg(rhot,dvxc(1,jj),ircut,2*l1,d2exc(kk,jj),rr)
-   end do !jj
- end do !kk
+   do kk=1,nv
+      l1=la(nc+kk)+1
+      rhot(:)=rho(:,kk)*rr(:)**2
+      do jj=1,nv
+         call vpinteg(rhot,dvxc(1,jj),ircut,2*l1,d2exc(kk,jj),rr)
+      end do  !jj
+   end do  !kk
 
- ss=0.0d0
- do kk=1,nv
-   do jj=1,nv
-     ss=ss+(d2exc(jj,kk)-d2ref(jj,kk))**2
+   ss=0.0d0
+   do kk=1,nv
+      do jj=1,nv
+         ss=ss+(d2exc(jj,kk)-d2ref(jj,kk))**2
+      end do
    end do
- end do
- d2mdiff=sqrt(ss/nv**2)
+   d2mdiff=sqrt(ss/nv**2)
 
- deallocate(vo,vxct,rhot,dvxc)
- end subroutine der2exc
+   deallocate(vo,vxct,rhot,dvxc)
+end subroutine der2exc

--- a/src/dpnint.f90
+++ b/src/dpnint.f90
@@ -2,21 +2,21 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- subroutine dpnint(xx, yy, nn, tt, ss, mm)
+subroutine dpnint(xx, yy, nn, tt, ss, mm)
 
 ! local polynomial interpolation of data yy on nn points xx
 ! giving values ss on mm points tt
@@ -24,89 +24,89 @@
 ! xx must be ordered in ascending order
 ! output mm interpolated values ss on points tt
 
- implicit none
+   implicit none
 
- integer, parameter :: dp=kind(1.0d0)
+   integer, parameter :: dp=kind(1.0d0)
 
 !Input variables
- real(dp) ::  xx(*),yy(*),tt(*)
- integer nn,mm
+   real(dp) ::  xx(*),yy(*),tt(*)
+   integer :: nn,mm
 
 !Output variables
- real(dp) :: ss(*)
+   real(dp) :: ss(*)
 
 !Local variables
- real(dp) :: sum,term,zz
- integer ii,imin,imax,iprod,iy,istart,jj,kk
+   real(dp) :: sum,term,zz
+   integer :: ii,imin,imax,iprod,iy,istart,jj,kk
 
 ! set order of polynomial
- integer, parameter :: npoly=7
+   integer, parameter :: npoly=7
 
- if(nn<npoly+1) then
-   write(6,'(/a,i6,a,i4)') 'dpnint: interpolation ERROR, n=', &
-&       nn,'< npoly=',npoly
-   stop
- end if
+   if(nn<npoly+1) then
+      write(6,'(/a,i6,a,i4)') 'dpnint: interpolation ERROR, n=', &
+      &       nn,'< npoly=',npoly
+      stop
+   end if
 
 ! note: output point 1 is skipped in this version because of special
 ! properties of pp data (ie., log grid)
 ! this point receives special treatment (see below)
 
- ss(1:mm)=0.0d0
- imin = 1
- do jj = 2, mm
-   if(tt(jj)<xx(1)) then
-     write(6,'(/a)') 'dpnint: interpolation ERROR - out of range'
-     stop
-   end if
-   if(tt(jj)>xx(nn)) then
-     write(6,'(/a)') 'dpnint: interpolation ERROR - out of range'
-     stop
-   end if
+   ss(1:mm)=0.0d0
+   imin = 1
+   do jj = 2, mm
+      if(tt(jj)<xx(1)) then
+         write(6,'(/a)') 'dpnint: interpolation ERROR - out of range'
+         stop
+      end if
+      if(tt(jj)>xx(nn)) then
+         write(6,'(/a)') 'dpnint: interpolation ERROR - out of range'
+         stop
+      end if
 
 ! interval halving search for xx(ii) points bracketing tt(jj)
-   if(jj>2) then
-     if(tt(jj)<tt(jj-1)) imin=1
-   end if
-   imin = 1
-   imax = nn
-   do kk = 1, nn
-     ii = (imin + imax) / 2
-     if(tt(jj)>xx(ii)) then
-       imin = ii
-     else
-       imax = ii
-     end if
-     if(imax - imin .eq. 1) then
-       exit
-     end if
-   end do
+      if(jj>2) then
+         if(tt(jj)<tt(jj-1)) imin=1
+      end if
+      imin = 1
+      imax = nn
+      do kk = 1, nn
+         ii = (imin + imax) / 2
+         if(tt(jj)>xx(ii)) then
+            imin = ii
+         else
+            imax = ii
+         end if
+         if(imax - imin == 1) then
+            exit
+         end if
+      end do
 
 
-   zz=tt(jj)
+      zz=tt(jj)
 
-   if(mod(npoly,2)==1) then
-    istart=imin-npoly/2
-   else if(zz-xx(imin) < xx(imax)-zz) then
-     istart=imin-npoly/2
-   else
-     istart=imax-npoly/2
-   end if
+      if(mod(npoly,2)==1) then
+         istart=imin-npoly/2
+      else if(zz-xx(imin) < xx(imax)-zz) then
+         istart=imin-npoly/2
+      else
+         istart=imax-npoly/2
+      end if
 
-   istart = min(istart, nn - npoly)
-   istart = max(istart, 1)
+      istart = min(istart, nn - npoly)
+      istart = max(istart, 1)
 
-   sum=0.0d0
-   do iy=istart,istart+npoly
-    if(yy(iy)==0.0d0) cycle
-    term=yy(iy)
-    do iprod=istart, istart+npoly
-     if(iprod==iy) cycle
-     term=term*(zz-xx(iprod))/(xx(iy)-xx(iprod))
-    end do
-    sum=sum+term
-   end do
-   ss(jj)=sum
+      sum=0.0d0
+      do iy=istart,istart+npoly
+         if(yy(iy)==0.0d0) cycle
+         term=yy(iy)
+         do iprod=istart, istart+npoly
+            if(iprod==iy) cycle
+            term=term*(zz-xx(iprod))/(xx(iy)-xx(iprod))
+         end do
+         sum=sum+term
+      end do
+      ss(jj)=sum
 
 ! special treatment for the origin
 ! Do order npoly EXTRAPOLATION to the origin using the points inerpolated
@@ -116,25 +116,25 @@
 ! error would not be acceptable If the fitted function is a polynomial
 ! of order npoly or less, this is exact.
 
-  if(tt(1)==0.0d0) then
+      if(tt(1)==0.0d0) then
 
-   istart=2
-   zz=0.0d0
+         istart=2
+         zz=0.0d0
 
-   sum=0.0d0
-   do iy=istart,istart+npoly
-    if(ss(iy)==0.0d0) cycle
-    term=ss(iy)
-    do iprod=istart, istart+npoly
-     if(iprod==iy) cycle
-     term=term*(zz-tt(iprod))/(tt(iy)-tt(iprod))
-    end do
-    sum=sum+term
+         sum=0.0d0
+         do iy=istart,istart+npoly
+            if(ss(iy)==0.0d0) cycle
+            term=ss(iy)
+            do iprod=istart, istart+npoly
+               if(iprod==iy) cycle
+               term=term*(zz-tt(iprod))/(tt(iy)-tt(iprod))
+            end do
+            sum=sum+term
+         end do
+         ss(1)=sum
+
+      end if
+
    end do
-   ss(1)=sum
-
-  end if
-
- end do
- return
- end subroutine dpnint
+   return
+end subroutine dpnint

--- a/src/eresid.f90
+++ b/src/eresid.f90
@@ -2,23 +2,23 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
 ! calculates residual energy operator matrix elements as a function of q
 
- subroutine eresid(ll,irc,nnull,nbas,mmax,rr,drdum,dqdum,qmax,qroot, &
+subroutine eresid(ll,irc,nnull,nbas,mmax,rr,drdum,dqdum,qmax,qroot, &
 &                  uu,pswf0_sb,pswfnull_sb, nqout,qout, &
 &                  eresid0,eresiddot,eresidmat)
 
@@ -33,9 +33,9 @@
 !qmax  largest wave vector for E_res integration
 !qroot(nbas)  q values for sbfs in basis
 !uu(mmax)  r*all-electron wave function
-!pswf0_sb(nbas)  sbf basis  coefficients for constrained part of pseudo 
+!pswf0_sb(nbas)  sbf basis  coefficients for constrained part of pseudo
 !                    wave function
-!pswfnull_sb(nbas,nnull) sbf coefficients for unconstrained basis of pseudo 
+!pswfnull_sb(nbas,nnull) sbf coefficients for unconstrained basis of pseudo
 !                       wave function
 !nqout  number of wave vector lower cutoffs
 !qout(nqout)  wave vector lower cutoffs for E_res for which output is wanted,
@@ -46,94 +46,94 @@
 !eresiddot(nnull,nqout) set of <pswfnull| E_resid |pswf0> matrix elements
 !eresidevec(nnull,null,nqout)  set of <pswfnull| E_res |pswfnull'> matrices
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
- real(dp), parameter :: pi=3.141592653589793238462643383279502884197_dp
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
+   real(dp), parameter :: pi=3.141592653589793238462643383279502884197_dp
 
 !Input variables
- integer :: irc,ll,nnull,nbas,mmax,nqout
- real(dp) :: rr(mmax),uu(mmax),pswf0_sb(nbas),pswfnull_sb(nbas,nnull)
- real(dp) :: qroot(nbas)
+   integer :: irc,ll,nnull,nbas,mmax,nqout
+   real(dp) :: rr(mmax),uu(mmax),pswf0_sb(nbas),pswfnull_sb(nbas,nnull)
+   real(dp) :: qroot(nbas)
 !real(dp) :: dr,dq,qmax
- real(dp) :: drdum,dqdum,qmax
+   real(dp) :: drdum,dqdum,qmax
 
 !Output variables
- real(dp) :: eresid0(nqout),eresiddot(nnull,nqout)
- real(dp) :: eresidmat(nnull,nnull,nqout)
+   real(dp) :: eresid0(nqout),eresiddot(nnull,nqout)
+   real(dp) :: eresidmat(nnull,nnull,nqout)
 
 !Input/output variables
- real(dp) :: qout(nqout)
+   real(dp) :: qout(nqout)
 
 !Local variables
- real(dp), allocatable :: rlin(:),uulin(:),sbf(:),ps0(:)
- real(dp), allocatable :: erdot(:),ereval(:),erevec(:,:)
- real(dp), allocatable :: psnull(:,:),tpsnull(:),psnullq(:)
- real(dp), allocatable :: dac0(:),dacdot(:,:),dacmat(:,:,:)
- real(dp), allocatable :: acdot(:),acmat(:,:)
- real(dp), allocatable :: work(:),wmat(:,:),wev(:),wvec(:)
- real(dp) :: sb_out(5)
- real(dp) :: ac0,rc,ps0q,tps0,xx,qq,qq4,sn,tn,td
- real(dp) :: dr,dq
+   real(dp), allocatable :: rlin(:),uulin(:),sbf(:),ps0(:)
+   real(dp), allocatable :: erdot(:),ereval(:),erevec(:,:)
+   real(dp), allocatable :: psnull(:,:),tpsnull(:),psnullq(:)
+   real(dp), allocatable :: dac0(:),dacdot(:,:),dacmat(:,:,:)
+   real(dp), allocatable :: acdot(:),acmat(:,:)
+   real(dp), allocatable :: work(:),wmat(:,:),wev(:),wvec(:)
+   real(dp) :: sb_out(5)
+   real(dp) :: ac0,rc,ps0q,tps0,xx,qq,qq4,sn,tn,td
+   real(dp) :: dr,dq
 
- integer :: nrlin,nq,irclin,mmaxlin
- integer :: ii,info,iq,jj,kk,ll1
+   integer :: nrlin,nq,irclin,mmaxlin
+   integer :: ii,info,iq,jj,kk,ll1
 
 
 ! new calculations of dq, dr
 ! larger denominators yield better convergence at the cost of more time
 ! dq=2.0d0*pi/(300.0d0*rr(irc))
-  dq=2.0d0*pi/(150.0d0*rr(irc))
+   dq=2.0d0*pi/(150.0d0*rr(irc))
 ! dq=2.0d0*pi/(75.0d0*rr(irc))
 ! dr=2.0d0*pi/(150.0d0*qmax)
-  dr=2.0d0*pi/(75.0d0*qmax)
+   dr=2.0d0*pi/(75.0d0*qmax)
 
 !set up linear radial mesh
- rc=rr(irc)
- irclin=rc/dr + 1.5d0
- dr=rc/(irclin-1)
+   rc=rr(irc)
+   irclin=rc/dr + 1.5d0
+   dr=rc/(irclin-1)
 
- do ii=mmax,1,-1
-   if(abs(uu(ii))>1.0d-10) then
-     mmaxlin=rr(ii)/dr - 2.0d0
-     exit
-    end if
- end do
+   do ii=mmax,1,-1
+      if(abs(uu(ii))>1.0d-10) then
+         mmaxlin=rr(ii)/dr - 2.0d0
+         exit
+      end if
+   end do
 !mmaxlin=rr(mmax)/dr - 1.5d0 !leave non-zero room for cubic interpolation
 
- allocate(rlin(mmaxlin),uulin(mmaxlin),ps0(mmaxlin))
- allocate(psnull(irclin,nnull),tpsnull(nnull),psnullq(nnull))
- allocate(sbf(mmaxlin))
- allocate(dac0(4),dacdot(nnull,4),dacmat(nnull,nnull,4))
- allocate(acdot(nnull),acmat(nnull,nnull))
+   allocate(rlin(mmaxlin),uulin(mmaxlin),ps0(mmaxlin))
+   allocate(psnull(irclin,nnull),tpsnull(nnull),psnullq(nnull))
+   allocate(sbf(mmaxlin))
+   allocate(dac0(4),dacdot(nnull,4),dacmat(nnull,nnull,4))
+   allocate(acdot(nnull),acmat(nnull,nnull))
 
 
- do ii=1,mmaxlin
-  rlin(ii)=(ii-1)*dr
- end do
+   do ii=1,mmaxlin
+      rlin(ii)=(ii-1)*dr
+   end do
 
 !interpolate all-electron wave function onto linear mesh, even though we
 !will only use the tail region
 
- call dpnint(rr,uu,mmax,rlin,uulin,mmaxlin)
+   call dpnint(rr,uu,mmax,rlin,uulin,mmaxlin)
 
- do ii=irclin,mmaxlin
-  ps0(ii)=uulin(ii)
- end do
+   do ii=irclin,mmaxlin
+      ps0(ii)=uulin(ii)
+   end do
 
 !set up constrained basis functions on linear grid inside rc (multiplied by r)
- ll1=ll+1
- do ii=1,irclin
-  tps0=0.0d0
-  tpsnull(:)=0.0d0
-  do jj=1,nbas
-   xx=rlin(ii)*qroot(jj)
-   call sbf8(ll1,xx,sb_out)
-   tps0      =tps0      +pswf0_sb(jj)     *sb_out(ll1)
-   tpsnull(:)=tpsnull(:)+pswfnull_sb(jj,:)*sb_out(ll1)
-  end do
-  ps0(ii)=rlin(ii)*tps0
-  psnull(ii,:)=rlin(ii)*tpsnull(:)
- end do
+   ll1=ll+1
+   do ii=1,irclin
+      tps0=0.0d0
+      tpsnull(:)=0.0d0
+      do jj=1,nbas
+         xx=rlin(ii)*qroot(jj)
+         call sbf8(ll1,xx,sb_out)
+         tps0      =tps0      +pswf0_sb(jj)     *sb_out(ll1)
+         tpsnull(:)=tpsnull(:)+pswfnull_sb(jj,:)*sb_out(ll1)
+      end do
+      ps0(ii)=rlin(ii)*tps0
+      psnull(ii,:)=rlin(ii)*tpsnull(:)
+   end do
 
 !big q integration loop
 
@@ -141,116 +141,116 @@
 !inward from qmax (considered infinity) to qq=0, saving snapshots along the
 !way
 
- nq=qmax/dq+1
+   nq=qmax/dq+1
 
 !null accumulators and running registers
 
- ac0=0.0d0
- acdot(:)=0.0d0
- acmat(:,:)=0.0d0
+   ac0=0.0d0
+   acdot(:)=0.0d0
+   acmat(:,:)=0.0d0
 
- dac0(:)=0.0d0
- dacdot(:,:)=0.0d0
- dacmat(:,:,:)=0.0d0
+   dac0(:)=0.0d0
+   dacdot(:,:)=0.0d0
+   dacmat(:,:,:)=0.0d0
 
- do iq=nq,1,-1
-  qq=dq*(iq-1)
+   do iq=nq,1,-1
+      qq=dq*(iq-1)
 
 !sbfs on full rlin mesh for this qq
 !multiply by rlin for integration
-  do ii=1,mmaxlin
-   xx=qq*rlin(ii)
-   call sbf8(ll1,xx,sb_out)
-   sbf(ii)=rlin(ii)*sb_out(ll1)
-  end do
+      do ii=1,mmaxlin
+         xx=qq*rlin(ii)
+         call sbf8(ll1,xx,sb_out)
+         sbf(ii)=rlin(ii)*sb_out(ll1)
+      end do
 
 !Fourier transforms of basis functions
 !null functions exist for r<rc
 
-  ps0q=( 9.0d0*ps0(1       )*sbf(1       ) &
-&      +28.0d0*ps0(2       )*sbf(2       ) &
-&      +23.0d0*ps0(3       )*sbf(3    )    &
-&      +23.0d0*ps0(irclin-2)*sbf(irclin-2) &
-&      +28.0d0*ps0(irclin-1)*sbf(irclin-1) &
-&      + 9.0d0*ps0(irclin  )*sbf(irclin  ))/24.0d0
+      ps0q=( 9.0d0*ps0(1       )*sbf(1       ) &
+      &      +28.0d0*ps0(2       )*sbf(2       ) &
+      &      +23.0d0*ps0(3       )*sbf(3    )    &
+      &      +23.0d0*ps0(irclin-2)*sbf(irclin-2) &
+      &      +28.0d0*ps0(irclin-1)*sbf(irclin-1) &
+      &      + 9.0d0*ps0(irclin  )*sbf(irclin  ))/24.0d0
 
-  psnullq(:)=( 9.0d0*psnull(1       ,:)*sbf(1       ) &
-&            +28.0d0*psnull(2       ,:)*sbf(2       ) &
-&            +23.0d0*psnull(3       ,:)*sbf(3    )    &
-&            +23.0d0*psnull(irclin-2,:)*sbf(irclin-2) &
-&            +28.0d0*psnull(irclin-1,:)*sbf(irclin-1) &
-&            + 9.0d0*psnull(irclin  ,:)*sbf(irclin  ))/24.0d0
+      psnullq(:)=( 9.0d0*psnull(1       ,:)*sbf(1       ) &
+      &            +28.0d0*psnull(2       ,:)*sbf(2       ) &
+      &            +23.0d0*psnull(3       ,:)*sbf(3    )    &
+      &            +23.0d0*psnull(irclin-2,:)*sbf(irclin-2) &
+      &            +28.0d0*psnull(irclin-1,:)*sbf(irclin-1) &
+      &            + 9.0d0*psnull(irclin  ,:)*sbf(irclin  ))/24.0d0
 
-  do ii=4,irclin-3
-   ps0q=ps0q+ps0(ii)*sbf(ii)
-   psnullq(:)=psnullq(:)+psnull(ii,:)*sbf(ii)
-  end do
+      do ii=4,irclin-3
+         ps0q=ps0q+ps0(ii)*sbf(ii)
+         psnullq(:)=psnullq(:)+psnull(ii,:)*sbf(ii)
+      end do
 
-  ps0q=ps0q +( 9.0d0*ps0(irclin   )*sbf(irclin   ) &
-&            +28.0d0*ps0(irclin+1 )*sbf(irclin+1 ) &
-&            +23.0d0*ps0(irclin+2 )*sbf(irclin+2 )    &
-&            +23.0d0*ps0(mmaxlin-2)*sbf(mmaxlin-2) &
-&            +28.0d0*ps0(mmaxlin-1)*sbf(mmaxlin-1) &
-&            + 9.0d0*ps0(mmaxlin  )*sbf(mmaxlin  ))/24.0d0
+      ps0q=ps0q +( 9.0d0*ps0(irclin   )*sbf(irclin   ) &
+      &            +28.0d0*ps0(irclin+1 )*sbf(irclin+1 ) &
+      &            +23.0d0*ps0(irclin+2 )*sbf(irclin+2 )    &
+      &            +23.0d0*ps0(mmaxlin-2)*sbf(mmaxlin-2) &
+      &            +28.0d0*ps0(mmaxlin-1)*sbf(mmaxlin-1) &
+      &            + 9.0d0*ps0(mmaxlin  )*sbf(mmaxlin  ))/24.0d0
 
-  do ii=irclin+3,mmaxlin-3
-   ps0q=ps0q+ps0(ii)*sbf(ii)
-  end do
+      do ii=irclin+3,mmaxlin-3
+         ps0q=ps0q+ps0(ii)*sbf(ii)
+      end do
 
-  ps0q=dr*ps0q
-  psnullq(:)=dr*psnullq(:)
+      ps0q=dr*ps0q
+      psnullq(:)=dr*psnullq(:)
 
 !stuff integrands for E_resid q integration
-  qq4=dq*qq**4
-  dac0(1)=qq4*ps0q**2
-  dacdot(:,1)=qq4*ps0q*psnullq(:)
-  do jj=1,nnull
-    dacmat(:,jj,1)=qq4*psnullq(:)*psnullq(jj)
-  end do
+      qq4=dq*qq**4
+      dac0(1)=qq4*ps0q**2
+      dacdot(:,1)=qq4*ps0q*psnullq(:)
+      do jj=1,nnull
+         dacmat(:,jj,1)=qq4*psnullq(:)*psnullq(jj)
+      end do
 
 !inward integration as soon as dac arrays ("derivative accumulator arrays")
 !are full
-  if(iq<nq-3) then
-   ac0=ac0+(9.0d0*dac0(1)+19.0d0*dac0(2) &
-&      -5.0d0*dac0(3)+dac0(4))/24.0d0
+      if(iq<nq-3) then
+         ac0=ac0+(9.0d0*dac0(1)+19.0d0*dac0(2) &
+         &      -5.0d0*dac0(3)+dac0(4))/24.0d0
 
-   acdot(:)=acdot(:)+(9.0d0*dacdot(:,1)+19.0d0*dacdot(:,2) &
-&      -5.0d0*dacdot(:,3)+dacdot(:,4))/24.0d0
+         acdot(:)=acdot(:)+(9.0d0*dacdot(:,1)+19.0d0*dacdot(:,2) &
+         &      -5.0d0*dacdot(:,3)+dacdot(:,4))/24.0d0
 
-   acmat(:,:)=acmat(:,:)+(9.0d0*dacmat(:,:,1)+19.0d0*dacmat(:,:,2) &
-&      -5.0d0*dacmat(:,:,3)+dacmat(:,:,4))/24.0d0
-  end if
+         acmat(:,:)=acmat(:,:)+(9.0d0*dacmat(:,:,1)+19.0d0*dacmat(:,:,2) &
+         &      -5.0d0*dacmat(:,:,3)+dacmat(:,:,4))/24.0d0
+      end if
 
 !shift dac* arrays one step inward
 
-  do ii=4,2,-1
-   dac0(ii)=dac0(ii-1)
-   dacdot(:,ii)=dacdot(:,ii-1)
-   dacmat(:,:,ii)=dacmat(:,:,ii-1)
-  end do
-  dac0(1)=0.0d0
-  dacdot(:,1)=0.0d0
-  dacmat(:,:,1)=0.0d0
+      do ii=4,2,-1
+         dac0(ii)=dac0(ii-1)
+         dacdot(:,ii)=dacdot(:,ii-1)
+         dacmat(:,:,ii)=dacmat(:,:,ii-1)
+      end do
+      dac0(1)=0.0d0
+      dacdot(:,1)=0.0d0
+      dacmat(:,:,1)=0.0d0
 
 !test if present qq value is a "save" point
 !1/pi factor from implicit sbf*sbf integral
-  do ii=1,nqout
-   if(abs(qout(ii)-qq)<0.5d0*dq) then
-    eresid0(ii)=ac0/pi
-    eresiddot(:,ii)=acdot(:)/pi
-    eresidmat(:,:,ii)=acmat(:,:)/pi
-    qout(ii)=qq
-   end if
-  end do
- 
- end do !big iq loop
+      do ii=1,nqout
+         if(abs(qout(ii)-qq)<0.5d0*dq) then
+            eresid0(ii)=ac0/pi
+            eresiddot(:,ii)=acdot(:)/pi
+            eresidmat(:,:,ii)=acmat(:,:)/pi
+            qout(ii)=qq
+         end if
+      end do
+
+   end do  !big iq loop
 
 
- deallocate(rlin,uulin,ps0)
- deallocate(psnull,tpsnull,psnullq)
- deallocate(sbf)
- deallocate(dac0,dacdot,dacmat)
- deallocate(acdot,acmat)
+   deallocate(rlin,uulin,ps0)
+   deallocate(psnull,tpsnull,psnullq)
+   deallocate(sbf)
+   deallocate(dac0,dacdot,dacmat)
+   deallocate(acdot,acmat)
 
- return
- end subroutine  eresid
+   return
+end subroutine eresid

--- a/src/exc_libxc.f90
+++ b/src/exc_libxc.f90
@@ -2,186 +2,186 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University, and M. Verstratte, University of Liege
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- 
+
 subroutine exc_libxc(iexc,al,rho,vxc,exc,rr,mmax)
 !
 !  interface to libxc library for potential and energy density calculation
 !
- use functionals_m
- implicit none
- 
- integer, parameter :: dp=kind(1.0d0)
- 
- real(dp), intent(in) :: al
- real(dp), intent(in) :: rho(mmax),rr(mmax)
- real(dp), intent(out) :: vxc(mmax),exc(mmax)
- integer, intent(in) :: mmax, iexc
- integer :: ii, unit
- 
-! local
- integer ::  id(2), ifunc
- integer, save :: functprinted = 0
- type(xc_functl_t) :: functls(2)
- integer :: nspin, irel, deriv_method
- real(dp),allocatable :: ip(:)
- real(dp), parameter :: pi=3.141592653589793238462643383279502884197_dp
- 
- real(dp), allocatable :: v(:), e(:)
- real(dp), allocatable :: dpr(:), dppr(:), dlap(:)
- real(dp), allocatable :: tau_dummy(:), vtau_dummy(:)
- real(dp), allocatable :: rho_loc(:)
+   use functionals_m
+   implicit none
 
- allocate(v(mmax), e(mmax))
- allocate(dpr(mmax), dppr(mmax), dlap(mmax))
- allocate(tau_dummy(mmax), vtau_dummy(mmax))
- allocate(rho_loc(mmax))
+   integer, parameter :: dp=kind(1.0d0)
+
+   real(dp), intent(in) :: al
+   real(dp), intent(in) :: rho(mmax),rr(mmax)
+   real(dp), intent(out) :: vxc(mmax),exc(mmax)
+   integer, intent(in) :: mmax, iexc
+   integer :: ii, unit
+
+! local
+   integer ::  id(2), ifunc
+   integer, save :: functprinted = 0
+   type(xc_functl_t) :: functls(2)
+   integer :: nspin, irel, deriv_method
+   real(dp),allocatable :: ip(:)
+   real(dp), parameter :: pi=3.141592653589793238462643383279502884197_dp
+
+   real(dp), allocatable :: v(:), e(:)
+   real(dp), allocatable :: dpr(:), dppr(:), dlap(:)
+   real(dp), allocatable :: tau_dummy(:), vtau_dummy(:)
+   real(dp), allocatable :: rho_loc(:)
+
+   allocate(v(mmax), e(mmax))
+   allocate(dpr(mmax), dppr(mmax), dlap(mmax))
+   allocate(tau_dummy(mmax), vtau_dummy(mmax))
+   allocate(rho_loc(mmax))
 !
 !conf = (3.d0*pi**2)**thrd
 !conrs = (3.d0/(4.d0*pi))**thrd
- 
- rho_loc = rho(1:mmax) /4.0d0 / pi
- 
- call derivs(mmax, rho_loc, al, rr, dpr, dppr, dlap)
- 
+
+   rho_loc = rho(1:mmax) /4.0d0 / pi
+
+   call derivs(mmax, rho_loc, al, rr, dpr, dppr, dlap)
+
 !
 ! determine xc to be used from input code (negative by convention)
- 
- id(1) = abs(iexc)/1000
- id(2) = abs(iexc) - id(1)*1000
- nspin = 1
- irel = 0 !XC_NON_RELATIVISTIC
+
+   id(1) = abs(iexc)/1000
+   id(2) = abs(iexc) - id(1)*1000
+   nspin = 1
+   irel = 0  !XC_NON_RELATIVISTIC
 !deriv_method = XC_DERIV_ANALYTICAL
- deriv_method = XC_DERIV_NUMERICAL
- ! call xc_functl_init(functls(1),nspin)
- ! call xc_functl_init(functls(2),nspin)
- call xc_functl_init_functl(functls(1),id(1),3,0.d0,nspin,deriv_method)
- call xc_functl_init_functl(functls(2),id(2),3,0.d0,nspin,deriv_method)
- 
- if (functprinted==0) then
-    call xc_functl_write_info(functls(1), 6)
-    call xc_functl_write_info(functls(2), 6)
-   write (*,*)
-   functprinted = 1
- end if
- 
+   deriv_method = XC_DERIV_NUMERICAL
+   ! call xc_functl_init(functls(1),nspin)
+   ! call xc_functl_init(functls(2),nspin)
+   call xc_functl_init_functl(functls(1),id(1),3,0.d0,nspin,deriv_method)
+   call xc_functl_init_functl(functls(2),id(2),3,0.d0,nspin,deriv_method)
+
+   if (functprinted==0) then
+      call xc_functl_write_info(functls(1), 6)
+      call xc_functl_write_info(functls(2), 6)
+      write (*,*)
+      functprinted = 1
+   end if
+
 ! no use of vtau kin en density optional argument
 ! ip is an ionization potential parameter for certain xc functionals, not supported here. Set to 0.5 Ha
- allocate (ip(nspin))
- ip = 0.5_dp
- tau_dummy = 0.0d0
- vtau_dummy = 0.0d0
- vxc(1:mmax) = 0.0d0
- exc(1:mmax) = 0.0d0
- do ifunc = 1, 2
-   v = 0.0d0
-   e = 0.0d0
-   call xc_functl_get_vxc(functls(ifunc), mmax, al, rr, rho_loc, dpr, dlap, &
- &        tau_dummy, ip, v, e, vtau_dummy)
-   vxc(1:mmax) = vxc(1:mmax) + v(1:mmax)
-   exc(1:mmax) = exc(1:mmax) + e(1:mmax) 
- end do
- 
+   allocate (ip(nspin))
+   ip = 0.5_dp
+   tau_dummy = 0.0d0
+   vtau_dummy = 0.0d0
+   vxc(1:mmax) = 0.0d0
+   exc(1:mmax) = 0.0d0
+   do ifunc = 1, 2
+      v = 0.0d0
+      e = 0.0d0
+      call xc_functl_get_vxc(functls(ifunc), mmax, al, rr, rho_loc, dpr, dlap, &
+      &        tau_dummy, ip, v, e, vtau_dummy)
+      vxc(1:mmax) = vxc(1:mmax) + v(1:mmax)
+      exc(1:mmax) = exc(1:mmax) + e(1:mmax)
+   end do
+
 ! go to convention for Don Hamman code - I do not understand:
 ! in principle libxc outputs energy per particle,
 ! and here we divide by rho again to get an LDA exc
 ! identical to the other routine...
- do ii=1,mmax
-   exc(ii) = exc(ii) / max(rho_loc(ii),1.d-20)
- end do
+   do ii=1,mmax
+      exc(ii) = exc(ii) / max(rho_loc(ii),1.d-20)
+   end do
 
- ! finish
- call xc_functl_end(functls(1))
- call xc_functl_end(functls(2))
- deallocate (ip)
- deallocate(v, e)
- deallocate(dpr, dppr, dlap)
- deallocate(tau_dummy, vtau_dummy)
- deallocate(rho_loc)
- 
+   ! finish
+   call xc_functl_end(functls(1))
+   call xc_functl_end(functls(2))
+   deallocate (ip)
+   deallocate(v, e)
+   deallocate(dpr, dppr, dlap)
+   deallocate(tau_dummy, vtau_dummy)
+   deallocate(rho_loc)
+
 end subroutine exc_libxc
- 
- 
+
+
 subroutine derivs(mmax, rho, al, rr, dpr, dppr, dlap)
 ! NB: presumes incoming rho is properly scaled without 4pi or r**2 factors.
- 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
- 
- integer, intent(in) :: mmax
- real(dp), intent(in) :: al
- real(dp), intent(in) :: rr(mmax)
- real(dp), intent(in) :: rho(mmax)
- real(dp), intent(out) :: dpr(mmax), dppr(mmax), dlap(mmax)
- 
+
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
+
+   integer, intent(in) :: mmax
+   real(dp), intent(in) :: al
+   real(dp), intent(in) :: rr(mmax)
+   real(dp), intent(in) :: rho(mmax)
+   real(dp), intent(out) :: dpr(mmax), dppr(mmax), dlap(mmax)
+
 ! local vars
- integer :: i
- real(dp) :: dpn(mmax), dppn(mmax)
- real(dp) :: c11,c12,c13,c14,c15
- real(dp) :: c21,c22,c23,c24,c25
- 
- c11 =   2.0d0 / 24.0d0
- c12 = -16.0d0 / 24.0d0
- c13 =   0.0d0 / 24.0d0
- c14 =  16.0d0 / 24.0d0
- c15 =  -2.0d0 / 24.0d0
+   integer :: i
+   real(dp) :: dpn(mmax), dppn(mmax)
+   real(dp) :: c11,c12,c13,c14,c15
+   real(dp) :: c21,c22,c23,c24,c25
+
+   c11 =   2.0d0 / 24.0d0
+   c12 = -16.0d0 / 24.0d0
+   c13 =   0.0d0 / 24.0d0
+   c14 =  16.0d0 / 24.0d0
+   c15 =  -2.0d0 / 24.0d0
 !
- c21 =   -1.0d0 / 12.0d0
- c22 =   16.0d0 / 12.0d0
- c23 =  -30.0d0 / 12.0d0
- c24 =   16.0d0 / 12.0d0
- c25 =   -1.0d0 / 12.0d0
+   c21 =   -1.0d0 / 12.0d0
+   c22 =   16.0d0 / 12.0d0
+   c23 =  -30.0d0 / 12.0d0
+   c24 =   16.0d0 / 12.0d0
+   c25 =   -1.0d0 / 12.0d0
 !
 ! n derivatives of d
-!     
- i=1
- dpn(i) = -25.d0/12.d0*rho(i) +4.d0*rho(i+1) -3.d0*rho(i+2) &
-&         +4.d0/3.d0*rho(i+3) -1.d0/4.d0*rho(i+4)
- dppn(i) = 15.d0/4.d0*rho(i) -77.d0/6.d0*rho(i+1) +107.d0/6.d0*rho(i+2) &
-&         -13.d0*rho(i+3) +61.d0/12.d0*rho(i+4) -5.d0/6.d0*rho(i+5)
- i=2
- dpn(i) = -25.d0/12.d0*rho(i) +4.d0*rho(i+1) -3.d0*rho(i+2)  &
-&         +4.d0/3.d0*rho(i+3) -1.d0/4.d0*rho(i+4)
- dppn(i) = 15.d0/4.d0*rho(i) -77.d0/6.d0*rho(i+1) +107.d0/6.d0*rho(i+2) &
-&         -13.d0*rho(i+3) +61.d0/12.d0*rho(i+4) -5.d0/6.d0*rho(i+5)
- 
- do i = 3, mmax - 2
-   dpn(i) =  c11*rho(i-2) + c12*rho(i-1) + c14*rho(i+1) + c15*rho(i+2)
-   dppn(i) = c21*rho(i-2) + c22*rho(i-1) + c23*rho(i)   + c24*rho(i+1) &
-&           +c25*rho(i+2)
- end do
- 
- i=mmax-1
- dpn(i) = +25.d0/12.d0*rho(i) -4.d0*rho(i-1) +3.d0*rho(i-2) &
-&         -4.d0/3.d0*rho(i-3) +1.d0/4.d0*rho(i-4)
- dppn(i) = -15.d0/4.d0*rho(i) +77.d0/6.d0*rho(i-1) -107.d0/6.d0*rho(i-2) &
-&          +13.d0*rho(i-3) -61.d0/12.d0*rho(i-4) +5.d0/6.d0*rho(i-5)
- i=mmax
- dpn(i) = +25.d0/12.d0*rho(i) -4.d0*rho(i-1) +3.d0*rho(i-2) &
-&         -4.d0/3.d0*rho(i-3) +1.d0/4.d0*rho(i-4)
- dppn(i) = -15.d0/4.d0*rho(i) +77.d0/6.d0*rho(i-1) -107.d0/6.d0*rho(i-2) &
-&          +13.d0*rho(i-3) -61.d0/12.d0*rho(i-4) +5.d0/6.d0*rho(i-5)
- 
+!
+   i=1
+   dpn(i) = -25.d0/12.d0*rho(i) +4.d0*rho(i+1) -3.d0*rho(i+2) &
+   &         +4.d0/3.d0*rho(i+3) -1.d0/4.d0*rho(i+4)
+   dppn(i) = 15.d0/4.d0*rho(i) -77.d0/6.d0*rho(i+1) +107.d0/6.d0*rho(i+2) &
+   &         -13.d0*rho(i+3) +61.d0/12.d0*rho(i+4) -5.d0/6.d0*rho(i+5)
+   i=2
+   dpn(i) = -25.d0/12.d0*rho(i) +4.d0*rho(i+1) -3.d0*rho(i+2)  &
+   &         +4.d0/3.d0*rho(i+3) -1.d0/4.d0*rho(i+4)
+   dppn(i) = 15.d0/4.d0*rho(i) -77.d0/6.d0*rho(i+1) +107.d0/6.d0*rho(i+2) &
+   &         -13.d0*rho(i+3) +61.d0/12.d0*rho(i+4) -5.d0/6.d0*rho(i+5)
+
+   do i = 3, mmax - 2
+      dpn(i) =  c11*rho(i-2) + c12*rho(i-1) + c14*rho(i+1) + c15*rho(i+2)
+      dppn(i) = c21*rho(i-2) + c22*rho(i-1) + c23*rho(i)   + c24*rho(i+1) &
+      &           +c25*rho(i+2)
+   end do
+
+   i=mmax-1
+   dpn(i) = +25.d0/12.d0*rho(i) -4.d0*rho(i-1) +3.d0*rho(i-2) &
+   &         -4.d0/3.d0*rho(i-3) +1.d0/4.d0*rho(i-4)
+   dppn(i) = -15.d0/4.d0*rho(i) +77.d0/6.d0*rho(i-1) -107.d0/6.d0*rho(i-2) &
+   &          +13.d0*rho(i-3) -61.d0/12.d0*rho(i-4) +5.d0/6.d0*rho(i-5)
+   i=mmax
+   dpn(i) = +25.d0/12.d0*rho(i) -4.d0*rho(i-1) +3.d0*rho(i-2) &
+   &         -4.d0/3.d0*rho(i-3) +1.d0/4.d0*rho(i-4)
+   dppn(i) = -15.d0/4.d0*rho(i) +77.d0/6.d0*rho(i-1) -107.d0/6.d0*rho(i-2) &
+   &          +13.d0*rho(i-3) -61.d0/12.d0*rho(i-4) +5.d0/6.d0*rho(i-5)
+
 !
 ! r derivatives of d
 !
- do i = 1, mmax
-   dpr(i) = dpn(i) / (al * rr(i))
-   dppr(i) = (dppn(i) - al * dpn(i)) / (al * rr(i))**2
-   dlap(i) = (dppn(i) + al * dpn(i)) / (al * rr(i))**2
- end do
- 
+   do i = 1, mmax
+      dpr(i) = dpn(i) / (al * rr(i))
+      dppr(i) = (dppn(i) - al * dpn(i)) / (al * rr(i))**2
+      dlap(i) = (dppn(i) + al * dpn(i)) / (al * rr(i))**2
+   end do
+
 end subroutine derivs

--- a/src/exc_libxc_stub.f90
+++ b/src/exc_libxc_stub.f90
@@ -2,39 +2,39 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University, and M. Verstratte, University of Liege
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- 
+
 subroutine exc_libxc(iexc,al,rho,vxc,exc,rr,mmax)
 !
 !  dummy substitute for interface to libxc library to allow successful
 !  build without this library
 !
- implicit none
- 
- integer, parameter :: dp=kind(1.0d0)
- 
- real(dp), intent(in) :: al
- real(dp), intent(in) :: rho(mmax),rr(mmax)
- real(dp), intent(out) :: vxc(mmax),exc(mmax)
- integer, intent(in) :: mmax, iexc
- 
- write(6,'(a,i8,a)') 'exc_libxc_stub: ERROR iexc = ',iexc,' requires libxc'
- write(6,'(a)') 'The present oncvpsp executable was built without libxc.'
- write(6,'(a)') 'Program will stop.'
- 
- stop
- return
+   implicit none
+
+   integer, parameter :: dp=kind(1.0d0)
+
+   real(dp), intent(in) :: al
+   real(dp), intent(in) :: rho(mmax),rr(mmax)
+   real(dp), intent(out) :: vxc(mmax),exc(mmax)
+   integer, intent(in) :: mmax, iexc
+
+   write(6,'(a,i8,a)') 'exc_libxc_stub: ERROR iexc = ',iexc,' requires libxc'
+   write(6,'(a)') 'The present oncvpsp executable was built without libxc.'
+   write(6,'(a)') 'Program will stop.'
+
+   stop
+   return
 end subroutine exc_libxc

--- a/src/exc_off_pbe.f
+++ b/src/exc_off_pbe.f
@@ -2,17 +2,17 @@
 ! Copyright (c) 1989-2014 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
@@ -79,10 +79,10 @@ c
       end do
 c
 c n derivatives of d
-c     
+c
       do i = 3, mmax - 2
         dpn(i) =  c11*d(i-2) + c12*d(i-1) + c14*d(i+1) + c15*d(i+2)
-        dppn(i) = c21*d(i-2) + c22*d(i-1) + c23*d(i)   + c24*d(i+1) 
+        dppn(i) = c21*d(i-2) + c22*d(i-1) + c23*d(i)   + c24*d(i+1)
      &          + c25*d(i+2)
       end do
 c
@@ -224,7 +224,7 @@ c   	e_x[unif]=ax*rho^(4/3)  [LDA]
 c ax = -0.75*(3/pi)^(1/3)
 c	e_x[PBE]=e_x[unif]*FxPBE(s)
 c	FxPBE(s)=1+uk-uk/(1+ul*s*s)                 [a](13)
-c uk, ul defined after [a](13) 
+c uk, ul defined after [a](13)
 c----------------------------------------------------------------------
 c----------------------------------------------------------------------
       IMPLICIT REAL*8 (A-H,O-Z)
@@ -259,7 +259,7 @@ c  Fss=d Fs/ds
       Fss=-4.d0*ul*S*Fs/P0
 c----------------------------------------------------------------------
 c----------------------------------------------------------------------
-c calculate potential from [b](24) 
+c calculate potential from [b](24)
       VX = exunif*(THRD4*FxPBE-(U-THRD4*S2*s)*FSS-V*FS)
       RETURN
       END
@@ -288,7 +288,7 @@ c        : dvcdn=nonlocal correction to vcdn
 c----------------------------------------------------------------------
 c----------------------------------------------------------------------
 c References:
-c [a] J.P.~Perdew, K.~Burke, and M.~Ernzerhof, 
+c [a] J.P.~Perdew, K.~Burke, and M.~Ernzerhof,
 c     {\sl Generalized gradient approximation made simple}, sub.
 c     to Phys. Rev.Lett. May 1996.
 c [b] J. P. Perdew, K. Burke, and Y. Wang, {\sl Real-space cutoff
@@ -305,7 +305,7 @@ c      FZZ=f''(0)= 8/(9*GAM)
 c numbers for construction of PBE
 c      gamma=(1-log(2))/pi^2
 c      bet=coefficient in gradient expansion for correlation, [a](4).
-c      eta=small number to stop d phi/ dzeta from blowing up at 
+c      eta=small number to stop d phi/ dzeta from blowing up at
 c          |zeta|=1.
       parameter(thrd=1.d0/3.d0,thrdm=-thrd,thrd2=2.d0*thrd)
       parameter(sixthm=thrdm/2.d0)
@@ -519,7 +519,7 @@ c######################################################################
 c----------------------------------------------------------------------
       SUBROUTINE CORpw91(RS,ZET,G,EC,ECRS,ECZET,T,UU,VV,WW,H,
      1                   DVCUP,DVCDN)
-C  pw91 CORRELATION, modified by K. Burke to put all arguments 
+C  pw91 CORRELATION, modified by K. Burke to put all arguments
 c  as variables in calling statement, rather than in common block
 c  May, 1996.
 C  INPUT RS: SEITZ RADIUS

--- a/src/exchdl.f90
+++ b/src/exchdl.f90
@@ -2,67 +2,67 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- subroutine exchdl(rho,vxc,exc,mmax)
+subroutine exchdl(rho,vxc,exc,mmax)
 
 !calculates Hedin-Lundquist exchange-correlation potential and energy
 !density
 
- implicit none
+   implicit none
 
- integer, parameter :: dp=kind(1.0d0)
- real(dp), parameter :: pi=3.141592653589793238462643383279502884197_dp
- real(dp), parameter :: pi4=4.0d0*pi
- real(dp), parameter :: pi4i=1.0d0/pi4
- real(dp), parameter :: thrd=1.0d0/3.0d0
+   integer, parameter :: dp=kind(1.0d0)
+   real(dp), parameter :: pi=3.141592653589793238462643383279502884197_dp
+   real(dp), parameter :: pi4=4.0d0*pi
+   real(dp), parameter :: pi4i=1.0d0/pi4
+   real(dp), parameter :: thrd=1.0d0/3.0d0
 
 !Inpupt variables
- integer :: mmax
- real(dp) :: rho(mmax)
+   integer :: mmax
+   real(dp) :: rho(mmax)
 
 !Output variables
- real(dp) :: vxc(mmax),exc(mmax)
+   real(dp) :: vxc(mmax),exc(mmax)
 
 !Local variables
- integer :: ii
- real(dp) :: conrs,convx,conex
- real(dp) :: rs,ecp,aln,xx,rh
+   integer :: ii
+   real(dp) :: conrs,convx,conex
+   real(dp) :: rs,ecp,aln,xx,rh
 
- conrs = (3.d0/(4.d0*pi))**thrd
- convx = (1.5d0/pi)**(2.0d0/3.0d0)
- conex = 0.75d0*convx
+   conrs = (3.d0/(4.d0*pi))**thrd
+   convx = (1.5d0/pi)**(2.0d0/3.0d0)
+   conex = 0.75d0*convx
 
 ! Hedin-Lundqvist correlation
 
- do ii=1,mmax
-   if(rho(ii)>1.0d-20) then
-     rh=rho(ii)*pi4i
-     rs=conrs/rh**thrd
-     xx=rs/21.0d0
-     aln=dlog(1.0d0 + 1.0d0/xx)
-     ecp = aln+(xx**3*aln-xx*xx)+0.5d0*xx-thrd
+   do ii=1,mmax
+      if(rho(ii)>1.0d-20) then
+         rh=rho(ii)*pi4i
+         rs=conrs/rh**thrd
+         xx=rs/21.0d0
+         aln=dlog(1.0d0 + 1.0d0/xx)
+         ecp = aln+(xx**3*aln-xx*xx)+0.5d0*xx-thrd
 !    ecp = aln+(xx**3*aln-xx*xx)+xx/2-1.0d0/3.0d0
 !    exc(ii)=-0.458175d0/rs - 0.0225d0*ecp
 !    vxc(ii)=-0.6109d0/rs - 0.0225d0*aln
-     exc(ii)=-conex/rs - 0.0225d0*ecp
-     vxc(ii)=-convx/rs - 0.0225d0*aln
-   else
-     vxc(ii)=0.0d0 ; exc(ii)=0.0d0
-   end if
- end do
+         exc(ii)=-conex/rs - 0.0225d0*ecp
+         vxc(ii)=-convx/rs - 0.0225d0*aln
+      else
+         vxc(ii)=0.0d0 ; exc(ii)=0.0d0
+      end if
+   end do
 
- return
- end subroutine exchdl
+   return
+end subroutine exchdl

--- a/src/excpzca.f90
+++ b/src/excpzca.f90
@@ -2,23 +2,23 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- subroutine excpzca(rho,vxc,exc,mmax)
+subroutine excpzca(rho,vxc,exc,mmax)
 
-!calculates Perdew-Zunger-Ceperly_Alder exchange-correlation potential 
+!calculates Perdew-Zunger-Ceperly_Alder exchange-correlation potential
 ! and energy density J. P. Perdew and A. Zunger, Phys. Rev. B23, 5048 (1981)
 
 !rho  charge density
@@ -26,66 +26,66 @@
 !exc  exchange-correlation energy density
 !mmax  dimension of log radial grid
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
- real(dp), parameter :: pi=3.141592653589793238462643383279502884197_dp
- real(dp), parameter :: pi4=4.0d0*pi
- real(dp), parameter :: pi4i=1.0d0/pi4
- real(dp), parameter :: thrd=1.0d0/3.0d0
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
+   real(dp), parameter :: pi=3.141592653589793238462643383279502884197_dp
+   real(dp), parameter :: pi4=4.0d0*pi
+   real(dp), parameter :: pi4i=1.0d0/pi4
+   real(dp), parameter :: thrd=1.0d0/3.0d0
 
 !Input variables
- integer :: mmax
- real(dp) :: rho(mmax)
+   integer :: mmax
+   real(dp) :: rho(mmax)
 
 !Output variables
- real(dp) :: vxc(mmax),exc(mmax)
+   real(dp) :: vxc(mmax),exc(mmax)
 
 !Local variables
- integer :: ii
- real(dp) :: rs,rh,sqrs,rsl,den
+   integer :: ii
+   real(dp) :: rs,rh,sqrs,rsl,den
 
- real(dp), parameter :: conrs = (3.d0/(4.d0*pi))**thrd
- real(dp), parameter :: convx = (1.5d0/pi)**(2.0d0/3.0d0)
- real(dp), parameter ::conex = 0.75d0*convx
+   real(dp), parameter :: conrs = (3.d0/(4.d0*pi))**thrd
+   real(dp), parameter :: convx = (1.5d0/pi)**(2.0d0/3.0d0)
+   real(dp), parameter ::conex = 0.75d0*convx
 
 
 !rs>1, Ceperley-Alder fit to QMC
- real(dp), parameter :: gam = -0.1423d0
- real(dp), parameter :: bt1 =  1.0529d0
- real(dp), parameter :: bt2 =  0.3334d0
+   real(dp), parameter :: gam = -0.1423d0
+   real(dp), parameter :: bt1 =  1.0529d0
+   real(dp), parameter :: bt2 =  0.3334d0
 
 !rs<1, Perdew-Zunger leading terms of RPA high-density expansion
 !AA and BB known from Gell-Mann & Bruckner
 !PZ adjust CC and DD for contiunity of exc and vxc at rs=1
- real(dp), parameter :: AA =   0.0311d0
- real(dp), parameter :: BB =  -0.0480d0
- real(dp), parameter :: CC =   0.0020d0
- real(dp), parameter :: DD =  -0.0116d0
+   real(dp), parameter :: AA =   0.0311d0
+   real(dp), parameter :: BB =  -0.0480d0
+   real(dp), parameter :: CC =   0.0020d0
+   real(dp), parameter :: DD =  -0.0116d0
 
 !PZ modified coeffients from libxc
 !real(dp), parameter :: CC =   0.0020191519406228d0
 !real(dp), parameter :: DD =  -0.0116320663789130d0
 
- do ii=1,mmax
-   if(rho(ii)>1.0d-20) then
-      rh=rho(ii)/pi4
-      rs=conrs*rh**(-thrd)
-      if(rs > 1.0d0) then
-        sqrs=dsqrt(rs)
-        den=1.0d0 + bt1*sqrs +bt2*rs
-        exc(ii)=-conex/rs + gam/den
-        vxc(ii)=-convx/rs + gam*(1.0d0 + (3.5d0*bt1*sqrs &
-   &            + 4.0d0*bt2*rs)*thrd)/den**2
+   do ii=1,mmax
+      if(rho(ii)>1.0d-20) then
+         rh=rho(ii)/pi4
+         rs=conrs*rh**(-thrd)
+         if(rs > 1.0d0) then
+            sqrs=dsqrt(rs)
+            den=1.0d0 + bt1*sqrs +bt2*rs
+            exc(ii)=-conex/rs + gam/den
+            vxc(ii)=-convx/rs + gam*(1.0d0 + (3.5d0*bt1*sqrs &
+            &            + 4.0d0*bt2*rs)*thrd)/den**2
+         else
+            rsl=dlog(rs)
+            exc(ii)=-conex/rs + AA*rsl + BB + CC*rs*rsl + DD*rs
+            vxc(ii)=-convx/rs + AA*rsl + (BB-thrd*AA) + 2.0d0*thrd*CC*rs*rsl &
+            &            + thrd*(2.0d0*DD-CC)*rs
+         end if
       else
-        rsl=dlog(rs)
-        exc(ii)=-conex/rs + AA*rsl + BB + CC*rs*rsl + DD*rs
-        vxc(ii)=-convx/rs + AA*rsl + (BB-thrd*AA) + 2.0d0*thrd*CC*rs*rsl &
-   &            + thrd*(2.0d0*DD-CC)*rs
+         vxc(ii)=0.0d0 ; exc(ii)=0.0d0
       end if
-   else
-      vxc(ii)=0.0d0 ; exc(ii)=0.0d0
-   end if
- end do
+   end do
 
- return
- end subroutine excpzca
+   return
+end subroutine excpzca

--- a/src/excwig.f90
+++ b/src/excwig.f90
@@ -2,21 +2,21 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- subroutine excwig(rho,vxc,exc,mmax)
+subroutine excwig(rho,vxc,exc,mmax)
 
 ! Wigner ingerpolation formula for exchange-correlation potential and
 ! energy density
@@ -26,40 +26,39 @@
 !exc  exchange-correlation energy density
 !mmax  dimension of log radial grid
 
- implicit none
+   implicit none
 
- integer, parameter :: dp=kind(1.0d0)
- real(dp), parameter :: pi=3.141592653589793238462643383279502884197_dp
- real(dp), parameter :: pi4=4.0d0*pi
- real(dp), parameter :: pi4i=1.0d0/pi4
- real(dp), parameter :: thrd=1.0d0/3.0d0
+   integer, parameter :: dp=kind(1.0d0)
+   real(dp), parameter :: pi=3.141592653589793238462643383279502884197_dp
+   real(dp), parameter :: pi4=4.0d0*pi
+   real(dp), parameter :: pi4i=1.0d0/pi4
+   real(dp), parameter :: thrd=1.0d0/3.0d0
 
 !Input variables
- real(dp) ::  rho(mmax)
- integer :: mmax
+   real(dp) ::  rho(mmax)
+   integer :: mmax
 
 !Output variables
- real(dp) :: vxc(mmax),exc(mmax)
+   real(dp) :: vxc(mmax),exc(mmax)
 
 !Local vafriables
- real(dp) ::  rh,rs
- real(dp) :: conrs,convx,conex
- integer :: ii
+   real(dp) ::  rh,rs
+   real(dp) :: conrs,convx,conex
+   integer :: ii
 
- conrs = (3.d0/(4.d0*pi))**thrd
- convx = (1.5d0/pi)**(2.0d0/3.0d0)
- conex = 0.75d0*convx
+   conrs = (3.d0/(4.d0*pi))**thrd
+   convx = (1.5d0/pi)**(2.0d0/3.0d0)
+   conex = 0.75d0*convx
 
 ! Wigner interpolation formula, E. Wigner, Phys. Rev. 46, 1002 (1934).
 
- do ii=1,mmax
-  if(rho(ii)>=1.0d-15) then
-   rh=rho(ii)*pi4i
-   rs=conrs*rh**(-thrd)
-   vxc(ii)=-convx/rs - 0.44d0*(4.0d0*thrd*rs+7.8d0)/(rs+7.8d0)**2
-   exc(ii)=-conex/rs - 0.44d0/(rs+7.8d0)
-  end if
- end do
- return
- end subroutine excwig
-
+   do ii=1,mmax
+      if(rho(ii)>=1.0d-15) then
+         rh=rho(ii)*pi4i
+         rs=conrs*rh**(-thrd)
+         vxc(ii)=-convx/rs - 0.44d0*(4.0d0*thrd*rs+7.8d0)/(rs+7.8d0)**2
+         exc(ii)=-conex/rs - 0.44d0/(rs+7.8d0)
+      end if
+   end do
+   return
+end subroutine excwig

--- a/src/fphsft.f90
+++ b/src/fphsft.f90
@@ -2,21 +2,21 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- subroutine fphsft(ll,epsh2,depsh,pshf,rr,vv,zz,mmax,mch,npsh,srel)
+subroutine fphsft(ll,epsh2,depsh,pshf,rr,vv,zz,mmax,mch,npsh,srel)
 
 ! computes full potential scattering log derivatives
 ! returns atan(rr(mch) * du/dr / u) which is sort-of like a phase shift
@@ -35,50 +35,50 @@
 !npsh  number of energy points in scan
 !srel .true. for scalar-relativistic, .false. for non-relativistic
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
- real(dp), parameter :: pi=3.141592653589793238462643383279502884197_dp
- real(dp), parameter :: pi2=2.0d0*pi
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
+   real(dp), parameter :: pi=3.141592653589793238462643383279502884197_dp
+   real(dp), parameter :: pi2=2.0d0*pi
 
 !Input variables
- integer :: ll,mmax,npsh,mch
- real(dp) :: rr(mmax),vv(mmax)
- real(dp) :: depsh,epsh2,zz
- logical :: srel
+   integer :: ll,mmax,npsh,mch
+   real(dp) :: rr(mmax),vv(mmax)
+   real(dp) :: depsh,epsh2,zz
+   logical :: srel
 
 !Output variables
- real(dp) :: pshf(npsh)
+   real(dp) :: pshf(npsh)
 
 !Local variables
- real(dp) :: al,epsh,phi,phip,pshoff
- integer :: ii,ierr,nn
+   real(dp) :: al,epsh,phi,phip,pshoff
+   integer :: ii,ierr,nn
 
- real(dp), allocatable :: uu(:),up(:)
+   real(dp), allocatable :: uu(:),up(:)
 
 
 
- allocate(uu(mmax),up(mmax))
+   allocate(uu(mmax),up(mmax))
 
- al = 0.01d0 * dlog(rr(101) / rr(1))
+   al = 0.01d0 * dlog(rr(101) / rr(1))
 
- pshoff = 0.0d0
+   pshoff = 0.0d0
 
- do ii = 1,npsh
-   epsh = epsh2-(ii-1)*depsh
+   do ii = 1,npsh
+      epsh = epsh2-(ii-1)*depsh
 
-   call lschfs(nn,ll,ierr,epsh,rr,vv,uu,up,zz,mmax,mch,srel)
+      call lschfs(nn,ll,ierr,epsh,rr,vv,uu,up,zz,mmax,mch,srel)
 
-   phi = uu(mch)/rr(mch)
-   phip = (up(mch)-al*uu(mch))/(al*rr(mch)**2)
-   pshf(ii) = atan2(rr(mch)*phip,phi) + pshoff
-   if(ii>1) then
-      if(pshf(ii)<pshf(ii-1)) then
-         pshoff = pshoff+pi2
-         pshf(ii) = pshf(ii)+pi2
+      phi = uu(mch)/rr(mch)
+      phip = (up(mch)-al*uu(mch))/(al*rr(mch)**2)
+      pshf(ii) = atan2(rr(mch)*phip,phi) + pshoff
+      if(ii>1) then
+         if(pshf(ii)<pshf(ii-1)) then
+            pshoff = pshoff+pi2
+            pshf(ii) = pshf(ii)+pi2
+         end if
       end if
-   end if
- end do
+   end do
 
- deallocate(uu,up)
- return
- end subroutine fphsft
+   deallocate(uu,up)
+   return
+end subroutine fphsft

--- a/src/fphsft_r.f90
+++ b/src/fphsft_r.f90
@@ -2,21 +2,21 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- subroutine fphsft_r(ll,kap,epsh2,depsh,pshf,rr,vv,zz,mmax,mch,npsh)
+subroutine fphsft_r(ll,kap,epsh2,depsh,pshf,rr,vv,zz,mmax,mch,npsh)
 
 ! computes full potential scattering log derivatives
 ! returns atan(rr(mch) * du/dr / u) which is sort-of like a phase shift
@@ -35,48 +35,48 @@
 !mch  index of radius for log der test
 !npsh  number of energy points in scan
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
- real(dp), parameter :: pi=3.141592653589793238462643383279502884197_dp
- real(dp), parameter :: pi2=2.0d0*pi
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
+   real(dp), parameter :: pi=3.141592653589793238462643383279502884197_dp
+   real(dp), parameter :: pi2=2.0d0*pi
 
 !Input variables
- integer :: ll,kap,mmax,npsh,mch
- real(dp) :: rr(mmax),vv(mmax)
- real(dp) :: depsh,epsh2,zz
- logical :: srel
+   integer :: ll,kap,mmax,npsh,mch
+   real(dp) :: rr(mmax),vv(mmax)
+   real(dp) :: depsh,epsh2,zz
+   logical :: srel
 
 !Output variables
- real(dp) :: pshf(npsh)
+   real(dp) :: pshf(npsh)
 
 !Local variables
- real(dp) :: al,epsh,phi,phip,pshoff
- integer :: ii,ierr,nnae
+   real(dp) :: al,epsh,phi,phip,pshoff
+   integer :: ii,ierr,nnae
 
- real(dp), allocatable :: uu(:,:),up(:,:)
+   real(dp), allocatable :: uu(:,:),up(:,:)
 
- allocate(uu(mmax,2),up(mmax,2))
+   allocate(uu(mmax,2),up(mmax,2))
 
- al = 0.01d0 * dlog(rr(101) / rr(1))
+   al = 0.01d0 * dlog(rr(101) / rr(1))
 
- pshoff = 0.0d0
+   pshoff = 0.0d0
 
- do ii = 1,npsh
-   epsh = epsh2-(ii-1)*depsh
+   do ii = 1,npsh
+      epsh = epsh2-(ii-1)*depsh
 
-   call ldiracfs(nnae,ll,kap,ierr,epsh,rr,zz,vv,uu,up,mmax,mch)
+      call ldiracfs(nnae,ll,kap,ierr,epsh,rr,zz,vv,uu,up,mmax,mch)
 
-   phi = uu(mch,1)/rr(mch)
-   phip = (up(mch,1)-al*uu(mch,1))/(al*rr(mch)**2)
-   pshf(ii) = atan2(rr(mch)*phip,phi) + pshoff
-   if(ii>1) then
-      if(pshf(ii)<pshf(ii-1)) then
-         pshoff = pshoff+pi2
-         pshf(ii) = pshf(ii)+pi2
+      phi = uu(mch,1)/rr(mch)
+      phip = (up(mch,1)-al*uu(mch,1))/(al*rr(mch)**2)
+      pshf(ii) = atan2(rr(mch)*phip,phi) + pshoff
+      if(ii>1) then
+         if(pshf(ii)<pshf(ii-1)) then
+            pshoff = pshoff+pi2
+            pshf(ii) = pshf(ii)+pi2
+         end if
       end if
-   end if
- end do
+   end do
 
- deallocate(uu,up)
- return
- end subroutine fphsft_r
+   deallocate(uu,up)
+   return
+end subroutine fphsft_r

--- a/src/fpovlp.f90
+++ b/src/fpovlp.f90
@@ -2,26 +2,26 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
 ! calculates all-electron wave function overlap intergrals
 
- subroutine fpovlp(gg,hh,nn,ll,zz,ss,rr,srel)
+subroutine fpovlp(gg,hh,nn,ll,zz,ss,rr,srel)
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !gg wave function one
 !hh wave function two
@@ -33,48 +33,48 @@
 !srel .true. for scalar-relativistic, .false. for non-relativistic
 
 
-! product of all-elecctron scalar-relativistic wave functions gg*hh 
+! product of all-elecctron scalar-relativistic wave functions gg*hh
 ! goes like rr**(2*gamma) as rr -> 0
 ! integral on usual log mesh from rr=0 to rr(nn)
 
 !Input variables
- real(dp) :: zz
- real(dp) :: gg(nn),hh(nn),rr(nn)
- integer :: nn,ll
- logical :: srel
+   real(dp) :: zz
+   real(dp) :: gg(nn),hh(nn),rr(nn)
+   integer :: nn,ll
+   logical :: srel
 
 !Output variable
- real(dp) :: ss
+   real(dp) :: ss
 
 !Local variables
- real(dp) :: r0,amesh,al,fss,gamma
- integer :: ii
+   real(dp) :: r0,amesh,al,fss,gamma
+   integer :: ii
 
- al = 0.01d0 * dlog(rr(101)/rr(1))
- amesh = exp(al)
+   al = 0.01d0 * dlog(rr(101)/rr(1))
+   amesh = exp(al)
 
- if(srel) then
-  fss=(1.0d0/137.036d0)**2
- else
-  fss=1.0d-12
- end if
+   if(srel) then
+      fss=(1.0d0/137.036d0)**2
+   else
+      fss=1.0d-12
+   end if
 
- if(ll==0) gamma=dsqrt(1.0d0-fss*zz**2)
- if(ll>0) gamma=(ll*dsqrt(ll**2-fss*zz**2) + &
-& (ll+1)*dsqrt((ll+1)**2-fss*zz**2))/(2*ll+1)
+   if(ll==0) gamma=dsqrt(1.0d0-fss*zz**2)
+   if(ll>0) gamma=(ll*dsqrt(ll**2-fss*zz**2) + &
+   & (ll+1)*dsqrt((ll+1)**2-fss*zz**2))/(2*ll+1)
 
- r0=rr(1)/dsqrt(amesh)
- ss=r0**(2.0d0*gamma+1.0d0)/(2.d0*gamma+1.0d0)
- ss=(ss*gg(1)*hh(1))/rr(1)**(2.d0*gamma)
+   r0=rr(1)/dsqrt(amesh)
+   ss=r0**(2.0d0*gamma+1.0d0)/(2.d0*gamma+1.0d0)
+   ss=(ss*gg(1)*hh(1))/rr(1)**(2.d0*gamma)
 
- do ii = 1, nn - 3
-   ss =  ss + al*gg(ii)*hh(ii)*rr(ii)
- end do
+   do ii = 1, nn - 3
+      ss =  ss + al*gg(ii)*hh(ii)*rr(ii)
+   end do
 
- ss=ss + al*(23.d0*rr(nn-2)*gg(nn-2)*hh(nn-2) &
-&        + 28.d0*rr(nn-1)*gg(nn-1)*hh(nn-1) &
-&        +  9.d0*rr(nn  )*gg(nn  )*hh(nn  ))/24.d0
+   ss=ss + al*(23.d0*rr(nn-2)*gg(nn-2)*hh(nn-2) &
+   &        + 28.d0*rr(nn-1)*gg(nn-1)*hh(nn-1) &
+   &        +  9.d0*rr(nn  )*gg(nn  )*hh(nn  ))/24.d0
 
 
- return
- end subroutine fpovlp
+   return
+end subroutine fpovlp

--- a/src/fpovlp_r.f90
+++ b/src/fpovlp_r.f90
@@ -2,26 +2,26 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
 ! calculates all-electron wave function overlap intergrals
 
- subroutine fpovlp_r(gg,hh,nn,ll,kap,zz,ss,rr)
+subroutine fpovlp_r(gg,hh,nn,ll,kap,zz,ss,rr)
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !gg Dirac wave function one
 !hh Dirac wave function two
@@ -32,32 +32,32 @@
 !ss overlap output
 !rr log radial mesh
 
-! product of all-elecctron relativistic wave functions gg*hh 
+! product of all-elecctron relativistic wave functions gg*hh
 ! goes like rr**(2*gamma) as rr -> 0
 ! integral on usual log mesh from rr=0 to rr(nn)
 
 !Input variables
- real(dp) :: zz
- real(dp) :: gg(nn,2),hh(nn,2),rr(nn)
- integer :: nn,ll,kap
+   real(dp) :: zz
+   real(dp) :: gg(nn,2),hh(nn,2),rr(nn)
+   integer :: nn,ll,kap
 
 !Output variable
- real(dp) :: ss
+   real(dp) :: ss
 
 !Local variables
- real(dp) :: r0,amesh,al,fss,gam,cc,cci
- integer :: ii
+   real(dp) :: r0,amesh,al,fss,gam,cc,cci
+   integer :: ii
 
- al = 0.01d0 * dlog(rr(101)/rr(1))
- amesh = exp(al)
+   al = 0.01d0 * dlog(rr(101)/rr(1))
+   amesh = exp(al)
 
- cc=137.036d0
- cci=1.0d0/cc
+   cc=137.036d0
+   cci=1.0d0/cc
 
- gam=sqrt(kap**2-(zz*cci)**2)
+   gam=sqrt(kap**2-(zz*cci)**2)
 
- r0=rr(1)/dsqrt(amesh)
- ss=r0**(2.0d0*gam+1.0d0)/(2.d0*gam+1.0d0)
+   r0=rr(1)/dsqrt(amesh)
+   ss=r0**(2.0d0*gam+1.0d0)/(2.d0*gam+1.0d0)
 
 ! original version used large and small components, now deprecated (see docs)
 
@@ -73,15 +73,15 @@
 
 ! current version based on large-component only
 
- ss=ss*(gg(1,1)*hh(1,1))/rr(1)**(2.d0*gam)
+   ss=ss*(gg(1,1)*hh(1,1))/rr(1)**(2.d0*gam)
 
- do ii = 1, nn - 3
-   ss =  ss + al*(gg(ii,1)*hh(ii,1))*rr(ii)
- end do
+   do ii = 1, nn - 3
+      ss =  ss + al*(gg(ii,1)*hh(ii,1))*rr(ii)
+   end do
 
- ss=ss+al*(23.d0*rr(nn-2)*(gg(nn-2,1)*hh(nn-2,1)) &
-&        + 28.d0*rr(nn-1)*(gg(nn-1,1)*hh(nn-1,1)) &
-&        +  9.d0*rr(nn  )*(gg(nn  ,1)*hh(nn  ,1)))/24.d0
+   ss=ss+al*(23.d0*rr(nn-2)*(gg(nn-2,1)*hh(nn-2,1)) &
+   &        + 28.d0*rr(nn-1)*(gg(nn-1,1)*hh(nn-1,1)) &
+   &        +  9.d0*rr(nn  )*(gg(nn  ,1)*hh(nn  ,1)))/24.d0
 
- return
- end subroutine fpovlp_r
+   return
+end subroutine fpovlp_r

--- a/src/functionals.F90
+++ b/src/functionals.F90
@@ -19,772 +19,772 @@
 
 ! generic interfaces
 module parser
-  implicit none
-  interface parse_variable
-     module procedure real_parser ! interface for a module
-     module procedure logical_parser ! procedure is implicit
-  end interface parse_variable
+   implicit none
+   interface parse_variable
+      module procedure real_parser  ! interface for a module
+      module procedure logical_parser  ! procedure is implicit
+   end interface parse_variable
 contains
-  subroutine real_parser(varval, var)
-    real(8), intent(in) :: varval
-    real(8), intent(out) :: var
-    var = varval
-  end subroutine real_parser
-  subroutine logical_parser(varval, var)
-    logical, intent(in) :: varval
-    logical, intent(out) :: var
-    var = varval
-  end subroutine logical_parser
+subroutine real_parser(varval, var)
+   real(8), intent(in) :: varval
+   real(8), intent(out) :: var
+   var = varval
+end subroutine real_parser
+subroutine logical_parser(varval, var)
+   logical, intent(in) :: varval
+   logical, intent(out) :: var
+   var = varval
+end subroutine logical_parser
 end module parser
 
 ! For messaging
 module xc_messages
-  implicit none
-  ! Messages
-  character(1200) :: message(2)
+   implicit none
+   ! Messages
+   character(1200) :: message(2)
 contains
-  subroutine messages_info(lmess, iunit)
-    integer, intent(in) :: lmess, iunit
-    integer :: i
-    do i=1,lmess
-       write(iunit,'("LXC ",A)') trim(message(i))
-    end do
-  end subroutine messages_info
+subroutine messages_info(lmess, iunit)
+   integer, intent(in) :: lmess, iunit
+   integer :: i
+   do i=1,lmess
+      write(iunit,'("LXC ",A)') trim(message(i))
+   end do
+end subroutine messages_info
 
-  subroutine messages_fatal(lmess)
-    integer, intent(in) :: lmess
-    integer :: i
-    do i=1,lmess
-       write(*,'("Fatal ",A)') trim(message(i))
-    end do
-    stop
-  end subroutine messages_fatal
+subroutine messages_fatal(lmess)
+   integer, intent(in) :: lmess
+   integer :: i
+   do i=1,lmess
+      write(*,'("Fatal ",A)') trim(message(i))
+   end do
+   stop
+end subroutine messages_fatal
 
-  subroutine messages_warning(lmess)
-    integer, intent(in) :: lmess
-    integer :: i
-    do i=1,lmess
-       write(*,'("Warning ",A)') trim(message(i))
-    end do
-  end subroutine messages_warning
+subroutine messages_warning(lmess)
+   integer, intent(in) :: lmess
+   integer :: i
+   do i=1,lmess
+      write(*,'("Warning ",A)') trim(message(i))
+   end do
+end subroutine messages_warning
 
-  subroutine messages_input_error(str1,str2)
-    character(*), intent(in) :: str1,str2
-    write(*,'("Input error ",A,A)') trim(str1),trim(str2)
-  end subroutine messages_input_error
+subroutine messages_input_error(str1,str2)
+   character(*), intent(in) :: str1,str2
+   write(*,'("Input error ",A,A)') trim(str1),trim(str2)
+end subroutine messages_input_error
 
-  subroutine messages_experimental(str)
-    character(*), intent(in) :: str
-    write(*,'("Experimental xc ",A)') trim(str)
-  end subroutine messages_experimental
+subroutine messages_experimental(str)
+   character(*), intent(in) :: str
+   write(*,'("Experimental xc ",A)') trim(str)
+end subroutine messages_experimental
 
-  subroutine messages_not_implemented(str)
-    character(*), intent(in) :: str
-    write(*,'("Not implemented ",A)') trim(str)
-  end subroutine messages_not_implemented
+subroutine messages_not_implemented(str)
+   character(*), intent(in) :: str
+   write(*,'("Not implemented ",A)') trim(str)
+end subroutine messages_not_implemented
 end module xc_messages
 
 ! The main module
 module functionals_m
-  use parser
-  use xc_messages
-  use iso_c_binding
+use parser
+use xc_messages
+use iso_c_binding
 #include "xc_version.h"
 
 #if XC_MAJOR_VERSION>=6
-  use xc_f03_lib_m
+use xc_f03_lib_m
 #elif XC_MAJOR_VERSION==5
-  use xc_f90_lib_m
+use xc_f90_lib_m
 #endif
 
-  implicit none
+implicit none
 
-  ! Parameters
-  integer, parameter :: iunit = 6
-  real(8), parameter :: pi = 3.141592653589793238462643383279502884197d0
-  integer(c_size_t), parameter, private :: xc_one = 1
+ ! Parameters
+integer, parameter :: iunit = 6
+real(8), parameter :: pi = 3.141592653589793238462643383279502884197d0
+integer(c_size_t), parameter, private :: xc_one = 1
 
-  private
-  public ::                     &
-       xc_functl_t,                &
-       xc_functl_init_functl,      &
-       xc_functl_end,              &
-       xc_functl_write_info, &
-       xc_functl_get_vxc
+private
+public ::                     &
+   xc_functl_t,                &
+   xc_functl_init_functl,      &
+   xc_functl_end,              &
+   xc_functl_write_info, &
+   xc_functl_get_vxc
 
-  integer, public, parameter :: XC_DERIV_NUMERICAL = 1,XC_DERIV_ANALYTICAL = 2
+integer, public, parameter :: XC_DERIV_NUMERICAL = 1,XC_DERIV_ANALYTICAL = 2
 
-  type xc_functl_t
-     integer         :: family            !< LDA, GGA, etc.
-     integer         :: type              !< exchange, correlation, or exchange-correlation
-     integer         :: id                !< identifier
+type xc_functl_t
+   integer         :: family            !< LDA, GGA, etc.
+   integer         :: type              !< exchange, correlation, or exchange-correlation
+   integer         :: id                !< identifier
 
-     integer         :: nspin             !< XC_UNPOLARIZED | XC_POLARIZED
-     integer         :: flags             !< XC_FLAGS_HAVE_EXC + XC_FLAGS_HAVE_VXC + ...
+   integer         :: nspin             !< XC_UNPOLARIZED | XC_POLARIZED
+   integer         :: flags             !< XC_FLAGS_HAVE_EXC + XC_FLAGS_HAVE_VXC + ...
 
 #if XC_MAJOR_VERSION>=6
-     type(xc_f03_func_t) :: conf          !< the pointer used to call the library
-     type(xc_f03_func_info_t) :: info     !< information about the functional
+   type(xc_f03_func_t) :: conf          !< the pointer used to call the library
+   type(xc_f03_func_info_t) :: info     !< information about the functional
 #elif XC_MAJOR_VERSION==5
-     type(xc_f90_func_t) :: conf          !< the pointer used to call the library
-     type(xc_f90_func_info_t) :: info     !< information about the functional
+   type(xc_f90_func_t) :: conf          !< the pointer used to call the library
+   type(xc_f90_func_info_t) :: info     !< information about the functional
 #endif
 
-     integer         :: LB94_modified     !< should I use a special version of LB94 that
-     real(8)         :: LB94_threshold    !< needs to be handled specially
+   integer         :: LB94_modified     !< should I use a special version of LB94 that
+   real(8)         :: LB94_threshold    !< needs to be handled specially
 
-     integer  :: deriv_method
-  end type xc_functl_t
+   integer  :: deriv_method
+end type xc_functl_t
 
 contains
 
-  ! ---------------------------------------------------------
-  subroutine xc_functl_init(functl, nspin, deriv_method)
-    type(xc_functl_t), intent(out) :: functl
-    integer,           intent(in)  :: nspin, deriv_method
+ ! ---------------------------------------------------------
+subroutine xc_functl_init(functl, nspin, deriv_method)
+   type(xc_functl_t), intent(out) :: functl
+   integer,           intent(in)  :: nspin, deriv_method
 
 
-    functl%family = 0
-    functl%type   = 0
-    functl%id     = 0
-    functl%flags  = 0
-    functl%nspin = nspin
-    functl%deriv_method = deriv_method
+   functl%family = 0
+   functl%type   = 0
+   functl%id     = 0
+   functl%flags  = 0
+   functl%nspin = nspin
+   functl%deriv_method = deriv_method
 
-  end subroutine xc_functl_init
+end subroutine xc_functl_init
 
-  ! ---------------------------------------------------------
+ ! ---------------------------------------------------------
 
-  subroutine xc_functl_init_functl(functl, id, ndim,nel, nspin, deriv_method)
-    type(xc_functl_t), intent(out) :: functl
-    integer,           intent(in)  :: id
-    integer,           intent(in)  :: ndim
-    real(8),             intent(in)  :: nel
-    integer,           intent(in)  :: nspin
-    integer,           intent(in)  :: deriv_method
+subroutine xc_functl_init_functl(functl, id, ndim,nel, nspin, deriv_method)
+   type(xc_functl_t), intent(out) :: functl
+   integer,           intent(in)  :: id
+   integer,           intent(in)  :: ndim
+   real(8),             intent(in)  :: nel
+   integer,           intent(in)  :: nspin
+   integer,           intent(in)  :: deriv_method
 
-    real(8)   :: alpha
-    real(8)   :: parameters(2)
-    logical :: ok, lb94_modified
+   real(8)   :: alpha
+   real(8)   :: parameters(2)
+   logical :: ok, lb94_modified
 
 #if XC_MAJOR_VERSION<5
-    call messages_input_error('LibXC version', 'at least v5 is now required')
+   call messages_input_error('LibXC version', 'at least v5 is now required')
 #endif
 
-    ! initialize structure
-    call xc_functl_init(functl, nspin, deriv_method)
+   ! initialize structure
+   call xc_functl_init(functl, nspin, deriv_method)
 
-    functl%id = id
+   functl%id = id
 
-    if(functl%id == 0) then
-       functl%family = XC_FAMILY_NONE
-    else
-       ! get the family of the functional
+   if(functl%id == 0) then
+      functl%family = XC_FAMILY_NONE
+   else
+      ! get the family of the functional
 #if XC_MAJOR_VERSION>=6
-       functl%family = xc_f03_family_from_id(functl%id)
+      functl%family = xc_f03_family_from_id(functl%id)
 #elif XC_MAJOR_VERSION==5
-       functl%family = xc_f90_family_from_id(functl%id)
+      functl%family = xc_f90_family_from_id(functl%id)
 #endif
-       ! this also ensures it is actually a functional defined by the linked version of libxc
+      ! this also ensures it is actually a functional defined by the linked version of libxc
 
-       if(functl%family == XC_FAMILY_UNKNOWN) then
-          call messages_input_error('XCFunctional', 'Unknown functional')
-       end if
-    end if
+      if(functl%family == XC_FAMILY_UNKNOWN) then
+         call messages_input_error('XCFunctional', 'Unknown functional')
+      end if
+   end if
 
-    if(functl%family == XC_FAMILY_OEP) then
-       functl%type = XC_EXCHANGE
+   if(functl%family == XC_FAMILY_OEP) then
+      functl%type = XC_EXCHANGE
 
-    else if(functl%family  ==  XC_FAMILY_NONE) then
-       functl%type = -1
-       functl%flags = 0
-    else ! handled by libxc
-       ! initialize
+   else if(functl%family  ==  XC_FAMILY_NONE) then
+      functl%type = -1
+      functl%flags = 0
+   else  ! handled by libxc
+      ! initialize
 #if XC_MAJOR_VERSION>=6
-       call xc_f03_func_init(functl%conf, functl%id, nspin)
-       functl%info     = xc_f03_func_get_info(functl%conf)
-       functl%type     = xc_f03_func_info_get_kind(functl%info)
-       functl%flags    = xc_f03_func_info_get_flags(functl%info)
+      call xc_f03_func_init(functl%conf, functl%id, nspin)
+      functl%info     = xc_f03_func_get_info(functl%conf)
+      functl%type     = xc_f03_func_info_get_kind(functl%info)
+      functl%flags    = xc_f03_func_info_get_flags(functl%info)
 #elif XC_MAJOR_VERSION==5
-       call xc_f90_func_init(functl%conf, functl%id, nspin)
-       functl%info     = xc_f90_func_get_info(functl%conf)
-       functl%type     = xc_f90_func_info_get_kind(functl%info)
-       functl%flags    = xc_f90_func_info_get_flags(functl%info)
+      call xc_f90_func_init(functl%conf, functl%id, nspin)
+      functl%info     = xc_f90_func_get_info(functl%conf)
+      functl%type     = xc_f90_func_info_get_kind(functl%info)
+      functl%flags    = xc_f90_func_info_get_flags(functl%info)
 #endif
 
-       ! FIXME: no need to say this for kernel
-       if(iand(functl%flags, XC_FLAGS_HAVE_EXC) == 0) then
-          message(1) = 'Specified functional does not have total energy available.'
-          message(2) = 'Corresponding component of energy will just be left as zero.'
-          call messages_warning(2)
-       end if
+      ! FIXME: no need to say this for kernel
+      if(iand(functl%flags, XC_FLAGS_HAVE_EXC) == 0) then
+         message(1) = 'Specified functional does not have total energy available.'
+         message(2) = 'Corresponding component of energy will just be left as zero.'
+         call messages_warning(2)
+      end if
 
-       if(iand(functl%flags, XC_FLAGS_HAVE_VXC) == 0) then
-          message(1) = 'Specified functional does not have XC potential available.'
-          message(2) = 'Cannot run calculations. Choose another XCFunctional.'
-          call messages_fatal(2)
-       end if
-    end if
+      if(iand(functl%flags, XC_FLAGS_HAVE_VXC) == 0) then
+         message(1) = 'Specified functional does not have XC potential available.'
+         message(2) = 'Cannot run calculations. Choose another XCFunctional.'
+         call messages_fatal(2)
+      end if
+   end if
 
-    !    XC_NON_RELATIVISTIC     =   0
-    !    XC_RELATIVISTIC         =   1
+   !    XC_NON_RELATIVISTIC     =   0
+   !    XC_RELATIVISTIC         =   1
 
-    ! FIXME: aren`t there other parameters that can or should be set?
-    ! special parameters that have to be configured
-    select case(functl%id)
+   ! FIXME: aren`t there other parameters that can or should be set?
+   ! special parameters that have to be configured
+   select case(functl%id)
     case(XC_LDA_C_XALPHA)
-       ! FIXME: aren`t there other Xalpha functionals?
-       ! Variable Xalpha
-       ! The parameter of the Slater X<math>\alpha</math> functional
-       call parse_variable(1.0d0, alpha)
-       parameters(1) = alpha
+      ! FIXME: aren`t there other Xalpha functionals?
+      ! Variable Xalpha
+      ! The parameter of the Slater X<math>\alpha</math> functional
+      call parse_variable(1.0d0, alpha)
+      parameters(1) = alpha
 #if XC_MAJOR_VERSION>=6
-       call xc_f03_func_set_ext_params(functl%conf, parameters(1))
+      call xc_f03_func_set_ext_params(functl%conf, parameters(1))
 #elif XC_MAJOR_VERSION==5
-       call xc_f90_func_set_ext_params(functl%conf, parameters(1))
+      call xc_f90_func_set_ext_params(functl%conf, parameters(1))
 #endif
     case(XC_GGA_X_LB)
-       ! FIXME: libxc has XC_GGA_X_LBM, isn`t that the modified one?
-       ! Whether to use a modified form of the LB94 functional
-       call parse_variable(.false., lb94_modified)
-       if(lb94_modified) then
-          functl%LB94_modified = 1
-       else
-          functl%LB94_modified = 0
-       end if
-       ! FIXME: libxc seems to have 1e-32 as a threshold, should we not use that?
-       ! A threshold for the LB94 functional
-       call parse_variable(1.0d-6, functl%LB94_threshold)
-    end select
+      ! FIXME: libxc has XC_GGA_X_LBM, isn`t that the modified one?
+      ! Whether to use a modified form of the LB94 functional
+      call parse_variable(.false., lb94_modified)
+      if(lb94_modified) then
+         functl%LB94_modified = 1
+      else
+         functl%LB94_modified = 0
+      end if
+      ! FIXME: libxc seems to have 1e-32 as a threshold, should we not use that?
+      ! A threshold for the LB94 functional
+      call parse_variable(1.0d-6, functl%LB94_threshold)
+   end select
 
-  end subroutine xc_functl_init_functl
-
-
-  ! ---------------------------------------------------------
-  subroutine xc_functl_end(functl)
-    type(xc_functl_t), intent(inout) :: functl
+end subroutine xc_functl_init_functl
 
 
-    if(functl%family /= XC_FAMILY_NONE .and. functl%family /= XC_FAMILY_OEP)  then
+ ! ---------------------------------------------------------
+subroutine xc_functl_end(functl)
+   type(xc_functl_t), intent(inout) :: functl
+
+
+   if(functl%family /= XC_FAMILY_NONE .and. functl%family /= XC_FAMILY_OEP)  then
 #if XC_MAJOR_VERSION>=6
-       call xc_f03_func_end(functl%conf)
+      call xc_f03_func_end(functl%conf)
 #elif XC_MAJOR_VERSION==5
-       call xc_f90_func_end(functl%conf)
+      call xc_f90_func_end(functl%conf)
 #endif
-    end if
+   end if
 
-  end subroutine xc_functl_end
+end subroutine xc_functl_end
 
 
-  ! ---------------------------------------------------------
-  subroutine xc_functl_write_info(functl, iunit)
-    type(xc_functl_t), intent(in) :: functl
-    integer,           intent(in) :: iunit
+ ! ---------------------------------------------------------
+subroutine xc_functl_write_info(functl, iunit)
+   type(xc_functl_t), intent(in) :: functl
+   integer,           intent(in) :: iunit
 
-    character(len=1000) :: s1, s2
-    integer :: ii
+   character(len=1000) :: s1, s2
+   integer :: ii
 #if XC_MAJOR_VERSION>=6
-    type(xc_f03_func_reference_t) :: xc_ref
+   type(xc_f03_func_reference_t) :: xc_ref
 #elif XC_MAJOR_VERSION==5
-    type(xc_f90_func_reference_t) :: xc_ref
-#endif
-
-#if XC_MAJOR_VERSION>=6
-#elif XC_MAJOR_VERSION==5
+   type(xc_f90_func_reference_t) :: xc_ref
 #endif
 
-    if(functl%family /= XC_FAMILY_NONE) then ! all the other families
-       select case(functl%type)
+#if XC_MAJOR_VERSION>=6
+#elif XC_MAJOR_VERSION==5
+#endif
+
+   if(functl%family /= XC_FAMILY_NONE) then  ! all the other families
+      select case(functl%type)
        case(XC_EXCHANGE)
-          write(message(1), '(2x,a)') 'Exchange'
+         write(message(1), '(2x,a)') 'Exchange'
        case(XC_CORRELATION)
-          write(message(1), '(2x,a)') 'Correlation'
+         write(message(1), '(2x,a)') 'Correlation'
        case(XC_EXCHANGE_CORRELATION)
-          write(message(1), '(2x,a)') 'Exchange-correlation'
+         write(message(1), '(2x,a)') 'Exchange-correlation'
        case(XC_KINETIC)
-          call messages_not_implemented("kinetic-energy functionals")
+         call messages_not_implemented("kinetic-energy functionals")
        case default
-          write(message(1), '(a,i6,a,i6)') "Unknown functional type ", functl%type, ' for functional ', functl%id
-          call messages_fatal(1)
-       end select
+         write(message(1), '(a,i6,a,i6)') "Unknown functional type ", functl%type, ' for functional ', functl%id
+         call messages_fatal(1)
+      end select
 
 #if XC_MAJOR_VERSION>=6
-       s1 = xc_f03_func_info_get_name(functl%info)
+      s1 = xc_f03_func_info_get_name(functl%info)
 #elif XC_MAJOR_VERSION==5
-       s1 = xc_f90_func_info_get_name(functl%info)
+      s1 = xc_f90_func_info_get_name(functl%info)
 #endif
-       select case(functl%family)
+      select case(functl%family)
        case (XC_FAMILY_LDA);       write(s2,'(a)') "LDA"
        case (XC_FAMILY_GGA);       write(s2,'(a)') "GGA"
        case (XC_FAMILY_HYB_GGA);   write(s2,'(a)') "Hybrid GGA"
        case (XC_FAMILY_HYB_MGGA);  write(s2,'(a)') "Hybrid MGGA"
        case (XC_FAMILY_MGGA);      write(s2,'(a)') "MGGA"
-       end select
-       write(message(2), '(4x,4a)') trim(s1), ' (', trim(s2), ')'
-       call messages_info(2, iunit)
+      end select
+      write(message(2), '(4x,4a)') trim(s1), ' (', trim(s2), ')'
+      call messages_info(2, iunit)
 
-       ii = 0
+      ii = 0
 #if XC_MAJOR_VERSION>=6
-       xc_ref = xc_f03_func_info_get_references(functl%info, ii)
-       s1 = xc_f03_func_reference_get_ref(xc_ref)
-       do while(ii >= 0)
-          write(message(1), '(4x,a,i1,2a)') '[', ii, '] ', trim(s1)
-          call messages_info(1, iunit)
-          xc_ref = xc_f03_func_info_get_references(functl%info, ii)
-          s1 = xc_f03_func_reference_get_ref(xc_ref)
-       end do
+      xc_ref = xc_f03_func_info_get_references(functl%info, ii)
+      s1 = xc_f03_func_reference_get_ref(xc_ref)
+      do while(ii >= 0)
+         write(message(1), '(4x,a,i1,2a)') '[', ii, '] ', trim(s1)
+         call messages_info(1, iunit)
+         xc_ref = xc_f03_func_info_get_references(functl%info, ii)
+         s1 = xc_f03_func_reference_get_ref(xc_ref)
+      end do
 #elif XC_MAJOR_VERSION==5
-       xc_ref = xc_f90_func_info_get_references(functl%info, ii)
-       s1 = xc_f90_func_reference_get_ref(xc_ref)
-       do while(ii >= 0)
-          write(message(1), '(4x,a,i1,2a)') '[', ii, '] ', trim(s1)
-          call messages_info(1, iunit)
-          xc_ref = xc_f90_func_info_get_references(functl%info, ii)
-          s1 = xc_f90_func_reference_get_ref(xc_ref)
-       end do
+      xc_ref = xc_f90_func_info_get_references(functl%info, ii)
+      s1 = xc_f90_func_reference_get_ref(xc_ref)
+      do while(ii >= 0)
+         write(message(1), '(4x,a,i1,2a)') '[', ii, '] ', trim(s1)
+         call messages_info(1, iunit)
+         xc_ref = xc_f90_func_info_get_references(functl%info, ii)
+         s1 = xc_f90_func_reference_get_ref(xc_ref)
+      end do
 #endif
-    end if
-  end subroutine xc_functl_write_info
+   end if
+end subroutine xc_functl_write_info
 
-  subroutine xc_functl_get_vxc(functl, np, al, rr, rho, rho_grad, rho_lapl, tau, ip, v, e, vtau)
-    !-----------------------------------------------------------------------!
-    ! Given a density, computes the corresponding exchange/correlation      !
-    ! potentials and energies.                                              !
-    !                                                                       !
-    !  functl   - functional                                                !
-    !  np       - number of mesh points                                     !
-    !  al       - grid parameter                                            !
-    !  rr       - radial points                                             !
-    !  rho      - electronic radial density                                 !
-    !  rho_grad - gradient of the electronic radial density                 !
-    !  rho_lapl - laplacian of the electronic radial density                !
-    !  tau      - radial kinetic energy density                             !
-    !  ip       - ionization potential                                      !
-    !  v        - potential                                                 !
-    !  e        - energy per-volume                                         !
-    !  vtau     - extra term arising from MGGA potential                    !
-    !-----------------------------------------------------------------------!
-    type(xc_functl_t), intent(inout) :: functl
-    integer     ,       intent(in)    :: np
-    real(8),           intent(in)    :: al
-    real(8),           intent(in)    :: rr(np)
-    real(8),           intent(in)    :: rho(np, functl%nspin)
-    real(8),           intent(in)    :: rho_grad(np, functl%nspin)
-    real(8),           intent(in)    :: rho_lapl(np, functl%nspin)
-    real(8),           intent(in)    :: tau(np, functl%nspin)
-    real(8),           intent(in)    :: ip(functl%nspin)
-    real(8),           intent(out)   :: v(np, functl%nspin), e(np)
-    real(8),           intent(out)   :: vtau(np, functl%nspin)
+subroutine xc_functl_get_vxc(functl, np, al, rr, rho, rho_grad, rho_lapl, tau, ip, v, e, vtau)
+   !-----------------------------------------------------------------------!
+   ! Given a density, computes the corresponding exchange/correlation      !
+   ! potentials and energies.                                              !
+   !                                                                       !
+   !  functl   - functional                                                !
+   !  np       - number of mesh points                                     !
+   !  al       - grid parameter                                            !
+   !  rr       - radial points                                             !
+   !  rho      - electronic radial density                                 !
+   !  rho_grad - gradient of the electronic radial density                 !
+   !  rho_lapl - laplacian of the electronic radial density                !
+   !  tau      - radial kinetic energy density                             !
+   !  ip       - ionization potential                                      !
+   !  v        - potential                                                 !
+   !  e        - energy per-volume                                         !
+   !  vtau     - extra term arising from MGGA potential                    !
+   !-----------------------------------------------------------------------!
+   type(xc_functl_t), intent(inout) :: functl
+   integer     ,       intent(in)    :: np
+   real(8),           intent(in)    :: al
+   real(8),           intent(in)    :: rr(np)
+   real(8),           intent(in)    :: rho(np, functl%nspin)
+   real(8),           intent(in)    :: rho_grad(np, functl%nspin)
+   real(8),           intent(in)    :: rho_lapl(np, functl%nspin)
+   real(8),           intent(in)    :: tau(np, functl%nspin)
+   real(8),           intent(in)    :: ip(functl%nspin)
+   real(8),           intent(out)   :: v(np, functl%nspin), e(np)
+   real(8),           intent(out)   :: vtau(np, functl%nspin)
 
-    integer  :: i, is, nspin
-    real(8) :: a, b, c
-    real(8), parameter   :: alpha = -0.012d0, beta = 1.023d0
+   integer  :: i, is, nspin
+   real(8) :: a, b, c
+   real(8), parameter   :: alpha = -0.012d0, beta = 1.023d0
 
-    ! Global variables
-    real(8), allocatable :: dedrho(:,:), dedgrad(:,:), dedlapl(:,:), dedtau(:,:)
-    real(8), allocatable :: d2edrhodgrad(:,:), d2edgrad2(:,:)
+   ! Global variables
+   real(8), allocatable :: dedrho(:,:), dedgrad(:,:), dedlapl(:,:), dedtau(:,:)
+   real(8), allocatable :: d2edrhodgrad(:,:), d2edgrad2(:,:)
 
-    ! Local variables
-    real(8), allocatable :: n(:), s(:), l(:), t(:)
-    real(8), allocatable :: dedn(:), deds(:), dedl(:), dedt(:)
-    real(8), allocatable :: d2edn2(:), d2eds2(:), d2ednds(:)
+   ! Local variables
+   real(8), allocatable :: n(:), s(:), l(:), t(:)
+   real(8), allocatable :: dedn(:), deds(:), dedl(:), dedt(:)
+   real(8), allocatable :: d2edn2(:), d2eds2(:), d2ednds(:)
 
-    real(8), allocatable :: dpr(:), dppr(:), dlap(:)
-    real(8)   :: parameters(2)
-
-
-    if (.not. (size(v, dim=2) == functl%nspin)) stop 'functionals: ERROR bad nspin definition'
-
-    ! Initialize all output quantities to zero
-    v =0.0d0 ; e =0.0d0 ; vtau =0.0d0
-
-    ! If the functional is not set, there is nothing to be done
-    if (functl%family == 0) then
-       return
-    end if
-
-    ! Shortcut
-    nspin = functl%nspin
+   real(8), allocatable :: dpr(:), dppr(:), dlap(:)
+   real(8)   :: parameters(2)
 
 
-    ! Compute c parameter of the TB09 functional
-    if (functl%id == XC_MGGA_X_TB09) then
-       if (maxval(ip) ==0.0d0) then
-          c = 1.0d0
-       else
-          a =0.0d0
-          do
-             c = alpha + beta*sqrt(2.0d0*sqrt(2.0d0*(maxval(ip) + a)))
-             b = (3.0d0*c - 2.0d0)/pi*sqrt(5.0d0/6.0d0*(maxval(ip) + a))
-             if (abs(a - b) < 1.0e-8) exit
-             a = b
-          end do
-       end if
-       parameters(1) = c
-#if XC_MAJOR_VERSION>=6
-       call xc_f03_func_set_ext_params(functl%conf, parameters(1))
-#elif XC_MAJOR_VERSION==5
-       call xc_f90_func_set_ext_params(functl%conf, parameters(1))
-#endif
-    end if
+   if (.not. (size(v, dim=2) == functl%nspin)) stop 'functionals: ERROR bad nspin definition'
+
+   ! Initialize all output quantities to zero
+   v =0.0d0 ; e =0.0d0 ; vtau =0.0d0
+
+   ! If the functional is not set, there is nothing to be done
+   if (functl%family == 0) then
+      return
+   end if
+
+   ! Shortcut
+   nspin = functl%nspin
 
 
-    !---Allocate work arrays---!
-
-    ! LDA
-    allocate(n(nspin), dedn(nspin))
-    allocate(dedrho(np, nspin))
-    n =0.0d0; dedn =0.0d0
-    dedrho =0.0d0
-
-    if (functl%deriv_method == XC_DERIV_ANALYTICAL) then
-       if (nspin == 1) then
-          allocate(d2edn2(1))
-       else
-          allocate(d2edn2(3))
-       end if
-       d2edn2 =0.0d0
-    end if
-
-    ! GGA
-    if (functl%family == XC_FAMILY_GGA .or. functl%family == XC_FAMILY_MGGA) then
-       if (nspin == 1) then
-          allocate(s(1), deds(1))
-       else
-          allocate(s(3), deds(3))
-       end if
-       allocate(dedgrad(np, nspin))
-       s =0.0d0; deds =0.0d0
-       dedgrad =0.0d0
-
-       if (functl%deriv_method == XC_DERIV_ANALYTICAL) then
-          if (nspin == 1) then
-             allocate(d2eds2(1), d2ednds(1))
-             allocate(d2edgrad2(np, 1))
-             allocate(d2edrhodgrad(np, 1))
-          else
-             allocate(d2eds2(6), d2ednds(6))
-             allocate(d2edgrad2(np, 3))
-             allocate(d2edrhodgrad(np, 4))
-          end if
-          d2eds2 =0.0d0; d2ednds =0.0d0
-          d2edgrad2 =0.0d0; d2edrhodgrad =0.0d0
-       end if
-
-    end if
-
-    ! MGGA
-    if (functl%family == XC_FAMILY_MGGA) then
-       allocate(l(nspin), dedl(nspin))
-       allocate(t(nspin), dedt(nspin))
-       allocate(dedlapl(np, nspin))
-       allocate(dedtau(np, nspin))
-       l =0.0d0; dedl =0.0d0
-       t =0.0d0; dedt =0.0d0
-       dedlapl =0.0d0
-       dedtau =0.0d0
-
-       if (functl%deriv_method == XC_DERIV_ANALYTICAL) then
-          !Not yet implemented
-       end if
-
-    end if
-
-
-    !---Space loop---!
-
-    do i = 1, np
-       ! make a local copy with the correct memory order
-       n(1:nspin) = rho(i, 1:nspin)
-       if (functl%family == XC_FAMILY_GGA .or. functl%family == XC_FAMILY_MGGA) then
-          s(1) = rho_grad(i, 1)**2
-          if(nspin == 2) then
-             s(2) = rho_grad(i, 1)*rho_grad(i, 2)
-             s(3) = rho_grad(i, 2)**2
-          end if
-       end if
-       if (functl%family == XC_FAMILY_MGGA) then
-          t(1:nspin) = tau(i, 1:nspin)/2.0d0
-          l(1:nspin) = rho_lapl(i, 1:nspin)
-       end if
-
-#if XC_MAJOR_VERSION>=6
-       if (iand(xc_f03_func_info_get_flags(functl%info), XC_FLAGS_HAVE_EXC) .ne. 0) then
-
-          select case(functl%family)
-          case(XC_FAMILY_LDA)
-             call xc_f03_lda_exc_vxc(functl%conf, xc_one, n(1), e(i), dedn(1))
-          case(XC_FAMILY_GGA)
-             call xc_f03_gga_exc_vxc(functl%conf, xc_one, n(1), s(1), e(i), dedn(1), deds(1))
-          case(XC_FAMILY_MGGA)
-             call xc_f03_mgga_exc_vxc(functl%conf, xc_one, n(1), s(1), l(1), t(1), e(i), &
-                  dedn(1), deds(1), dedl(1), dedt(1))
-          end select
-
-       else !Just get the potential
-
-          select case(functl%family)
-          case(XC_FAMILY_LDA)
-             call xc_f03_lda_vxc(functl%conf, xc_one, n(1), dedn(1))
-          case(XC_FAMILY_GGA)
-             call xc_f03_gga_vxc(functl%conf, xc_one, n(1), s(1), dedn(1), deds(1))
-          case(XC_FAMILY_MGGA)
-             call xc_f03_mgga_vxc(functl%conf, xc_one, n(1), s(1), l(1), t(1), &
-                  dedn(1), deds(1), dedl(1), dedt(1))
-          end select
-          e(i) =0.0d0
-
-       end if
-#elif XC_MAJOR_VERSION==5
-       if (iand(xc_f90_func_info_get_flags(functl%info), XC_FLAGS_HAVE_EXC) .ne. 0) then
-
-          select case(functl%family)
-          case(XC_FAMILY_LDA)
-             call xc_f90_lda_exc_vxc(functl%conf, xc_one, n(1), e(i), dedn(1))
-          case(XC_FAMILY_GGA)
-             call xc_f90_gga_exc_vxc(functl%conf, xc_one, n(1), s(1), e(i), dedn(1), deds(1))
-          case(XC_FAMILY_MGGA)
-             call xc_f90_mgga_exc_vxc(functl%conf, xc_one, n(1), s(1), l(1), t(1), e(i), &
-                  dedn(1), deds(1), dedl(1), dedt(1))
-          end select
-
-       else !Just get the potential
-
-          select case(functl%family)
-          case(XC_FAMILY_LDA)
-             call xc_f90_lda_vxc(functl%conf, xc_one, n(1), dedn(1))
-          case(XC_FAMILY_GGA)
-             call xc_f90_gga_vxc(functl%conf, xc_one, n(1), s(1), dedn(1), deds(1))
-          case(XC_FAMILY_MGGA)
-             call xc_f90_mgga_vxc(functl%conf, xc_one, n(1), s(1), l(1), t(1), &
-                  dedn(1), deds(1), dedl(1), dedt(1))
-          end select
-          e(i) =0.0d0
-
-       end if
-#endif
-
-       e(i) = e(i)*sum(n)
-       dedrho(i, :) = dedn(:)
-       if (functl%family == XC_FAMILY_GGA .or. functl%family == XC_FAMILY_MGGA) then
-          if (nspin == 1) then
-             dedgrad(i, 1) = 2.0d0*deds(1)*rho_grad(i, 1)
-          else
-             dedgrad(i, 1) = 2.0d0*deds(1)*rho_grad(i, 1) + deds(2)*rho_grad(i, 2)
-             dedgrad(i, 2) = 2.0d0*deds(3)*rho_grad(i, 2) + deds(2)*rho_grad(i, 1)
-          end if
-       end if
-
-       if(functl%family == XC_FAMILY_MGGA) then
-          dedlapl(i, 1:nspin) = dedl(1:nspin)
-          dedtau(i, 1:nspin) = dedt(1:nspin)/2.0d0
-       end if
-
-       if (functl%deriv_method == XC_DERIV_ANALYTICAL) then
-          !Evaluate second-order derivatives
-          if (functl%family == XC_FAMILY_GGA .or. functl%family == XC_FAMILY_MGGA) then
-#if XC_MAJOR_VERSION>=6
-             call xc_f03_gga_fxc(functl%conf, xc_one, n(1), s(1), d2edn2(1), d2ednds(1), d2eds2(1))
-#elif XC_MAJOR_VERSION==5
-             call xc_f90_gga_fxc(functl%conf, xc_one, n(1), s(1), d2edn2(1), d2ednds(1), d2eds2(1))
-#endif
-
-             if (nspin == 1) then
-                d2edrhodgrad(i, 1) = 2.0d0*rho_grad(i, 1)*d2ednds(1)
-                d2edgrad2(i, 1) = 2.0d0*deds(1) + 4.0d0*s(1)*d2eds2(1)
-             else
-                d2edrhodgrad(i, 1) = 2.0d0*rho_grad(i, 1)*d2ednds(1) + rho_grad(i, 2)*d2ednds(2)
-                d2edrhodgrad(i, 2) = 2.0d0*rho_grad(i, 1)*d2ednds(4) + rho_grad(i, 2)*d2ednds(5)
-                d2edrhodgrad(i, 3) = 2.0d0*rho_grad(i, 2)*d2ednds(3) + rho_grad(i, 1)*d2ednds(2)
-                d2edrhodgrad(i, 4) = 2.0d0*rho_grad(i, 2)*d2ednds(6) + rho_grad(i, 1)*d2ednds(5)
-
-                d2edgrad2(i, 1) = 2.0d0*deds(1) + 4.0d0*s(1)*d2eds2(1) + 4.0d0*s(2)*d2eds2(2) + s(3)*d2eds2(4)
-                d2edgrad2(i, 2) = deds(2) + 4.0d0*s(2)*d2eds2(3) + 2.0d0*s(1)*d2eds2(2) + 2.0d0*s(3)*d2eds2(5) + s(2)*d2eds2(4)
-                d2edgrad2(i, 3) = 2.0d0*deds(3) + 4.0d0*s(3)*d2eds2(6) + 4.0d0*s(2)*d2eds2(5) + s(1)*d2eds2(4)
-             end if
-
-          else if (functl%family == XC_FAMILY_MGGA) then
-             !Not yet implemented
-          end if
-       end if
-
-    end do ! loop over points i
-
-
-    !---Compute potentials---!
-
-    ! LDA contribution
-    v = dedrho
-
-    ! GGA contribution
-    if (functl%family == XC_FAMILY_GGA .or. functl%family == XC_FAMILY_MGGA) then
-       if (functl%deriv_method == XC_DERIV_NUMERICAL) then
-          allocate (dpr(np))
-          allocate (dppr(np))
-          allocate (dlap(np))
-          do is = 1, nspin
-             call derivs(np, dedgrad(:,is), al, rr, dpr, dppr, dlap)
-             !          v(:, is) = v(:, is) - mesh_divergence(m, dedgrad(:, is))
-             v(:, is) = v(:, is) - (2.0d0/rr(:)*dedgrad(:,is) + dpr(:))
-          end do
-          deallocate (dpr, dppr, dlap)
-       elseif (functl%deriv_method == XC_DERIV_ANALYTICAL) then
-          stop 'functionals: ERROR - no analytical derivatives coded'
-       end if
-    end if
-
-    ! MGGA contribution
-    if (functl%family == XC_FAMILY_MGGA) then
-       stop 'functrionals: ERROOR : meta GGA not coded yet '
-       if (functl%deriv_method == XC_DERIV_NUMERICAL) then
-          allocate (dpr(np))
-          allocate (dppr(np))
-          allocate (dlap(np))
-          do is = 1, nspin
-             call derivs(np, dedlapl(:,is), al, rr, dpr, dppr, dlap)
-             !          v(:, is) = v(:, is) + mesh_laplacian(m, dedlapl(:, is))
-             v(:, is) = v(:, is) + dlap(:)
-          end do
-          deallocate (dpr, dppr, dlap)
-       elseif (functl%deriv_method == XC_DERIV_ANALYTICAL) then
-          !Not yet implemented
-       end if
-
-       vtau = dedtau
-    end if
-
-    !Shift potentials that do not go to zero at infinity
-    do is = 1, nspin
-       select case (functl%id)
-       case (XC_MGGA_X_BJ06)
-          a = sqrt(5.0d0/6.0d0)/pi
-       case (XC_MGGA_X_TB09)
-          a = (3.0d0*c - 2.0d0)*sqrt(5.0d0/6.0d0)/pi
-       case (XC_GGA_X_AK13)
-          a = sqrt(2.0d0)*(1.0d0/(54.0d0*pi) + 2.0d0/15.0d0)
-       case default
-          a =0.0d0
-       end select
-       do i = np, 1, -1
-          if (v(i, is) /=0.0d0) then
-             v(1:i, is) = v(1:i, is) - a*sqrt(ip(is))
-             exit
-          end if
-       end do
-    end do
-
-    !---Deallocate arrays---!
-
-    ! LDA
-    deallocate(n, dedn, dedrho)
-    if (functl%deriv_method == XC_DERIV_ANALYTICAL) then
-       deallocate(d2edn2)
-    end if
-
-    ! GGA
-    if (functl%family == XC_FAMILY_GGA .or. functl%family == XC_FAMILY_MGGA) then
-       deallocate(s, deds, dedgrad)
-       if (functl%deriv_method == XC_DERIV_ANALYTICAL) then
-          deallocate(d2eds2, d2ednds, d2edgrad2, d2edrhodgrad)
-       end if
-    end if
-
-    ! MGGA
-    if (functl%family == XC_FAMILY_MGGA) then
-       deallocate(l, dedl, dedlapl)
-       deallocate(t, dedt, dedtau)
-       if (functl%deriv_method == XC_DERIV_ANALYTICAL) then
-          message(1) = 'Not implemented analytical derivatives'
-          call messages_fatal(1)
-       end if
-    end if
-
-  end subroutine xc_functl_get_vxc
-
-  ! Not used for the moment
-  subroutine functional_get_tau(functl, np, rho, rho_grad, rho_lapl, tau)
-    !-----------------------------------------------------------------------!
-    ! Computes the approximated kinetic energy density.                     !
-    !                                                                       !
-    !  functl   - functional                                                !
-    !  m        - mesh                                                      !
-    !  rho      - electronic radial density                                 !
-    !  rho_grad - gradient of the electronic radial density                 !
-    !  rho_lapl - laplacian of the electronic radial density                !
-    !  tau      - radial kinetic energy density                             !
-    !-----------------------------------------------------------------------!
-    type(xc_functl_t), intent(in)  :: functl
-    integer     ,       intent(in)  :: np
-    real(8),           intent(in)  :: rho(np, functl%nspin)
-    real(8),           intent(in)  :: rho_grad(np, functl%nspin)
-    real(8),           intent(in)  :: rho_lapl(np, functl%nspin)
-    real(8),           intent(out) :: tau(np, functl%nspin)
-
-    integer  :: i, is, nspin
-    real(8), allocatable :: n(:), s(:), l(:), t(:)
-
-    nspin = functl%nspin
-
-    !Allocate work arrays
-    allocate(n(nspin), t(nspin))
-    n =0.0d0; t =0.0d0
-    if (functl%family == XC_FAMILY_GGA .or. functl%family == XC_FAMILY_MGGA) then
-      if (nspin == 1) then
-        allocate(s(1))
+   ! Compute c parameter of the TB09 functional
+   if (functl%id == XC_MGGA_X_TB09) then
+      if (maxval(ip) ==0.0d0) then
+         c = 1.0d0
       else
-        allocate(s(3))
+         a =0.0d0
+         do
+            c = alpha + beta*sqrt(2.0d0*sqrt(2.0d0*(maxval(ip) + a)))
+            b = (3.0d0*c - 2.0d0)/pi*sqrt(5.0d0/6.0d0*(maxval(ip) + a))
+            if (abs(a - b) < 1.0e-8) exit
+            a = b
+         end do
       end if
-      s =0.0d0
-    end if
-    if (functl%family == XC_FAMILY_MGGA) then
-      allocate(l(nspin))
-      l =0.0d0
-    end if
+      parameters(1) = c
+#if XC_MAJOR_VERSION>=6
+      call xc_f03_func_set_ext_params(functl%conf, parameters(1))
+#elif XC_MAJOR_VERSION==5
+      call xc_f90_func_set_ext_params(functl%conf, parameters(1))
+#endif
+   end if
 
-    !Spin loop
-    do is = 1, nspin
-      !Space loop
-      do i = 1, np
-        ! make a local copy with the correct memory order
-        n(is) = rho(i, is)
 
-        if (functl%family == XC_FAMILY_GGA .or. functl%family == XC_FAMILY_MGGA) then
-          s(1) = rho_grad(i, 1)**2
-          if(nspin == 2) then
+   !---Allocate work arrays---!
+
+   ! LDA
+   allocate(n(nspin), dedn(nspin))
+   allocate(dedrho(np, nspin))
+   n =0.0d0; dedn =0.0d0
+   dedrho =0.0d0
+
+   if (functl%deriv_method == XC_DERIV_ANALYTICAL) then
+      if (nspin == 1) then
+         allocate(d2edn2(1))
+      else
+         allocate(d2edn2(3))
+      end if
+      d2edn2 =0.0d0
+   end if
+
+   ! GGA
+   if (functl%family == XC_FAMILY_GGA .or. functl%family == XC_FAMILY_MGGA) then
+      if (nspin == 1) then
+         allocate(s(1), deds(1))
+      else
+         allocate(s(3), deds(3))
+      end if
+      allocate(dedgrad(np, nspin))
+      s =0.0d0; deds =0.0d0
+      dedgrad =0.0d0
+
+      if (functl%deriv_method == XC_DERIV_ANALYTICAL) then
+         if (nspin == 1) then
+            allocate(d2eds2(1), d2ednds(1))
+            allocate(d2edgrad2(np, 1))
+            allocate(d2edrhodgrad(np, 1))
+         else
+            allocate(d2eds2(6), d2ednds(6))
+            allocate(d2edgrad2(np, 3))
+            allocate(d2edrhodgrad(np, 4))
+         end if
+         d2eds2 =0.0d0; d2ednds =0.0d0
+         d2edgrad2 =0.0d0; d2edrhodgrad =0.0d0
+      end if
+
+   end if
+
+   ! MGGA
+   if (functl%family == XC_FAMILY_MGGA) then
+      allocate(l(nspin), dedl(nspin))
+      allocate(t(nspin), dedt(nspin))
+      allocate(dedlapl(np, nspin))
+      allocate(dedtau(np, nspin))
+      l =0.0d0; dedl =0.0d0
+      t =0.0d0; dedt =0.0d0
+      dedlapl =0.0d0
+      dedtau =0.0d0
+
+      if (functl%deriv_method == XC_DERIV_ANALYTICAL) then
+         !Not yet implemented
+      end if
+
+   end if
+
+
+   !---Space loop---!
+
+   do i = 1, np
+      ! make a local copy with the correct memory order
+      n(1:nspin) = rho(i, 1:nspin)
+      if (functl%family == XC_FAMILY_GGA .or. functl%family == XC_FAMILY_MGGA) then
+         s(1) = rho_grad(i, 1)**2
+         if(nspin == 2) then
             s(2) = rho_grad(i, 1)*rho_grad(i, 2)
             s(3) = rho_grad(i, 2)**2
-          end if
-        end if
-        if (functl%family == XC_FAMILY_MGGA) then
-          l(is) = rho_lapl(i, is)
-        end if
+         end if
+      end if
+      if (functl%family == XC_FAMILY_MGGA) then
+         t(1:nspin) = tau(i, 1:nspin)/2.0d0
+         l(1:nspin) = rho_lapl(i, 1:nspin)
+      end if
 
 #if XC_MAJOR_VERSION>=6
-        select case(functl%family)
-        case(XC_FAMILY_LDA)
-          call xc_f03_lda_exc(functl%conf, xc_one, n(1), t(1))
-        case(XC_FAMILY_GGA)
-          call xc_f03_gga_exc(functl%conf, xc_one, n(1), s(1), t(1))
-        end select
+      if (iand(xc_f03_func_info_get_flags(functl%info), XC_FLAGS_HAVE_EXC) /= 0) then
+
+         select case(functl%family)
+          case(XC_FAMILY_LDA)
+            call xc_f03_lda_exc_vxc(functl%conf, xc_one, n(1), e(i), dedn(1))
+          case(XC_FAMILY_GGA)
+            call xc_f03_gga_exc_vxc(functl%conf, xc_one, n(1), s(1), e(i), dedn(1), deds(1))
+          case(XC_FAMILY_MGGA)
+            call xc_f03_mgga_exc_vxc(functl%conf, xc_one, n(1), s(1), l(1), t(1), e(i), &
+                                     dedn(1), deds(1), dedl(1), dedt(1))
+         end select
+
+      else  !Just get the potential
+
+         select case(functl%family)
+          case(XC_FAMILY_LDA)
+            call xc_f03_lda_vxc(functl%conf, xc_one, n(1), dedn(1))
+          case(XC_FAMILY_GGA)
+            call xc_f03_gga_vxc(functl%conf, xc_one, n(1), s(1), dedn(1), deds(1))
+          case(XC_FAMILY_MGGA)
+            call xc_f03_mgga_vxc(functl%conf, xc_one, n(1), s(1), l(1), t(1), &
+                                 dedn(1), deds(1), dedl(1), dedt(1))
+         end select
+         e(i) =0.0d0
+
+      end if
 #elif XC_MAJOR_VERSION==5
-        select case(functl%family)
-        case(XC_FAMILY_LDA)
-          call xc_f90_lda_exc(functl%conf, xc_one, n(1), t(1))
-        case(XC_FAMILY_GGA)
-          call xc_f90_gga_exc(functl%conf, xc_one, n(1), s(1), t(1))
-        end select
+      if (iand(xc_f90_func_info_get_flags(functl%info), XC_FLAGS_HAVE_EXC) /= 0) then
+
+         select case(functl%family)
+          case(XC_FAMILY_LDA)
+            call xc_f90_lda_exc_vxc(functl%conf, xc_one, n(1), e(i), dedn(1))
+          case(XC_FAMILY_GGA)
+            call xc_f90_gga_exc_vxc(functl%conf, xc_one, n(1), s(1), e(i), dedn(1), deds(1))
+          case(XC_FAMILY_MGGA)
+            call xc_f90_mgga_exc_vxc(functl%conf, xc_one, n(1), s(1), l(1), t(1), e(i), &
+                                     dedn(1), deds(1), dedl(1), dedt(1))
+         end select
+
+      else  !Just get the potential
+
+         select case(functl%family)
+          case(XC_FAMILY_LDA)
+            call xc_f90_lda_vxc(functl%conf, xc_one, n(1), dedn(1))
+          case(XC_FAMILY_GGA)
+            call xc_f90_gga_vxc(functl%conf, xc_one, n(1), s(1), dedn(1), deds(1))
+          case(XC_FAMILY_MGGA)
+            call xc_f90_mgga_vxc(functl%conf, xc_one, n(1), s(1), l(1), t(1), &
+                                 dedn(1), deds(1), dedl(1), dedt(1))
+         end select
+         e(i) =0.0d0
+
+      end if
 #endif
 
-        tau(i, is) = 2.0d0*t(1)*n(is)
+      e(i) = e(i)*sum(n)
+      dedrho(i, :) = dedn(:)
+      if (functl%family == XC_FAMILY_GGA .or. functl%family == XC_FAMILY_MGGA) then
+         if (nspin == 1) then
+            dedgrad(i, 1) = 2.0d0*deds(1)*rho_grad(i, 1)
+         else
+            dedgrad(i, 1) = 2.0d0*deds(1)*rho_grad(i, 1) + deds(2)*rho_grad(i, 2)
+            dedgrad(i, 2) = 2.0d0*deds(3)*rho_grad(i, 2) + deds(2)*rho_grad(i, 1)
+         end if
+      end if
+
+      if(functl%family == XC_FAMILY_MGGA) then
+         dedlapl(i, 1:nspin) = dedl(1:nspin)
+         dedtau(i, 1:nspin) = dedt(1:nspin)/2.0d0
+      end if
+
+      if (functl%deriv_method == XC_DERIV_ANALYTICAL) then
+         !Evaluate second-order derivatives
+         if (functl%family == XC_FAMILY_GGA .or. functl%family == XC_FAMILY_MGGA) then
+#if XC_MAJOR_VERSION>=6
+            call xc_f03_gga_fxc(functl%conf, xc_one, n(1), s(1), d2edn2(1), d2ednds(1), d2eds2(1))
+#elif XC_MAJOR_VERSION==5
+            call xc_f90_gga_fxc(functl%conf, xc_one, n(1), s(1), d2edn2(1), d2ednds(1), d2eds2(1))
+#endif
+
+            if (nspin == 1) then
+               d2edrhodgrad(i, 1) = 2.0d0*rho_grad(i, 1)*d2ednds(1)
+               d2edgrad2(i, 1) = 2.0d0*deds(1) + 4.0d0*s(1)*d2eds2(1)
+            else
+               d2edrhodgrad(i, 1) = 2.0d0*rho_grad(i, 1)*d2ednds(1) + rho_grad(i, 2)*d2ednds(2)
+               d2edrhodgrad(i, 2) = 2.0d0*rho_grad(i, 1)*d2ednds(4) + rho_grad(i, 2)*d2ednds(5)
+               d2edrhodgrad(i, 3) = 2.0d0*rho_grad(i, 2)*d2ednds(3) + rho_grad(i, 1)*d2ednds(2)
+               d2edrhodgrad(i, 4) = 2.0d0*rho_grad(i, 2)*d2ednds(6) + rho_grad(i, 1)*d2ednds(5)
+
+               d2edgrad2(i, 1) = 2.0d0*deds(1) + 4.0d0*s(1)*d2eds2(1) + 4.0d0*s(2)*d2eds2(2) + s(3)*d2eds2(4)
+               d2edgrad2(i, 2) = deds(2) + 4.0d0*s(2)*d2eds2(3) + 2.0d0*s(1)*d2eds2(2) + 2.0d0*s(3)*d2eds2(5) + s(2)*d2eds2(4)
+               d2edgrad2(i, 3) = 2.0d0*deds(3) + 4.0d0*s(3)*d2eds2(6) + 4.0d0*s(2)*d2eds2(5) + s(1)*d2eds2(4)
+            end if
+
+         else if (functl%family == XC_FAMILY_MGGA) then
+            !Not yet implemented
+         end if
+      end if
+
+   end do  ! loop over points i
+
+
+   !---Compute potentials---!
+
+   ! LDA contribution
+   v = dedrho
+
+   ! GGA contribution
+   if (functl%family == XC_FAMILY_GGA .or. functl%family == XC_FAMILY_MGGA) then
+      if (functl%deriv_method == XC_DERIV_NUMERICAL) then
+         allocate (dpr(np))
+         allocate (dppr(np))
+         allocate (dlap(np))
+         do is = 1, nspin
+            call derivs(np, dedgrad(:,is), al, rr, dpr, dppr, dlap)
+            !          v(:, is) = v(:, is) - mesh_divergence(m, dedgrad(:, is))
+            v(:, is) = v(:, is) - (2.0d0/rr(:)*dedgrad(:,is) + dpr(:))
+         end do
+         deallocate (dpr, dppr, dlap)
+      elseif (functl%deriv_method == XC_DERIV_ANALYTICAL) then
+         stop 'functionals: ERROR - no analytical derivatives coded'
+      end if
+   end if
+
+   ! MGGA contribution
+   if (functl%family == XC_FAMILY_MGGA) then
+      stop 'functrionals: ERROOR : meta GGA not coded yet '
+      if (functl%deriv_method == XC_DERIV_NUMERICAL) then
+         allocate (dpr(np))
+         allocate (dppr(np))
+         allocate (dlap(np))
+         do is = 1, nspin
+            call derivs(np, dedlapl(:,is), al, rr, dpr, dppr, dlap)
+            !          v(:, is) = v(:, is) + mesh_laplacian(m, dedlapl(:, is))
+            v(:, is) = v(:, is) + dlap(:)
+         end do
+         deallocate (dpr, dppr, dlap)
+      elseif (functl%deriv_method == XC_DERIV_ANALYTICAL) then
+         !Not yet implemented
+      end if
+
+      vtau = dedtau
+   end if
+
+   !Shift potentials that do not go to zero at infinity
+   do is = 1, nspin
+      select case (functl%id)
+       case (XC_MGGA_X_BJ06)
+         a = sqrt(5.0d0/6.0d0)/pi
+       case (XC_MGGA_X_TB09)
+         a = (3.0d0*c - 2.0d0)*sqrt(5.0d0/6.0d0)/pi
+       case (XC_GGA_X_AK13)
+         a = sqrt(2.0d0)*(1.0d0/(54.0d0*pi) + 2.0d0/15.0d0)
+       case default
+         a =0.0d0
+      end select
+      do i = np, 1, -1
+         if (v(i, is) /=0.0d0) then
+            v(1:i, is) = v(1:i, is) - a*sqrt(ip(is))
+            exit
+         end if
       end do
-    end do
+   end do
 
-    !Deallocate arrays
-    deallocate(n, t)
-    if (functl%family == XC_FAMILY_GGA .or. functl%family == XC_FAMILY_MGGA) deallocate(s)
-    if (functl%family == XC_FAMILY_MGGA) deallocate(l)
+   !---Deallocate arrays---!
 
-  end subroutine functional_get_tau
+   ! LDA
+   deallocate(n, dedn, dedrho)
+   if (functl%deriv_method == XC_DERIV_ANALYTICAL) then
+      deallocate(d2edn2)
+   end if
+
+   ! GGA
+   if (functl%family == XC_FAMILY_GGA .or. functl%family == XC_FAMILY_MGGA) then
+      deallocate(s, deds, dedgrad)
+      if (functl%deriv_method == XC_DERIV_ANALYTICAL) then
+         deallocate(d2eds2, d2ednds, d2edgrad2, d2edrhodgrad)
+      end if
+   end if
+
+   ! MGGA
+   if (functl%family == XC_FAMILY_MGGA) then
+      deallocate(l, dedl, dedlapl)
+      deallocate(t, dedt, dedtau)
+      if (functl%deriv_method == XC_DERIV_ANALYTICAL) then
+         message(1) = 'Not implemented analytical derivatives'
+         call messages_fatal(1)
+      end if
+   end if
+
+end subroutine xc_functl_get_vxc
+
+ ! Not used for the moment
+subroutine functional_get_tau(functl, np, rho, rho_grad, rho_lapl, tau)
+   !-----------------------------------------------------------------------!
+   ! Computes the approximated kinetic energy density.                     !
+   !                                                                       !
+   !  functl   - functional                                                !
+   !  m        - mesh                                                      !
+   !  rho      - electronic radial density                                 !
+   !  rho_grad - gradient of the electronic radial density                 !
+   !  rho_lapl - laplacian of the electronic radial density                !
+   !  tau      - radial kinetic energy density                             !
+   !-----------------------------------------------------------------------!
+   type(xc_functl_t), intent(in)  :: functl
+   integer     ,       intent(in)  :: np
+   real(8),           intent(in)  :: rho(np, functl%nspin)
+   real(8),           intent(in)  :: rho_grad(np, functl%nspin)
+   real(8),           intent(in)  :: rho_lapl(np, functl%nspin)
+   real(8),           intent(out) :: tau(np, functl%nspin)
+
+   integer  :: i, is, nspin
+   real(8), allocatable :: n(:), s(:), l(:), t(:)
+
+   nspin = functl%nspin
+
+   !Allocate work arrays
+   allocate(n(nspin), t(nspin))
+   n =0.0d0; t =0.0d0
+   if (functl%family == XC_FAMILY_GGA .or. functl%family == XC_FAMILY_MGGA) then
+      if (nspin == 1) then
+         allocate(s(1))
+      else
+         allocate(s(3))
+      end if
+      s =0.0d0
+   end if
+   if (functl%family == XC_FAMILY_MGGA) then
+      allocate(l(nspin))
+      l =0.0d0
+   end if
+
+   !Spin loop
+   do is = 1, nspin
+      !Space loop
+      do i = 1, np
+         ! make a local copy with the correct memory order
+         n(is) = rho(i, is)
+
+         if (functl%family == XC_FAMILY_GGA .or. functl%family == XC_FAMILY_MGGA) then
+            s(1) = rho_grad(i, 1)**2
+            if(nspin == 2) then
+               s(2) = rho_grad(i, 1)*rho_grad(i, 2)
+               s(3) = rho_grad(i, 2)**2
+            end if
+         end if
+         if (functl%family == XC_FAMILY_MGGA) then
+            l(is) = rho_lapl(i, is)
+         end if
+
+#if XC_MAJOR_VERSION>=6
+         select case(functl%family)
+          case(XC_FAMILY_LDA)
+            call xc_f03_lda_exc(functl%conf, xc_one, n(1), t(1))
+          case(XC_FAMILY_GGA)
+            call xc_f03_gga_exc(functl%conf, xc_one, n(1), s(1), t(1))
+         end select
+#elif XC_MAJOR_VERSION==5
+         select case(functl%family)
+          case(XC_FAMILY_LDA)
+            call xc_f90_lda_exc(functl%conf, xc_one, n(1), t(1))
+          case(XC_FAMILY_GGA)
+            call xc_f90_gga_exc(functl%conf, xc_one, n(1), s(1), t(1))
+         end select
+#endif
+
+         tau(i, is) = 2.0d0*t(1)*n(is)
+      end do
+   end do
+
+   !Deallocate arrays
+   deallocate(n, t)
+   if (functl%family == XC_FAMILY_GGA .or. functl%family == XC_FAMILY_MGGA) deallocate(s)
+   if (functl%family == XC_FAMILY_MGGA) deallocate(l)
+
+end subroutine functional_get_tau
 
 end module functionals_m
 

--- a/src/gg1cc.f90
+++ b/src/gg1cc.f90
@@ -32,49 +32,49 @@ subroutine gg1cc(gg1cc_xx,xx)
 !This section has been created automatically by the script Abilint (TD).
 !Do not modify the following lines by hand.
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
- real(dp), parameter :: pi=3.141592653589793238462643383279502884197_dp
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
+   real(dp), parameter :: pi=3.141592653589793238462643383279502884197_dp
 
 !Arguments ------------------------------------
 !scalars
- real(dp),intent(in) :: xx
- real(dp),intent(out) :: gg1cc_xx
+   real(dp),intent(in) :: xx
+   real(dp),intent(out) :: gg1cc_xx
 
 !Local variables -------------------------------------------
 !The c s are coefficients for Taylor expansion of the analytic
 !form near xx=0, 1/2, and 1.
 !scalars
- real(dp) :: c21=4.d0/9.d0,c22=-40.d0/27.d0,c23=20.d0/3.d0-16.d0*pi**2/27.d0
- real(dp) :: c24=-4160.d0/243.d0+160.d0*pi**2/81.d0,c31=1.d0/36.d0
- real(dp) :: c32=-25.d0/108.d0,c33=485.d0/432.d0-pi**2/27.d0
- real(dp) :: c34=-4055.d0/972.d0+25.d0*pi**2/81.d0
- real(dp) :: sox,yy
+   real(dp) :: c21=4.d0/9.d0,c22=-40.d0/27.d0,c23=20.d0/3.d0-16.d0*pi**2/27.d0
+   real(dp) :: c24=-4160.d0/243.d0+160.d0*pi**2/81.d0,c31=1.d0/36.d0
+   real(dp) :: c32=-25.d0/108.d0,c33=485.d0/432.d0-pi**2/27.d0
+   real(dp) :: c34=-4055.d0/972.d0+25.d0*pi**2/81.d0
+   real(dp) :: sox,yy
 
 ! *************************************************************************
 
 !Cut off beyond 3/gcut=xcccrc
- if (xx>3.0d0) then
-   gg1cc_xx=0.0d0
+   if (xx>3.0d0) then
+      gg1cc_xx=0.0d0
 !  Take care of difficult limits near x=0, 1/2, and 1
 !else if (abs(xx)<=1.d-09) then
 !  gg1cc_xx=1.d0
- else if (abs(xx)<=1.d-03) then
-   yy=2.0d0*pi*xx
-   sox=1.0d0 - yy**2/6.0d0 + yy**4/120.0d0 + yy**6/5040.0d0
-   gg1cc_xx=(sox/( (1.d0-4.0d0*xx**2)*(1.d0-xx**2) )  )**2
- else if (abs(xx-0.5d0)<=1.d-04) then
+   else if (abs(xx)<=1.d-03) then
+      yy=2.0d0*pi*xx
+      sox=1.0d0 - yy**2/6.0d0 + yy**4/120.0d0 + yy**6/5040.0d0
+      gg1cc_xx=(sox/( (1.d0-4.0d0*xx**2)*(1.d0-xx**2) )  )**2
+   else if (abs(xx-0.5d0)<=1.d-04) then
 !  (this limit and next are more troublesome for numerical cancellation)
-   gg1cc_xx=c21+(xx-0.5d0)*(c22+(xx-0.5d0)*(c23+(xx-0.5d0)*c24))
- else if (abs(xx-1.d0)<=1.d-04) then
-   gg1cc_xx=c31+(xx-1.0d0)*(c32+(xx-1.0d0)*(c33+(xx-1.0d0)*c34))
- else
+      gg1cc_xx=c21+(xx-0.5d0)*(c22+(xx-0.5d0)*(c23+(xx-0.5d0)*c24))
+   else if (abs(xx-1.d0)<=1.d-04) then
+      gg1cc_xx=c31+(xx-1.0d0)*(c32+(xx-1.0d0)*(c33+(xx-1.0d0)*c34))
+   else
 !  The following is the square of the Fourier transform of a
 !  function built out of two spherical bessel functions in G
 !  space and cut off absolutely beyond gcut
-   gg1cc_xx=(sin(2.0d0*pi*xx)/( (2.0d0*pi*xx) * &
-&   (1.d0-4.0d0*xx**2)*(1.d0-xx**2) )  )**2
- end if
+      gg1cc_xx=(sin(2.0d0*pi*xx)/( (2.0d0*pi*xx) * &
+      &   (1.d0-4.0d0*xx**2)*(1.d0-xx**2) )  )**2
+   end if
 
 end subroutine gg1cc
 !!***

--- a/src/gnu_script.f90
+++ b/src/gnu_script.f90
@@ -2,23 +2,23 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
 ! creates appropriate input file for GNUPLOT
 
- subroutine gnu_script(epa,evkb,lmax,lloc,mxprj,nproj)
+subroutine gnu_script(epa,evkb,lmax,lloc,mxprj,nproj)
 
 !epa  wave function energies
 !lmax  maximum angular momentum
@@ -26,237 +26,237 @@
 !mxprj maximum number of projectors
 !nproj number of projectors for each l
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !Input variables
- integer :: lmax,lloc,mxprj
- integer :: nproj(6)
- real(dp) :: epa(mxprj,6),evkb(mxprj,4)
+   integer :: lmax,lloc,mxprj
+   integer :: nproj(6)
+   real(dp) :: epa(mxprj,6),evkb(mxprj,4)
 
 !Output -- printing only
 
 !Local variables
- integer ii,iprj,jj,l1,ll
+   integer :: ii,iprj,jj,l1,ll
 
- character (len=2), parameter :: cbs=',\'
+   character (len=2), parameter :: cbs=',\'
 
- character(len=80) :: gln(100)
- character(len=4) :: lead(6)
- character(len=80) :: pse,set,lset(12)
- character(len=50) :: plot_title(10)
- character(len=40) :: x_label(3)
+   character(len=80) :: gln(100)
+   character(len=4) :: lead(6)
+   character(len=80) :: pse,set,lset(12)
+   character(len=50) :: plot_title(10)
+   character(len=40) :: x_label(3)
 
- lead(:)='    '
- lead(1)='plot'
+   lead(:)='    '
+   lead(1)='plot'
 
- plot_title(1)='set title "t2   Semi-Local Ion Pseudopotentials"'
- plot_title(2)='set title "t2   Charge Densities"'
- plot_title(3)='set title "t2   Wave Function set'
- plot_title(4)='set title "t2   Projector Wave Functions"'
- plot_title(5)='set title "t2   ARCTAN(Log Derivatives)"'
- plot_title(6)='set title "t2   Energy Error per Electron (Ha)"'
- plot_title(7)='set title "t2   S Projs. evkb(:) ='
- plot_title(8)='set title "t2   P Projs. evkb(:) ='
- plot_title(9)='set title "t2   D Projs. evkb(:) ='
- plot_title(10)='set title "t2   F Projs. evkb(:) ='
+   plot_title(1)='set title "t2   Semi-Local Ion Pseudopotentials"'
+   plot_title(2)='set title "t2   Charge Densities"'
+   plot_title(3)='set title "t2   Wave Function set'
+   plot_title(4)='set title "t2   Projector Wave Functions"'
+   plot_title(5)='set title "t2   ARCTAN(Log Derivatives)"'
+   plot_title(6)='set title "t2   Energy Error per Electron (Ha)"'
+   plot_title(7)='set title "t2   S Projs. evkb(:) ='
+   plot_title(8)='set title "t2   P Projs. evkb(:) ='
+   plot_title(9)='set title "t2   D Projs. evkb(:) ='
+   plot_title(10)='set title "t2   F Projs. evkb(:) ='
 
- x_label(1)='set xlabel "Radius (a_B)"'
- x_label(2)='set xlabel "Energy (Ha)"'
- x_label(3)='set xlabel "Cutoff Energy (Ha)"'
- 
- pse='pause -1 "Hit enter to continue"'
+   x_label(1)='set xlabel "Radius (a_B)"'
+   x_label(2)='set xlabel "Energy (Ha)"'
+   x_label(3)='set xlabel "Cutoff Energy (Ha)"'
 
- lset(1)='set style line 1 lw 3 lt 1 lc rgb "#D00000"'
- lset(2)='set style line 2 lw 3 lt 1 lc rgb "#00B000"'
- lset(3)='set style line 3 lw 3 lt 1 lc rgb "#2020FF"'
- lset(4)='set style line 4 lw 3 lt 1 lc rgb "#FF8000"'
- lset(5)='set style line 5 lw 3 lt 1 lc rgb "#E000E0"'
- lset(6)='set style line 6 lw 3 lt 1 lc rgb "#303030"'
- lset(7)='set style line 7 lw 3 lt 2 lc rgb "#D00000"'
- lset(8)='set style line 8 lw 3 lt 2 lc rgb "#00B000"'
- lset(9)='set style line 9 lw 3 lt 2 lc rgb "#2020FF"'
- lset(10)='set style line 10 lw 3 lt 2 lc rgb "#FF8000"'
- lset(11)='set style line 11 lw 3 lt 2 lc rgb "#E000E0"'
- lset(12)='set style line 12 lw 3 lt 2 lc rgb "#303030"'
+   pse='pause -1 "Hit enter to continue"'
 
- gln( 1)='    "<grep ''!p'' t1" using 2:4 title "S" with lines ls 1'
- gln( 2)='    "<grep ''!p'' t1" using 2:5 title "P" with lines ls 2'
- gln( 3)='    "<grep ''!p'' t1" using 2:6 title "D" with lines ls 3'
- gln( 4)='    "<grep ''!p'' t1" using 2:7 title "F" with lines ls 4'
- gln( 5)='    "<grep ''!L'' t1" using 2:3 title "Loc" with lines ls 11'
+   lset(1)='set style line 1 lw 3 lt 1 lc rgb "#D00000"'
+   lset(2)='set style line 2 lw 3 lt 1 lc rgb "#00B000"'
+   lset(3)='set style line 3 lw 3 lt 1 lc rgb "#2020FF"'
+   lset(4)='set style line 4 lw 3 lt 1 lc rgb "#FF8000"'
+   lset(5)='set style line 5 lw 3 lt 1 lc rgb "#E000E0"'
+   lset(6)='set style line 6 lw 3 lt 1 lc rgb "#303030"'
+   lset(7)='set style line 7 lw 3 lt 2 lc rgb "#D00000"'
+   lset(8)='set style line 8 lw 3 lt 2 lc rgb "#00B000"'
+   lset(9)='set style line 9 lw 3 lt 2 lc rgb "#2020FF"'
+   lset(10)='set style line 10 lw 3 lt 2 lc rgb "#FF8000"'
+   lset(11)='set style line 11 lw 3 lt 2 lc rgb "#E000E0"'
+   lset(12)='set style line 12 lw 3 lt 2 lc rgb "#303030"'
 
- gln( 6)='    "<grep ''!r'' t1" using 2:3 title "rhoV" with lines ls 1'
- gln( 7)='    "<grep ''!r'' t1" using 2:4 title "rhoC" with lines ls 2'
- gln( 8)='    "<grep ''!r'' t1" using 2:5 title "rhoM" with lines ls 3'
+   gln( 1)='    "<grep ''!p'' t1" using 2:4 title "S" with lines ls 1'
+   gln( 2)='    "<grep ''!p'' t1" using 2:5 title "P" with lines ls 2'
+   gln( 3)='    "<grep ''!p'' t1" using 2:6 title "D" with lines ls 3'
+   gln( 4)='    "<grep ''!p'' t1" using 2:7 title "F" with lines ls 4'
+   gln( 5)='    "<grep ''!L'' t1" using 2:3 title "Loc" with lines ls 11'
 
- gln(60)='    "<grep ''&    '
+   gln( 6)='    "<grep ''!r'' t1" using 2:3 title "rhoV" with lines ls 1'
+   gln( 7)='    "<grep ''!r'' t1" using 2:4 title "rhoC" with lines ls 2'
+   gln( 8)='    "<grep ''!r'' t1" using 2:5 title "rhoM" with lines ls 3'
 
- gln( 9)='0'' t1" using 3:4 title "S full" with lines ls 1'
- gln(10)='0'' t1" using 3:5 title "S pseudo" with lines ls 8'
- gln(11)='1'' t1" using 3:4 title "P full" with lines ls 3'
- gln(12)='1'' t1" using 3:5 title "P pseudo" with lines ls 10'
- gln(13)='2'' t1" using 3:4 title "D full" with lines ls 5'
- gln(14)='2'' t1" using 3:5 title "D pseudo" with lines ls 12'
- gln(15)='3'' t1" using 3:4 title "F full" with lines ls 1'
- gln(16)='3'' t1" using 3:5 title "F pseudo" with lines ls 8'
+   gln(60)='    "<grep ''&    '
 
- gln(23)='    "<grep ''!      0'' t1" using 3:4 title "S   full" with lines ls 1'
- gln(24)='    "<grep ''!      0'' t1" using 3:5 title "S pseudo" with lines ls 8'
+   gln( 9)='0'' t1" using 3:4 title "S full" with lines ls 1'
+   gln(10)='0'' t1" using 3:5 title "S pseudo" with lines ls 8'
+   gln(11)='1'' t1" using 3:4 title "P full" with lines ls 3'
+   gln(12)='1'' t1" using 3:5 title "P pseudo" with lines ls 10'
+   gln(13)='2'' t1" using 3:4 title "D full" with lines ls 5'
+   gln(14)='2'' t1" using 3:5 title "D pseudo" with lines ls 12'
+   gln(15)='3'' t1" using 3:4 title "F full" with lines ls 1'
+   gln(16)='3'' t1" using 3:5 title "F pseudo" with lines ls 8'
 
- gln(27)='    "<grep ''!      1'' t1" using 3:4 title "P   full" with lines ls 3'
- gln(28)='    "<grep ''!      1'' t1" using 3:5 title "P pseudo" with lines ls 10'
+   gln(23)='    "<grep ''!      0'' t1" using 3:4 title "S   full" with lines ls 1'
+   gln(24)='    "<grep ''!      0'' t1" using 3:5 title "S pseudo" with lines ls 8'
 
- gln(31)='    "<grep ''!      2'' t1" using 3:4 title "D   full" with lines ls 5'
- gln(32)='    "<grep ''!      2'' t1" using 3:5 title "D pseudo" with lines ls 12'
+   gln(27)='    "<grep ''!      1'' t1" using 3:4 title "P   full" with lines ls 3'
+   gln(28)='    "<grep ''!      1'' t1" using 3:5 title "P pseudo" with lines ls 10'
 
- gln(35)='    "<grep ''!      3'' t1" using 3:4 title "F   full" with lines ls 1'
- gln(36)='    "<grep ''!      3'' t1" using 3:5 title "F pseudo" with lines ls 8'
+   gln(31)='    "<grep ''!      2'' t1" using 3:4 title "D   full" with lines ls 5'
+   gln(32)='    "<grep ''!      2'' t1" using 3:5 title "D pseudo" with lines ls 12'
 
- gln(47)='    "<grep ''!C     0'' t1" using 3:4 title "S" with lines ls 1'
- gln(48)='    "<grep ''!C     1'' t1" using 3:4 title "P" with lines ls 2'
- gln(49)='    "<grep ''!C     2'' t1" using 3:4 title "D" with lines ls 3'
- gln(50)='    "<grep ''!C     3'' t1" using 3:4 title "F" with lines ls 4'
+   gln(35)='    "<grep ''!      3'' t1" using 3:4 title "F   full" with lines ls 1'
+   gln(36)='    "<grep ''!      3'' t1" using 3:5 title "F pseudo" with lines ls 8'
 
- gln(70)=    '    "<grep ''!J     '
+   gln(47)='    "<grep ''!C     0'' t1" using 3:4 title "S" with lines ls 1'
+   gln(48)='    "<grep ''!C     1'' t1" using 3:4 title "P" with lines ls 2'
+   gln(49)='    "<grep ''!C     2'' t1" using 3:4 title "D" with lines ls 3'
+   gln(50)='    "<grep ''!C     3'' t1" using 3:4 title "F" with lines ls 4'
 
- gln(71)=''' t1" using 3:4 title "Prj 1" with lines ls 1'
- gln(72)=''' t1" using 3:5 title "Prj 2" with lines ls 2'
- gln(73)=''' t1" using 3:6 title "Prj 3" with lines ls 3'
- gln(74)=''' t1" using 3:7 title "Prj 4" with lines ls 4'
- gln(75)=''' t1" using 3:7 title "Prj 5" with lines ls 5'
+   gln(70)=    '    "<grep ''!J     '
+
+   gln(71)=''' t1" using 3:4 title "Prj 1" with lines ls 1'
+   gln(72)=''' t1" using 3:5 title "Prj 2" with lines ls 2'
+   gln(73)=''' t1" using 3:6 title "Prj 3" with lines ls 3'
+   gln(74)=''' t1" using 3:7 title "Prj 4" with lines ls 4'
+   gln(75)=''' t1" using 3:7 title "Prj 5" with lines ls 5'
 
 !write(6,*) 'lmax,lloc,mxprj',lmax,lloc,mxprj
- write(6,'(a)') 'GNUSCRIPT'
+   write(6,'(a)') 'GNUSCRIPT'
 
- set='set term wxt font "arial,14" size 800,600'
- write(6,'(a/)') trim(set)
- set='set termoption dash'
- write(6,'(a/)') trim(set)
- set='set termoption noenhanced'
- write(6,'(a/)') trim(set)
- do ii=1,12
-   write(6,'(a/)') trim(lset(ii))
- end do
+   set='set term wxt font "arial,14" size 800,600'
+   write(6,'(a/)') trim(set)
+   set='set termoption dash'
+   write(6,'(a/)') trim(set)
+   set='set termoption noenhanced'
+   write(6,'(a/)') trim(set)
+   do ii=1,12
+      write(6,'(a/)') trim(lset(ii))
+   end do
 
- write(6,'(a/)') trim(plot_title(1))
- write(6,'(a/)') trim(x_label(1))
-
- do l1=1,lmax+1
-  write(6,'(2a)',advance='no') lead(l1),trim(gln(l1))
-  if(l1<lmax+1 .or. lloc==4) then
-   write(6,'(a)') cbs
-  else
-   write(6,'(/)')
-  end if
- end do
-
- if(lloc==4) then
-  l1=5
-  write(6,'(2a)') lead(l1),trim(gln(l1))
- end if
-
- write(6,'(/a/)') trim(pse)
-
- write(6,'(a/)') trim(plot_title(2))
- write(6,'(a/)') trim(x_label(1))
-
- do ii=1,3
-  write(6,'(2a)',advance='no') lead(ii),trim(gln(ii+5))
-  if(ii<3) then
-   write(6,'(a)') cbs
-  else
-   write(6,'(/)')
-  end if
- end do
-
- write(6,'(/a/)') trim(pse)
-
- do l1=1,lmax+1
-  do iprj=1,nproj(l1)
-
-    write(6,'(a,i2,a,f7.2,a/)') trim(plot_title(3)),iprj,', E= ', &
-&         epa(iprj,l1),' Ha"'
-    write(6,'(a/)') trim(x_label(1))
-
-    write(6,'(2a,i5,2a)') lead(1),trim(gln(60)),iprj,trim(gln(2*l1+7)),cbs
-    write(6,'(2a,i5, a)') lead(2),trim(gln(60)),iprj,trim(gln(2*l1+8))
-
-    write(6,'(/a/)') trim(pse)
-
-  end do !iprj
-
-!orthonormal projector plot
- ll=l1-1
- if(ll/=lloc) then
+   write(6,'(a/)') trim(plot_title(1))
    write(6,'(a/)') trim(x_label(1))
-   write(6,'(a,1p,5e11.2)',advance='no') trim(plot_title(6+l1)), &
-&        (evkb(jj,l1),jj=1,nproj(l1))
-   write(6,'(a/)')    ' Ha"'
 
-   do jj=1,nproj(l1)
-     write(6,'(2a,i6,a)',advance='no') lead(jj),trim(gln(70)),ll,trim(gln(70+jj))
-     if(jj<nproj(l1)) then
-      write(6,'(a)') cbs
-     else
-      write(6,'(/)')
-     end if
+   do l1=1,lmax+1
+      write(6,'(2a)',advance='no') lead(l1),trim(gln(l1))
+      if(l1<lmax+1 .or. lloc==4) then
+         write(6,'(a)') cbs
+      else
+         write(6,'(/)')
+      end if
+   end do
+
+   if(lloc==4) then
+      l1=5
+      write(6,'(2a)') lead(l1),trim(gln(l1))
+   end if
+
+   write(6,'(/a/)') trim(pse)
+
+   write(6,'(a/)') trim(plot_title(2))
+   write(6,'(a/)') trim(x_label(1))
+
+   do ii=1,3
+      write(6,'(2a)',advance='no') lead(ii),trim(gln(ii+5))
+      if(ii<3) then
+         write(6,'(a)') cbs
+      else
+         write(6,'(/)')
+      end if
    end do
 
    write(6,'(/a/)') trim(pse)
 
- end if
+   do l1=1,lmax+1
+      do iprj=1,nproj(l1)
+
+         write(6,'(a,i2,a,f7.2,a/)') trim(plot_title(3)),iprj,', E= ', &
+         &         epa(iprj,l1),' Ha"'
+         write(6,'(a/)') trim(x_label(1))
+
+         write(6,'(2a,i5,2a)') lead(1),trim(gln(60)),iprj,trim(gln(2*l1+7)),cbs
+         write(6,'(2a,i5, a)') lead(2),trim(gln(60)),iprj,trim(gln(2*l1+8))
+
+         write(6,'(/a/)') trim(pse)
+
+      end do  !iprj
+
+!orthonormal projector plot
+      ll=l1-1
+      if(ll/=lloc) then
+         write(6,'(a/)') trim(x_label(1))
+         write(6,'(a,1p,5e11.2)',advance='no') trim(plot_title(6+l1)), &
+         &        (evkb(jj,l1),jj=1,nproj(l1))
+         write(6,'(a/)')    ' Ha"'
+
+         do jj=1,nproj(l1)
+            write(6,'(2a,i6,a)',advance='no') lead(jj),trim(gln(70)),ll,trim(gln(70+jj))
+            if(jj<nproj(l1)) then
+               write(6,'(a)') cbs
+            else
+               write(6,'(/)')
+            end if
+         end do
+
+         write(6,'(/a/)') trim(pse)
+
+      end if
 
 ! log derivative plots
 
-  write(6,'(a/)') trim(plot_title(5))
-  write(6,'(a/)') trim(x_label(2))
+      write(6,'(a/)') trim(plot_title(5))
+      write(6,'(a/)') trim(x_label(2))
 
-  write(6,'(3a)') lead(1),trim(gln(4*l1+19)),cbs
-  write(6,'(2a)') lead(2),trim(gln(4*l1+20))
+      write(6,'(3a)') lead(1),trim(gln(4*l1+19)),cbs
+      write(6,'(2a)') lead(2),trim(gln(4*l1+20))
 
-  write(6,'(/a/)') trim(pse)
+      write(6,'(/a/)') trim(pse)
 
- end do !l1
+   end do  !l1
 
-! log derivatives for angular momenta for which no pseudopotentials 
+! log derivatives for angular momenta for which no pseudopotentials
 ! were created
 
- do l1=lmax+2,4
+   do l1=lmax+2,4
 
-  write(6,'(a/)') trim(plot_title(5))
-  write(6,'(a/)') trim(x_label(2))
+      write(6,'(a/)') trim(plot_title(5))
+      write(6,'(a/)') trim(x_label(2))
 
-  write(6,'(3a)') lead(1),trim(gln(4*l1+19)),cbs
-  write(6,'(2a)') lead(2),trim(gln(4*l1+20))
+      write(6,'(3a)') lead(1),trim(gln(4*l1+19)),cbs
+      write(6,'(2a)') lead(2),trim(gln(4*l1+20))
 
-  write(6,'(/a/)') trim(pse)
+      write(6,'(/a/)') trim(pse)
 
- end do
+   end do
 
 ! Convergence profile
 
- set='set  logscale y'
- write(6,'(a/)') trim(set)
- set='set  grid'
- write(6,'(a/)') trim(set)
- set='set  yrange [5.e-6:2.e-2]'
- write(6,'(a/)') trim(set)
- write(6,'(a/)') trim(plot_title(6))
- write(6,'(a/)') trim(x_label(3))
+   set='set  logscale y'
+   write(6,'(a/)') trim(set)
+   set='set  grid'
+   write(6,'(a/)') trim(set)
+   set='set  yrange [5.e-6:2.e-2]'
+   write(6,'(a/)') trim(set)
+   write(6,'(a/)') trim(plot_title(6))
+   write(6,'(a/)') trim(x_label(3))
 
- do l1=1,lmax+1
-  write(6,'(2a)',advance='no') lead(l1),trim(gln(46+l1))
-  if(l1<lmax+1) then
-   write(6,'(a)') cbs
-  else
-   write(6,'(/)')
-  end if
- end do
+   do l1=1,lmax+1
+      write(6,'(2a)',advance='no') lead(l1),trim(gln(46+l1))
+      if(l1<lmax+1) then
+         write(6,'(a)') cbs
+      else
+         write(6,'(/)')
+      end if
+   end do
 
- write(6,'(/a/)') trim(pse)
+   write(6,'(/a/)') trim(pse)
 
- write(6,'(a)') 'END_GNU'
+   write(6,'(a)') 'END_GNU'
 
- return
- end subroutine gnu_script
+   return
+end subroutine gnu_script

--- a/src/gnu_script_r.f90
+++ b/src/gnu_script_r.f90
@@ -2,23 +2,23 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
 ! creates appropriate input file for GNUPLOT
 
- subroutine gnu_script_r(epa,evkb,lmax,lloc,mxprj,nproj)
+subroutine gnu_script_r(epa,evkb,lmax,lloc,mxprj,nproj)
 
 !epa  wave function energies
 !lmax  maximum angular momentum
@@ -26,291 +26,291 @@
 !mxprj maximum number of projectors
 !nproj number of projectors for each l
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !Input variables
- integer :: lmax,lloc,mxprj
- integer :: nproj(6)
- real(dp) :: epa(mxprj,6,2),evkb(mxprj,4,2)
+   integer :: lmax,lloc,mxprj
+   integer :: nproj(6)
+   real(dp) :: epa(mxprj,6,2),evkb(mxprj,4,2)
 
 !Output -- printing only
 
 !Local variables
- integer :: ii,iprj,jj,l1,ll
- integer :: ikap,mkap
+   integer :: ii,iprj,jj,l1,ll
+   integer :: ikap,mkap
 
- character (len=2), parameter :: cbs=',\'
+   character (len=2), parameter :: cbs=',\'
 
- character(len=80) :: gln(100)
- character(len=4) :: lead(6)
- character(len=80) :: pse,set,lset(12)
- character(len=50) :: plot_title(20)
- character(len=40) :: x_label(3)
+   character(len=80) :: gln(100)
+   character(len=4) :: lead(6)
+   character(len=80) :: pse,set,lset(12)
+   character(len=50) :: plot_title(20)
+   character(len=40) :: x_label(3)
 
- lead(:)='    '
- lead(1)='plot'
+   lead(:)='    '
+   lead(1)='plot'
 
- plot_title(1)='set title "t1 Ion Pseudopotentials"'
- plot_title(2)='set title "t1 Charge Densities"'
- plot_title(3)='set title "t1 Wave Function set'
- plot_title(4)='set title "t1 Projector Wave Functions"'
- plot_title(5)='set title "t1 ARCTAN(Log Derivatives)"'
- plot_title(6)='set title "t1 Energy Error per Electron (Ha)"'
- plot_title(7)='set title "S+ Ortho. Projs. evkb(:) ='
- plot_title(8)='set title "P+ Ortho. Projs. evkb(:) ='
- plot_title(9)='set title "D+ Ortho. Projs. evkb(:) ='
- plot_title(10)='set title "F+ Ortho. Projs. evkb(:) ='
- plot_title(11)='set title "S- Ortho. Projs. evkb(:) ='
- plot_title(12)='set title "P- Ortho. Projs. evkb(:) ='
- plot_title(13)='set title "D- Ortho. Projs. evkb(:) ='
- plot_title(14)='set title "F- Ortho. Projs. evkb(:) ='
+   plot_title(1)='set title "t1 Ion Pseudopotentials"'
+   plot_title(2)='set title "t1 Charge Densities"'
+   plot_title(3)='set title "t1 Wave Function set'
+   plot_title(4)='set title "t1 Projector Wave Functions"'
+   plot_title(5)='set title "t1 ARCTAN(Log Derivatives)"'
+   plot_title(6)='set title "t1 Energy Error per Electron (Ha)"'
+   plot_title(7)='set title "S+ Ortho. Projs. evkb(:) ='
+   plot_title(8)='set title "P+ Ortho. Projs. evkb(:) ='
+   plot_title(9)='set title "D+ Ortho. Projs. evkb(:) ='
+   plot_title(10)='set title "F+ Ortho. Projs. evkb(:) ='
+   plot_title(11)='set title "S- Ortho. Projs. evkb(:) ='
+   plot_title(12)='set title "P- Ortho. Projs. evkb(:) ='
+   plot_title(13)='set title "D- Ortho. Projs. evkb(:) ='
+   plot_title(14)='set title "F- Ortho. Projs. evkb(:) ='
 
- x_label(1)='set xlabel "Radius (a_B)"'
- x_label(2)='set xlabel "Energy (Ha)"'
- x_label(3)='set xlabel "Cutoff Energy (Ha)"'
- 
- pse='pause -1 "Hit enter to continue"'
+   x_label(1)='set xlabel "Radius (a_B)"'
+   x_label(2)='set xlabel "Energy (Ha)"'
+   x_label(3)='set xlabel "Cutoff Energy (Ha)"'
 
- lset(1)='set style line 1 lw 3 lt 1 lc rgb "#D00000"'
- lset(2)='set style line 2 lw 3 lt 1 lc rgb "#00B000"'
- lset(3)='set style line 3 lw 3 lt 1 lc rgb "#2020FF"'
- lset(4)='set style line 4 lw 3 lt 1 lc rgb "#FF8000"'
- lset(5)='set style line 5 lw 3 lt 1 lc rgb "#E000E0"'
- lset(6)='set style line 6 lw 3 lt 1 lc rgb "#303030"'
- lset(7)='set style line 7 lw 3 lt 2 lc rgb "#D00000"'
- lset(8)='set style line 8 lw 3 lt 2 lc rgb "#00B000"'
- lset(9)='set style line 9 lw 3 lt 2 lc rgb "#2020FF"'
- lset(10)='set style line 10 lw 3 lt 2 lc rgb "#FF8000"'
- lset(11)='set style line 11 lw 3 lt 2 lc rgb "#E000E0"'
- lset(12)='set style line 12 lw 3 lt 2 lc rgb "#303030"'
+   pse='pause -1 "Hit enter to continue"'
 
- gln( 1)='    "<grep ''!p'' t1" using 2:4 title "S" with lines ls 1'
- gln( 2)='    "<grep ''!p'' t1" using 2:5 title "P" with lines ls 2'
- gln( 3)='    "<grep ''!p'' t1" using 2:6 title "D" with lines ls 3'
- gln( 4)='    "<grep ''!p'' t1" using 2:7 title "F" with lines ls 4'
- gln( 5)='    "<grep ''!L'' t1" using 2:3 title "Loc" with lines ls 11'
+   lset(1)='set style line 1 lw 3 lt 1 lc rgb "#D00000"'
+   lset(2)='set style line 2 lw 3 lt 1 lc rgb "#00B000"'
+   lset(3)='set style line 3 lw 3 lt 1 lc rgb "#2020FF"'
+   lset(4)='set style line 4 lw 3 lt 1 lc rgb "#FF8000"'
+   lset(5)='set style line 5 lw 3 lt 1 lc rgb "#E000E0"'
+   lset(6)='set style line 6 lw 3 lt 1 lc rgb "#303030"'
+   lset(7)='set style line 7 lw 3 lt 2 lc rgb "#D00000"'
+   lset(8)='set style line 8 lw 3 lt 2 lc rgb "#00B000"'
+   lset(9)='set style line 9 lw 3 lt 2 lc rgb "#2020FF"'
+   lset(10)='set style line 10 lw 3 lt 2 lc rgb "#FF8000"'
+   lset(11)='set style line 11 lw 3 lt 2 lc rgb "#E000E0"'
+   lset(12)='set style line 12 lw 3 lt 2 lc rgb "#303030"'
 
- gln( 6)='    "<grep ''!r'' t1" using 2:3 title "rhoV" with lines ls 1'
- gln( 7)='    "<grep ''!r'' t1" using 2:4 title "rhoC" with lines ls 2'
- gln( 8)='    "<grep ''!r'' t1" using 2:5 title "rhoM" with lines ls 3'
+   gln( 1)='    "<grep ''!p'' t1" using 2:4 title "S" with lines ls 1'
+   gln( 2)='    "<grep ''!p'' t1" using 2:5 title "P" with lines ls 2'
+   gln( 3)='    "<grep ''!p'' t1" using 2:6 title "D" with lines ls 3'
+   gln( 4)='    "<grep ''!p'' t1" using 2:7 title "F" with lines ls 4'
+   gln( 5)='    "<grep ''!L'' t1" using 2:3 title "Loc" with lines ls 11'
 
- gln(60)='    "<grep ''&    '
+   gln( 6)='    "<grep ''!r'' t1" using 2:3 title "rhoV" with lines ls 1'
+   gln( 7)='    "<grep ''!r'' t1" using 2:4 title "rhoC" with lines ls 2'
+   gln( 8)='    "<grep ''!r'' t1" using 2:5 title "rhoM" with lines ls 3'
 
- gln( 9)='0'' t1" using 3:4 title "S+ full" with lines ls 1'
- gln(10)='0'' t1" using 3:5 title "S+ pseudo" with lines ls 8'
- gln(11)='1'' t1" using 3:4 title "P+ full" with lines ls 3'
- gln(12)='1'' t1" using 3:5 title "P+ pseudo" with lines ls 10'
- gln(13)='2'' t1" using 3:4 title "D+ full" with lines ls 5'
- gln(14)='2'' t1" using 3:5 title "D+ pseudo" with lines ls 12'
- gln(15)='3'' t1" using 3:4 title "F+ full" with lines ls 1'
- gln(16)='3'' t1" using 3:5 title "F+ pseudo" with lines ls 8'
+   gln(60)='    "<grep ''&    '
 
- gln(79)='0'' t1" using 3:4 title "S- full" with lines ls 1'
- gln(80)='0'' t1" using 3:5 title "S- pseudo" with lines ls 8'
- gln(81)='1'' t1" using 3:4 title "P- full" with lines ls 3'
- gln(82)='1'' t1" using 3:5 title "P- pseudo" with lines ls 10'
- gln(83)='2'' t1" using 3:4 title "D- full" with lines ls 5'
- gln(84)='2'' t1" using 3:5 title "D- pseudo" with lines ls 12'
- gln(85)='3'' t1" using 3:4 title "F- full" with lines ls 1'
- gln(86)='3'' t1" using 3:5 title "F- pseudo" with lines ls 8'
+   gln( 9)='0'' t1" using 3:4 title "S+ full" with lines ls 1'
+   gln(10)='0'' t1" using 3:5 title "S+ pseudo" with lines ls 8'
+   gln(11)='1'' t1" using 3:4 title "P+ full" with lines ls 3'
+   gln(12)='1'' t1" using 3:5 title "P+ pseudo" with lines ls 10'
+   gln(13)='2'' t1" using 3:4 title "D+ full" with lines ls 5'
+   gln(14)='2'' t1" using 3:5 title "D+ pseudo" with lines ls 12'
+   gln(15)='3'' t1" using 3:4 title "F+ full" with lines ls 1'
+   gln(16)='3'' t1" using 3:5 title "F+ pseudo" with lines ls 8'
 
- gln(23)='    "<grep ''!      0'' t1" using 3:4 title "S+   full" with lines ls 1'
- gln(24)='    "<grep ''!      0'' t1" using 3:5 title "S+ pseudo" with lines ls 8'
- gln(25)='    "<grep ''!      0'' t1" using 3:4 title "S-   full" with lines ls 1'
- gln(26)='    "<grep ''!      0'' t1" using 3:5 title "S- pseudo" with lines ls 8'
+   gln(79)='0'' t1" using 3:4 title "S- full" with lines ls 1'
+   gln(80)='0'' t1" using 3:5 title "S- pseudo" with lines ls 8'
+   gln(81)='1'' t1" using 3:4 title "P- full" with lines ls 3'
+   gln(82)='1'' t1" using 3:5 title "P- pseudo" with lines ls 10'
+   gln(83)='2'' t1" using 3:4 title "D- full" with lines ls 5'
+   gln(84)='2'' t1" using 3:5 title "D- pseudo" with lines ls 12'
+   gln(85)='3'' t1" using 3:4 title "F- full" with lines ls 1'
+   gln(86)='3'' t1" using 3:5 title "F- pseudo" with lines ls 8'
 
- gln(27)='    "<grep ''!      1'' t1" using 3:4 title "P+   full" with lines ls 3'
- gln(28)='    "<grep ''!      1'' t1" using 3:5 title "P+ pseudo" with lines ls 10'
- gln(29)='    "<grep ''!      1'' t1" using 3:4 title "P-   full" with lines ls 3'
- gln(30)='    "<grep ''!      1'' t1" using 3:5 title "P- pseudo" with lines ls 10'
+   gln(23)='    "<grep ''!      0'' t1" using 3:4 title "S+   full" with lines ls 1'
+   gln(24)='    "<grep ''!      0'' t1" using 3:5 title "S+ pseudo" with lines ls 8'
+   gln(25)='    "<grep ''!      0'' t1" using 3:4 title "S-   full" with lines ls 1'
+   gln(26)='    "<grep ''!      0'' t1" using 3:5 title "S- pseudo" with lines ls 8'
 
- gln(31)='    "<grep ''!      2'' t1" using 3:4 title "D+   full" with lines ls 5'
- gln(32)='    "<grep ''!      2'' t1" using 3:5 title "D+ pseudo" with lines ls 12'
- gln(33)='    "<grep ''!      2'' t1" using 3:4 title "D-   full" with lines ls 5'
- gln(34)='    "<grep ''!      2'' t1" using 3:5 title "D- pseudo" with lines ls 12'
+   gln(27)='    "<grep ''!      1'' t1" using 3:4 title "P+   full" with lines ls 3'
+   gln(28)='    "<grep ''!      1'' t1" using 3:5 title "P+ pseudo" with lines ls 10'
+   gln(29)='    "<grep ''!      1'' t1" using 3:4 title "P-   full" with lines ls 3'
+   gln(30)='    "<grep ''!      1'' t1" using 3:5 title "P- pseudo" with lines ls 10'
 
- gln(35)='    "<grep ''!      3'' t1" using 3:4 title "F+   full" with lines ls 1'
- gln(36)='    "<grep ''!      3'' t1" using 3:5 title "F+ pseudo" with lines ls 8'
- gln(37)='    "<grep ''!      3'' t1" using 3:4 title "F-   full" with lines ls 1'
- gln(38)='    "<grep ''!      3'' t1" using 3:5 title "F- pseudo" with lines ls 8'
+   gln(31)='    "<grep ''!      2'' t1" using 3:4 title "D+   full" with lines ls 5'
+   gln(32)='    "<grep ''!      2'' t1" using 3:5 title "D+ pseudo" with lines ls 12'
+   gln(33)='    "<grep ''!      2'' t1" using 3:4 title "D-   full" with lines ls 5'
+   gln(34)='    "<grep ''!      2'' t1" using 3:5 title "D- pseudo" with lines ls 12'
 
- gln(47)='    "<grep ''!C     0'' t1" using 3:4 title "S" with lines ls 1'
- gln(48)='    "<grep ''!C     1'' t1" using 3:4 title "P" with lines ls 2'
- gln(49)='    "<grep ''!C     2'' t1" using 3:4 title "D" with lines ls 3'
- gln(50)='    "<grep ''!C     3'' t1" using 3:4 title "F" with lines ls 4'
+   gln(35)='    "<grep ''!      3'' t1" using 3:4 title "F+   full" with lines ls 1'
+   gln(36)='    "<grep ''!      3'' t1" using 3:5 title "F+ pseudo" with lines ls 8'
+   gln(37)='    "<grep ''!      3'' t1" using 3:4 title "F-   full" with lines ls 1'
+   gln(38)='    "<grep ''!      3'' t1" using 3:5 title "F- pseudo" with lines ls 8'
 
- gln(70)=    '    "<grep ''!J     '
+   gln(47)='    "<grep ''!C     0'' t1" using 3:4 title "S" with lines ls 1'
+   gln(48)='    "<grep ''!C     1'' t1" using 3:4 title "P" with lines ls 2'
+   gln(49)='    "<grep ''!C     2'' t1" using 3:4 title "D" with lines ls 3'
+   gln(50)='    "<grep ''!C     3'' t1" using 3:4 title "F" with lines ls 4'
 
- gln(71)=''' t1" using 3:4 title "Prj 1" with lines ls 1'
- gln(72)=''' t1" using 3:5 title "Prj 2" with lines ls 2'
- gln(73)=''' t1" using 3:6 title "Prj 3" with lines ls 3'
- gln(74)=''' t1" using 3:7 title "Prj 4" with lines ls 4'
+   gln(70)=    '    "<grep ''!J     '
+
+   gln(71)=''' t1" using 3:4 title "Prj 1" with lines ls 1'
+   gln(72)=''' t1" using 3:5 title "Prj 2" with lines ls 2'
+   gln(73)=''' t1" using 3:6 title "Prj 3" with lines ls 3'
+   gln(74)=''' t1" using 3:7 title "Prj 4" with lines ls 4'
 
 !write(6,*) 'lmax,lloc,mxprj',lmax,lloc,mxprj
- write(6,'(a)') 'GNUSCRIPT'
+   write(6,'(a)') 'GNUSCRIPT'
 
- set='set term wxt font "arial,14" size 800,600'
- write(6,'(a/)') trim(set)
- set='set termoption dash'
- write(6,'(a/)') trim(set)
- set='set termoption noenhanced'
- write(6,'(a/)') trim(set)
- do ii=1,12
-   write(6,'(a/)') trim(lset(ii))
- end do
+   set='set term wxt font "arial,14" size 800,600'
+   write(6,'(a/)') trim(set)
+   set='set termoption dash'
+   write(6,'(a/)') trim(set)
+   set='set termoption noenhanced'
+   write(6,'(a/)') trim(set)
+   do ii=1,12
+      write(6,'(a/)') trim(lset(ii))
+   end do
 
- write(6,'(a/)') trim(plot_title(1))
- write(6,'(a/)') trim(x_label(1))
+   write(6,'(a/)') trim(plot_title(1))
+   write(6,'(a/)') trim(x_label(1))
 
- do l1=1,lmax+1
-  write(6,'(2a)',advance='no') lead(l1),trim(gln(l1))
-  if(l1<lmax+1 .or. lloc==4) then
-   write(6,'(a)') cbs
-  else
-   write(6,'(/)')
-  end if
- end do
-
- if(lloc==4) then
-  l1=5
-  write(6,'(2a)') lead(l1),trim(gln(l1))
- end if
-
- write(6,'(/a/)') trim(pse)
-
- write(6,'(a/)') trim(plot_title(2))
- write(6,'(a/)') trim(x_label(1))
-
- do ii=1,3
-  write(6,'(2a)',advance='no') lead(ii),trim(gln(ii+5))
-  if(ii<3) then
-   write(6,'(a)') cbs
-  else
-   write(6,'(/)')
-  end if
- end do
-
- write(6,'(/a/)') trim(pse)
-
-!wave function plots
-
- do l1=1,lmax+1
-  if(l1==1) then
-   mkap=1
-  else
-   mkap=2
-  end if
-! loop on J = ll +/- 1/2
-  do ikap=1,mkap
-
-   do iprj=1,nproj(l1)
-
-     write(6,'(a,i2,a,f7.2,a/)') trim(plot_title(3)),iprj,', E= ', &
-&          epa(iprj,l1,ikap),' Ha"'
-     write(6,'(a/)') trim(x_label(1))
-     if(ikap==1) then
-       write(6,'(2a,i5,2a)') lead(1),trim(gln(60)),-iprj,trim(gln(2*l1+7)),cbs
-       write(6,'(2a,i5, a)') lead(2),trim(gln(60)),-iprj,trim(gln(2*l1+8))
-     else
-       write(6,'(2a,i5,2a)') lead(1),trim(gln(60)),iprj,trim(gln(2*l1+77)),cbs
-       write(6,'(2a,i5, a)') lead(2),trim(gln(60)),iprj,trim(gln(2*l1+78))
-     end if
-
-     write(6,'(/a/)') trim(pse)
-
-   end do !iprj
-
-! orthonormal projector plot
-  ll=l1-1
-  if(ll/=lloc) then
-    write(6,'(a/)') trim(x_label(1))
-    if(ikap==1) then
-      write(6,'(a,1p,5e11.2)',advance='no') trim(plot_title(6+l1)), &
-&           (evkb(jj,l1,ikap),jj=1,nproj(l1))
-    else
-      write(6,'(a,1p,5e11.2)',advance='no') trim(plot_title(10+l1)), &
-&           (evkb(jj,l1,ikap),jj=1,nproj(l1))
-    end if
-    write(6,'(a/)')    ' Ha"'
-
-    do jj=1,nproj(l1)
-      write(6,'(2a,i6,a)',advance='no') lead(jj),trim(gln(70)),ll,trim(gln(70+jj))
-      if(jj<nproj(l1)) then
-       write(6,'(a)') cbs
+   do l1=1,lmax+1
+      write(6,'(2a)',advance='no') lead(l1),trim(gln(l1))
+      if(l1<lmax+1 .or. lloc==4) then
+         write(6,'(a)') cbs
       else
-       write(6,'(/)')
+         write(6,'(/)')
       end if
-    end do
+   end do
 
-    write(6,'(/a/)') trim(pse)
-
-  end if
-
-!  log derivative plots
-
-   write(6,'(a/)') trim(plot_title(5))
-   write(6,'(a/)') trim(x_label(2))
-
-   if(ikap==1) then
-     write(6,'(3a)') lead(1),trim(gln(4*l1+19)),cbs
-     write(6,'(2a)') lead(2),trim(gln(4*l1+20))
-   else
-     write(6,'(3a)') lead(1),trim(gln(4*l1+21)),cbs
-     write(6,'(2a)') lead(2),trim(gln(4*l1+22))
+   if(lloc==4) then
+      l1=5
+      write(6,'(2a)') lead(l1),trim(gln(l1))
    end if
 
    write(6,'(/a/)') trim(pse)
 
-  end do !ikap
- end do !l1
+   write(6,'(a/)') trim(plot_title(2))
+   write(6,'(a/)') trim(x_label(1))
 
-! log derivatives for angular momenta for which no pseudopotentials 
+   do ii=1,3
+      write(6,'(2a)',advance='no') lead(ii),trim(gln(ii+5))
+      if(ii<3) then
+         write(6,'(a)') cbs
+      else
+         write(6,'(/)')
+      end if
+   end do
+
+   write(6,'(/a/)') trim(pse)
+
+!wave function plots
+
+   do l1=1,lmax+1
+      if(l1==1) then
+         mkap=1
+      else
+         mkap=2
+      end if
+! loop on J = ll +/- 1/2
+      do ikap=1,mkap
+
+         do iprj=1,nproj(l1)
+
+            write(6,'(a,i2,a,f7.2,a/)') trim(plot_title(3)),iprj,', E= ', &
+            &          epa(iprj,l1,ikap),' Ha"'
+            write(6,'(a/)') trim(x_label(1))
+            if(ikap==1) then
+               write(6,'(2a,i5,2a)') lead(1),trim(gln(60)),-iprj,trim(gln(2*l1+7)),cbs
+               write(6,'(2a,i5, a)') lead(2),trim(gln(60)),-iprj,trim(gln(2*l1+8))
+            else
+               write(6,'(2a,i5,2a)') lead(1),trim(gln(60)),iprj,trim(gln(2*l1+77)),cbs
+               write(6,'(2a,i5, a)') lead(2),trim(gln(60)),iprj,trim(gln(2*l1+78))
+            end if
+
+            write(6,'(/a/)') trim(pse)
+
+         end do  !iprj
+
+! orthonormal projector plot
+         ll=l1-1
+         if(ll/=lloc) then
+            write(6,'(a/)') trim(x_label(1))
+            if(ikap==1) then
+               write(6,'(a,1p,5e11.2)',advance='no') trim(plot_title(6+l1)), &
+               &           (evkb(jj,l1,ikap),jj=1,nproj(l1))
+            else
+               write(6,'(a,1p,5e11.2)',advance='no') trim(plot_title(10+l1)), &
+               &           (evkb(jj,l1,ikap),jj=1,nproj(l1))
+            end if
+            write(6,'(a/)')    ' Ha"'
+
+            do jj=1,nproj(l1)
+               write(6,'(2a,i6,a)',advance='no') lead(jj),trim(gln(70)),ll,trim(gln(70+jj))
+               if(jj<nproj(l1)) then
+                  write(6,'(a)') cbs
+               else
+                  write(6,'(/)')
+               end if
+            end do
+
+            write(6,'(/a/)') trim(pse)
+
+         end if
+
+!  log derivative plots
+
+         write(6,'(a/)') trim(plot_title(5))
+         write(6,'(a/)') trim(x_label(2))
+
+         if(ikap==1) then
+            write(6,'(3a)') lead(1),trim(gln(4*l1+19)),cbs
+            write(6,'(2a)') lead(2),trim(gln(4*l1+20))
+         else
+            write(6,'(3a)') lead(1),trim(gln(4*l1+21)),cbs
+            write(6,'(2a)') lead(2),trim(gln(4*l1+22))
+         end if
+
+         write(6,'(/a/)') trim(pse)
+
+      end do  !ikap
+   end do  !l1
+
+! log derivatives for angular momenta for which no pseudopotentials
 ! were created
 
- if(lmax<3) then
-  do l1=lmax+2,4
- 
-   write(6,'(a/)') trim(plot_title(5))
-   write(6,'(a/)') trim(x_label(2))
- 
-   do ikap=1,2
-    if(ikap==1) then
-      write(6,'(3a)') lead(1),trim(gln(4*l1+19)),cbs
-      write(6,'(2a)') lead(2),trim(gln(4*l1+20))
-    else
-      write(6,'(3a)') lead(1),trim(gln(4*l1+21)),cbs
-      write(6,'(2a)') lead(2),trim(gln(4*l1+22))
-    end if
- 
-   write(6,'(/a/)') trim(pse)
-    end do !ikap
-  end do !l1
- end if
+   if(lmax<3) then
+      do l1=lmax+2,4
+
+         write(6,'(a/)') trim(plot_title(5))
+         write(6,'(a/)') trim(x_label(2))
+
+         do ikap=1,2
+            if(ikap==1) then
+               write(6,'(3a)') lead(1),trim(gln(4*l1+19)),cbs
+               write(6,'(2a)') lead(2),trim(gln(4*l1+20))
+            else
+               write(6,'(3a)') lead(1),trim(gln(4*l1+21)),cbs
+               write(6,'(2a)') lead(2),trim(gln(4*l1+22))
+            end if
+
+            write(6,'(/a/)') trim(pse)
+         end do  !ikap
+      end do  !l1
+   end if
 
 ! Convergence profile
 
- set='set  logscale y'
- write(6,'(a/)') trim(set)
- set='set  grid'
- write(6,'(a/)') trim(set)
- set='set  yrange [5.e-6:2.e-2]'
- write(6,'(a/)') trim(set)
- write(6,'(a/)') trim(plot_title(6))
- write(6,'(a/)') trim(x_label(3))
+   set='set  logscale y'
+   write(6,'(a/)') trim(set)
+   set='set  grid'
+   write(6,'(a/)') trim(set)
+   set='set  yrange [5.e-6:2.e-2]'
+   write(6,'(a/)') trim(set)
+   write(6,'(a/)') trim(plot_title(6))
+   write(6,'(a/)') trim(x_label(3))
 
- do l1=1,lmax+1
-  write(6,'(2a)',advance='no') lead(l1),trim(gln(46+l1))
-  if(l1<lmax+1) then
-   write(6,'(a)') cbs
-  else
-   write(6,'(/)')
-  end if
- end do
+   do l1=1,lmax+1
+      write(6,'(2a)',advance='no') lead(l1),trim(gln(46+l1))
+      if(l1<lmax+1) then
+         write(6,'(a)') cbs
+      else
+         write(6,'(/)')
+      end if
+   end do
 
- write(6,'(/a/)') trim(pse)
+   write(6,'(/a/)') trim(pse)
 
- write(6,'(a)') 'END_GNU'
+   write(6,'(a)') 'END_GNU'
 
- return
- end subroutine gnu_script_r
+   return
+end subroutine gnu_script_r

--- a/src/gp1cc.f90
+++ b/src/gp1cc.f90
@@ -36,55 +36,55 @@
 
 subroutine gp1cc(gp1cc_xx,xx)
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
- real(dp), parameter :: pi=3.141592653589793238462643383279502884197_dp
- real(dp), parameter :: two_pi=2.0d0*pi
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
+   real(dp), parameter :: pi=3.141592653589793238462643383279502884197_dp
+   real(dp), parameter :: two_pi=2.0d0*pi
 
 !Arguments ------------------------------------
 !scalars
- real(dp),intent(in) :: xx
- real(dp),intent(out) :: gp1cc_xx
+   real(dp),intent(in) :: xx
+   real(dp),intent(out) :: gp1cc_xx
 
 !Local variables -------------------------------------------
 !scalars
- real(dp),parameter :: c11=20.d0-8.d0*pi**2/3.d0
- real(dp),parameter :: c12=268.d0-160.d0/3.d0*pi**2+128.d0/45.d0*pi**4
- real(dp),parameter :: c21=-40.d0/27.d0,c22=40.d0/3.d0-32.d0*pi**2/27.d0
- real(dp),parameter :: c23=-4160.d0/81.d0+160.d0*pi**2/27.d0
- real(dp),parameter :: c24=157712.d0/729.d0-320.d0*pi**2/9.d0+512.d0*pi**4/405.d0
- real(dp),parameter :: c25=-452200.d0/729.d0+83200.d0*pi**2/729.d0-1280.d0*pi**4/243.d0
- real(dp),parameter :: c31=-25.d0/108.d0,c32=485.d0/216.d0-2.d0*pi**2/27.d0
- real(dp),parameter :: c33=-4055.d0/324.d0+25.d0*pi**2/27.d0
- real(dp),parameter :: c34=616697.d0/11664.d0-485.d0*pi**2/81.d0+32.d0*pi**4/405.d0
- real(dp),parameter :: c35=-2933875.d0/15552.d0+20275.d0*pi**2/729.d0-200.d0*pi**4/243.d0
- real(dp),parameter :: two_pim1=1.0d0/two_pi
- real(dp) :: denom,phi,phip
+   real(dp),parameter :: c11=20.d0-8.d0*pi**2/3.d0
+   real(dp),parameter :: c12=268.d0-160.d0/3.d0*pi**2+128.d0/45.d0*pi**4
+   real(dp),parameter :: c21=-40.d0/27.d0,c22=40.d0/3.d0-32.d0*pi**2/27.d0
+   real(dp),parameter :: c23=-4160.d0/81.d0+160.d0*pi**2/27.d0
+   real(dp),parameter :: c24=157712.d0/729.d0-320.d0*pi**2/9.d0+512.d0*pi**4/405.d0
+   real(dp),parameter :: c25=-452200.d0/729.d0+83200.d0*pi**2/729.d0-1280.d0*pi**4/243.d0
+   real(dp),parameter :: c31=-25.d0/108.d0,c32=485.d0/216.d0-2.d0*pi**2/27.d0
+   real(dp),parameter :: c33=-4055.d0/324.d0+25.d0*pi**2/27.d0
+   real(dp),parameter :: c34=616697.d0/11664.d0-485.d0*pi**2/81.d0+32.d0*pi**4/405.d0
+   real(dp),parameter :: c35=-2933875.d0/15552.d0+20275.d0*pi**2/729.d0-200.d0*pi**4/243.d0
+   real(dp),parameter :: two_pim1=1.0d0/two_pi
+   real(dp) :: denom,phi,phip
 
 ! *************************************************************************
 
 !Cut off beyond r=3*xcccrc is already done at the calling level
- if (xx>1.001d0) then
+   if (xx>1.001d0) then
 !  The part that follows will be repeated later, but written in this way,
 !  only one "if" condition is tested in most of the cases (1.001 < x < 3.0)
-   denom=1.d0/(xx*(1.d0-4.d0*xx**2)*(1.d0-xx**2))
-   phi=denom*sin(two_pi*xx)*two_pim1
-   phip=denom*(cos(two_pi*xx)-(1.d0-xx**2*(15.d0-xx**2*20))*phi)
-   gp1cc_xx=2.d0*phi*phip
+      denom=1.d0/(xx*(1.d0-4.d0*xx**2)*(1.d0-xx**2))
+      phi=denom*sin(two_pi*xx)*two_pim1
+      phip=denom*(cos(two_pi*xx)-(1.d0-xx**2*(15.d0-xx**2*20))*phi)
+      gp1cc_xx=2.d0*phi*phip
 !  Handle limits where denominator vanishes
- else if (abs(xx)<1.d-03) then
-   gp1cc_xx=xx*(c11+xx**2*c12)
- else if (abs(xx-0.5d0)<=1.d-03) then
-   gp1cc_xx=c21+(xx-0.5d0)*(c22+(xx-0.5d0)*(c23+(xx-0.5d0)*(c24+(xx-0.5d0)*c25)))
- else if (abs(xx-1.d0)<=1.d-03) then
-   gp1cc_xx=c31+(xx-1.0d0)*(c32+(xx-1.0d0)*(c33+(xx-1.0d0)*(c34+(xx-1.0d0)*c35)))
- else
+   else if (abs(xx)<1.d-03) then
+      gp1cc_xx=xx*(c11+xx**2*c12)
+   else if (abs(xx-0.5d0)<=1.d-03) then
+      gp1cc_xx=c21+(xx-0.5d0)*(c22+(xx-0.5d0)*(c23+(xx-0.5d0)*(c24+(xx-0.5d0)*c25)))
+   else if (abs(xx-1.d0)<=1.d-03) then
+      gp1cc_xx=c31+(xx-1.0d0)*(c32+(xx-1.0d0)*(c33+(xx-1.0d0)*(c34+(xx-1.0d0)*c35)))
+   else
 !  Here is the repeated part ...
-   denom=1.d0/(xx*(1.d0-4.d0*xx**2)*(1.d0-xx**2))
-   phi=denom*sin(two_pi*xx)*two_pim1
-   phip=denom*(cos(two_pi*xx)-(1.d0-xx**2*(15.d0-xx**2*20))*phi)
-   gp1cc_xx=2.d0*phi*phip
- end if
+      denom=1.d0/(xx*(1.d0-4.d0*xx**2)*(1.d0-xx**2))
+      phi=denom*sin(two_pi*xx)*two_pim1
+      phip=denom*(cos(two_pi*xx)-(1.d0-xx**2*(15.d0-xx**2*20))*phi)
+      gp1cc_xx=2.d0*phi*phip
+   end if
 
 end subroutine gp1cc
 !!***

--- a/src/gpp1cc.f90
+++ b/src/gpp1cc.f90
@@ -29,127 +29,127 @@
 
 subroutine gpp1cc(gpp1cc_xx,xx)
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
- real(dp), parameter :: pi=3.141592653589793238462643383279502884197_dp
- real(dp), parameter :: two_pi=2.0d0*pi
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
+   real(dp), parameter :: pi=3.141592653589793238462643383279502884197_dp
+   real(dp), parameter :: two_pi=2.0d0*pi
 
 !Arguments ------------------------------------
 !scalars
- real(dp),intent(in) :: xx
- real(dp),intent(out) :: gpp1cc_xx
+   real(dp),intent(in) :: xx
+   real(dp),intent(out) :: gpp1cc_xx
 
 !Local variables -------------------------------------------
 !scalars
- real(dp),parameter :: c2=40.d0/3.d0-32.d0*pi**2/27.d0
- real(dp),parameter :: c3=-8320.d0/81.d0+320.d0*pi**2/27.d0
- real(dp),parameter :: c4=157712.d0/243.d0-320.d0*pi**2/3.d0+512.d0*pi**4/135.d0
- real(dp),parameter :: c5=-18088.d2/729.d0+3328.d2*pi**2/729.d0-5120.d0*pi**4/243.d0
- real(dp),parameter :: c6=485.d0/216.d0-2.d0*pi**2/27.d0
- real(dp),parameter :: c7=-4055.d0/162.d0+50.d0*pi**2/27.d0
- real(dp),parameter :: c8=616697.d0/3888.d0-485.d0*pi**2/27.d0+32.d0*pi**4/135.d0
- real(dp),parameter :: c9=-2933875.d0/3888.d0+81100.d0*pi**2/729.d0-800.d0*pi**4/243.d0
+   real(dp),parameter :: c2=40.d0/3.d0-32.d0*pi**2/27.d0
+   real(dp),parameter :: c3=-8320.d0/81.d0+320.d0*pi**2/27.d0
+   real(dp),parameter :: c4=157712.d0/243.d0-320.d0*pi**2/3.d0+512.d0*pi**4/135.d0
+   real(dp),parameter :: c5=-18088.d2/729.d0+3328.d2*pi**2/729.d0-5120.d0*pi**4/243.d0
+   real(dp),parameter :: c6=485.d0/216.d0-2.d0*pi**2/27.d0
+   real(dp),parameter :: c7=-4055.d0/162.d0+50.d0*pi**2/27.d0
+   real(dp),parameter :: c8=616697.d0/3888.d0-485.d0*pi**2/27.d0+32.d0*pi**4/135.d0
+   real(dp),parameter :: c9=-2933875.d0/3888.d0+81100.d0*pi**2/729.d0-800.d0*pi**4/243.d0
 
 !Series expansion coefficients around xx=0 from Mathematica
- real(dp),parameter :: cpp0=20.d0-8.d0*pi**2/3.d00
+   real(dp),parameter :: cpp0=20.d0-8.d0*pi**2/3.d00
 
- real(dp),parameter :: cpp2=804.d0-160.d0*pi**2+(128.d0*pi**4)/15.d0
+   real(dp),parameter :: cpp2=804.d0-160.d0*pi**2+(128.d0*pi**4)/15.d0
 
- real(dp),parameter :: cpp4=11400.d0-2680.d0*pi**2 &
-&                          +(640.d0*pi**4)/3.d0-(128.d0*pi**6)/21.d0
- 
- real(dp),parameter :: cpp6=8.d0*(27967275.d0-7182000.d0*pi**2 &
-&                          +675360.d0*pi**4 &
-&                          -28800.d0*pi**6+512.d0*pi**8)/2025.d0
+   real(dp),parameter :: cpp4=11400.d0-2680.d0*pi**2 &
+   &                          +(640.d0*pi**4)/3.d0-(128.d0*pi**6)/21.d0
 
- real(dp) :: t1,t10,t100,t11,t12,t120,t121,t122,t127,t138,t14,t140,t15,t152
- real(dp) :: t157,t16,t160,t17,t174,t175,t18,t19,t2,t20,t21,t23,t24,t3,t31,t33
- real(dp) :: t34,t4,t41,t42,t44,t45,t46,t5,t54,t55,t56,t57,t6,t62,t64,t65,t7
- real(dp) :: t72,t78,t79,t8,t85,t9,t93
+   real(dp),parameter :: cpp6=8.d0*(27967275.d0-7182000.d0*pi**2 &
+   &                          +675360.d0*pi**4 &
+   &                          -28800.d0*pi**6+512.d0*pi**8)/2025.d0
+
+   real(dp) :: t1,t10,t100,t11,t12,t120,t121,t122,t127,t138,t14,t140,t15,t152
+   real(dp) :: t157,t16,t160,t17,t174,t175,t18,t19,t2,t20,t21,t23,t24,t3,t31,t33
+   real(dp) :: t34,t4,t41,t42,t44,t45,t46,t5,t54,t55,t56,t57,t6,t62,t64,t65,t7
+   real(dp) :: t72,t78,t79,t8,t85,t9,t93
 
 ! *************************************************************************
 
- if (xx>3.0d0) then
+   if (xx>3.0d0) then
 !  Cut off beyond 3/gcut=3*xcccrc
-   gpp1cc_xx=0.0d0
+      gpp1cc_xx=0.0d0
 !  Take care of difficult limits near xx=0, 1/2, and 1
- else if (abs(xx)<=1.d-03) then
-   gpp1cc_xx=cpp0+cpp2*xx**2+cpp4*xx**4+cpp6*xx**6
- else if (abs(xx-0.5d0)<=1.d-04) then
+   else if (abs(xx)<=1.d-03) then
+      gpp1cc_xx=cpp0+cpp2*xx**2+cpp4*xx**4+cpp6*xx**6
+   else if (abs(xx-0.5d0)<=1.d-04) then
 !  (this limit and next are more troublesome for numerical cancellation)
-   gpp1cc_xx=c2+(xx-0.5d0)*(c3+(xx-0.5d0)*(c4+(xx-0.5d0)*c5))
- else if (abs(xx-1.d0)<=1.d-04) then
-   gpp1cc_xx=c6+(xx-1.0d0)*(c7+(xx-1.0d0)*(c8+(xx-1.0d0)*c9))
- else
+      gpp1cc_xx=c2+(xx-0.5d0)*(c3+(xx-0.5d0)*(c4+(xx-0.5d0)*c5))
+   else if (abs(xx-1.d0)<=1.d-04) then
+      gpp1cc_xx=c6+(xx-1.0d0)*(c7+(xx-1.0d0)*(c8+(xx-1.0d0)*c9))
+   else
 
 !  Should fix up this Maple fortran later
-   t1 = xx**2
-   t2 = 1/t1
-   t3 = 1/Pi
-   t4 = 2*xx
-   t5 = t4-1
-   t6 = t5**2
-   t7 = 1/t6
-   t8 = t4+1
-   t9 = t8**2
-   t10 = 1/t9
-   t11 = xx-1
-   t12 = t11**2
-   t14 = 1/t12/t11
-   t15 = xx+1
-   t16 = t15**2
-   t17 = 1/t16
-   t18 = Pi*xx
-   t19 = sin(t18)
-   t20 = cos(t18)
-   t21 = t20**2
-   t23 = t19*t21*t20
-   t24 = t17*t23
-   t31 = t19**2
-   t33 = t31*t19*t20
-   t34 = t17*t33
-   t41 = Pi**2
-   t42 = 1/t41
-   t44 = 1/t16/t15
-   t45 = t31*t21
-   t46 = t44*t45
-   t54 = 1/t1/xx
-   t55 = 1/t12
-   t56 = t55*t46
-   t57 = t10*t56
-   t62 = t9**2
-   t64 = t17*t45
-   t65 = t55*t64
-   t72 = 1/t9/t8
-   t78 = t14*t64
-   t79 = t10*t78
-   t85 = t12**2
-   t93 = t21**2
-   t100 = t31**2
-   t120 = 1/t6/t5
-   t121 = t55*t34
-   t122 = t10*t121
-   t127 = t16**2
-   t138 = t6**2
-   t140 = t10*t65
-   t152 = t72*t65
-   t157 = t7*t140
-   t160 = t1**2
-   t174 = t55*t24
-   t175 = t10*t174
-   gpp1cc_xx = 8*t2*t3*t7*t10*t14*t34+8*t2*t42*t7*t10*t14*t46&
-&   -8*t2*t3*t7*t10*t14*t24+8*t2*t3*t7*t10*t55*t44*t33+&
-&   6*t2*t42*t7*t10*t55/t127*t45+24*t2*t42/t138*t140+&
-&   16*t54*t42*t120*t140+16*t2*t3*t120*t122+16*t2&
-&   *t42*t7*t72*t78-8*t2*t3*t7*t10*t55*t44*t23-8*t54*t3*t7*t175&
-&   +2*t2*t7*t10*t55*t17*t100+2*t2*t7*t10*t55*t17*t93+&
-&   8*t54*t42*t7*t79+16*t2*t42*t7*t72*t56+6*t2*t42*t7*t10/t85&
-&   *t64+24*t2*t42*t7/t62*t65+8*t54*t42*t7*t57-&
-&   16*t2*t3*t7*t72*t174+8*t54*t3*t7*t122-16*t2*t3*t120*t175&
-&   +16*t2*t42*t120*t79+16*t2*t42*t120*t57+16*t54*t42*t7*t152+&
-&   32*t2*t42*t120*t152+16*t2*t3*t7*t72*t121-12*t2*t157+&
-&   6/t160*t42*t157
- end if
+      t1 = xx**2
+      t2 = 1/t1
+      t3 = 1/Pi
+      t4 = 2*xx
+      t5 = t4-1
+      t6 = t5**2
+      t7 = 1/t6
+      t8 = t4+1
+      t9 = t8**2
+      t10 = 1/t9
+      t11 = xx-1
+      t12 = t11**2
+      t14 = 1/t12/t11
+      t15 = xx+1
+      t16 = t15**2
+      t17 = 1/t16
+      t18 = Pi*xx
+      t19 = sin(t18)
+      t20 = cos(t18)
+      t21 = t20**2
+      t23 = t19*t21*t20
+      t24 = t17*t23
+      t31 = t19**2
+      t33 = t31*t19*t20
+      t34 = t17*t33
+      t41 = Pi**2
+      t42 = 1/t41
+      t44 = 1/t16/t15
+      t45 = t31*t21
+      t46 = t44*t45
+      t54 = 1/t1/xx
+      t55 = 1/t12
+      t56 = t55*t46
+      t57 = t10*t56
+      t62 = t9**2
+      t64 = t17*t45
+      t65 = t55*t64
+      t72 = 1/t9/t8
+      t78 = t14*t64
+      t79 = t10*t78
+      t85 = t12**2
+      t93 = t21**2
+      t100 = t31**2
+      t120 = 1/t6/t5
+      t121 = t55*t34
+      t122 = t10*t121
+      t127 = t16**2
+      t138 = t6**2
+      t140 = t10*t65
+      t152 = t72*t65
+      t157 = t7*t140
+      t160 = t1**2
+      t174 = t55*t24
+      t175 = t10*t174
+      gpp1cc_xx = 8*t2*t3*t7*t10*t14*t34+8*t2*t42*t7*t10*t14*t46&
+      &   -8*t2*t3*t7*t10*t14*t24+8*t2*t3*t7*t10*t55*t44*t33+&
+      &   6*t2*t42*t7*t10*t55/t127*t45+24*t2*t42/t138*t140+&
+      &   16*t54*t42*t120*t140+16*t2*t3*t120*t122+16*t2&
+      &   *t42*t7*t72*t78-8*t2*t3*t7*t10*t55*t44*t23-8*t54*t3*t7*t175&
+      &   +2*t2*t7*t10*t55*t17*t100+2*t2*t7*t10*t55*t17*t93+&
+      &   8*t54*t42*t7*t79+16*t2*t42*t7*t72*t56+6*t2*t42*t7*t10/t85&
+      &   *t64+24*t2*t42*t7/t62*t65+8*t54*t42*t7*t57-&
+      &   16*t2*t3*t7*t72*t174+8*t54*t3*t7*t122-16*t2*t3*t120*t175&
+      &   +16*t2*t42*t120*t79+16*t2*t42*t120*t57+16*t54*t42*t7*t152+&
+      &   32*t2*t42*t120*t152+16*t2*t3*t7*t72*t121-12*t2*t157+&
+      &   6/t160*t42*t157
+   end if
 
 end subroutine gpp1cc
 !!***

--- a/src/ldiracfb.f90
+++ b/src/ldiracfb.f90
@@ -2,21 +2,21 @@
 ! Copyright (c) 1989-2012 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- subroutine ldiracfb(nn,ll,kap,ierr,ee,rr,zz,vv,uu,up,mmax,mch)
+subroutine ldiracfb(nn,ll,kap,ierr,ee,rr,zz,vv,uu,up,mmax,mch)
 
 ! Finds relativistic bound states of an al-electron potential
 
@@ -33,269 +33,268 @@
 !mmax  size of log grid
 !mch matching mesh point for inward-outward integrations
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !Input variables
- real(dp) :: rr(mmax),vv(mmax)
- real(dp) :: zz
- integer :: nn,ll,kap,mmax
+   real(dp) :: rr(mmax),vv(mmax)
+   real(dp) :: zz
+   integer :: nn,ll,kap,mmax
 
 !Output variables
- real(dp) :: uu(mmax,2),up(mmax,2)
- real(dp) :: ee
- integer :: ierr,mch
+   real(dp) :: uu(mmax,2),up(mmax,2)
+   real(dp) :: ee
+   integer :: ierr,mch
 
 !Local Variables
 
- real(dp), allocatable :: gu(:),fu(:),gup(:),fup(:),cf(:)
+   real(dp), allocatable :: gu(:),fu(:),gup(:),fup(:),cf(:)
 
- real(dp) :: aei,aeo,aii,aio !functions in aeo.f90
- real(dp) :: cc,cci,gam,cof
- real(dp) :: de,emax,emin
- real(dp) :: eps,ro,sc
- real(dp) :: sls,sn,cn,uout,upin,upout,xkap
- real(dp) :: amesh,al,als
- integer :: ii,kk,nint,node,nin
+   real(dp) :: aei,aeo,aii,aio  !functions in aeo.f90
+   real(dp) :: cc,cci,gam,cof
+   real(dp) :: de,emax,emin
+   real(dp) :: eps,ro,sc
+   real(dp) :: sls,sn,cn,uout,upin,upout,xkap
+   real(dp) :: amesh,al,als
+   integer :: ii,kk,nint,node,nin
 
- cc=137.036d0
- cci=1.0d0/cc
+   cc=137.036d0
+   cci=1.0d0/cc
 
- al = 0.01d0 * dlog(rr(101) / rr(1))
- amesh = exp(al)
+   al = 0.01d0 * dlog(rr(101) / rr(1))
+   amesh = exp(al)
 
 ! convergence factor for solution of Dirac eq.  if calculated
 ! correction to eigenvalue is smaller in magnitude than eps times
 ! the magnitude of the current guess, the current guess is not changed.
- eps=1.0d-10
- ierr = 60
+   eps=1.0d-10
+   ierr = 60
 
 ! check arguments
- if(ll>nn-1) then
-  write(6,'(/a,i4,a,i4)') 'ldiracfb: ERROR ll =',ll,' > nn =',nn
-  ierr=1
-  return
- end if
- if(kap/=ll .and. kap/=-(ll+1)) then
-  write(6,'(/a,i4,a,i4)') 'ldiracfb: ERROR kap =',kap,' ll =',ll
-  ierr=2
-  return
- end if
- if(zz<1.0d0) then
-  write(6,'(/a,f12.8)') 'ldiracfb: ERROR zz =',zz
-  ierr=3
-  return
- end if
+   if(ll>nn-1) then
+      write(6,'(/a,i4,a,i4)') 'ldiracfb: ERROR ll =',ll,' > nn =',nn
+      ierr=1
+      return
+   end if
+   if(kap/=ll .and. kap/=-(ll+1)) then
+      write(6,'(/a,i4,a,i4)') 'ldiracfb: ERROR kap =',kap,' ll =',ll
+      ierr=2
+      return
+   end if
+   if(zz<1.0d0) then
+      write(6,'(/a,f12.8)') 'ldiracfb: ERROR zz =',zz
+      ierr=3
+      return
+   end if
 
- sls=ll*(ll+1)
+   sls=ll*(ll+1)
 
 ! usual limits from non-relativistic Schroedinger eq. should be OK
- emax=vv(mmax)+0.5d0*sls/rr(mmax)**2
- emin=emax
- do ii=1,mmax
-   emin=dmin1(emin,vv(ii)+0.5d0*sls/rr(ii)**2)
- end do
- emin=dmax1(emin,-zz**2/nn**2)
- if(ee>emax) ee=0.5d0*(emax+emin)
- if(ee<emin) ee=0.5d0*(emax+emin)
- if(ee>emax) ee=0.5d0*(emax+emin)
+   emax=vv(mmax)+0.5d0*sls/rr(mmax)**2
+   emin=emax
+   do ii=1,mmax
+      emin=dmin1(emin,vv(ii)+0.5d0*sls/rr(ii)**2)
+   end do
+   emin=dmax1(emin,-zz**2/nn**2)
+   if(ee>emax) ee=0.5d0*(emax+emin)
+   if(ee<emin) ee=0.5d0*(emax+emin)
+   if(ee>emax) ee=0.5d0*(emax+emin)
 
- allocate(gu(mmax),fu(mmax),gup(mmax),fup(mmax),cf(mmax))
+   allocate(gu(mmax),fu(mmax),gup(mmax),fup(mmax),cf(mmax))
 
 ! null arrays
- gu(:)=0.0d0; fu(:)=0.0d0; gup(:)=0.0d0; fup(:)=0.0d0; cf(:)=0.0d0
+   gu(:)=0.0d0; fu(:)=0.0d0; gup(:)=0.0d0; fup(:)=0.0d0; cf(:)=0.0d0
 
- gam=sqrt(kap**2-(zz*cci)**2)
+   gam=sqrt(kap**2-(zz*cci)**2)
 
- cof=(kap+gam)*(cc/zz)
+   cof=(kap+gam)*(cc/zz)
 
 ! return point for bound state convergence
- do nint=1,60
-  
+   do nint=1,60
+
 ! coefficient array for u in Schroedinger eq.
-   do ii=1,mmax
-     cf(ii)=sls + 2.0d0*(vv(ii)-ee)*rr(ii)**2
-   end do
-  
+      do ii=1,mmax
+         cf(ii)=sls + 2.0d0*(vv(ii)-ee)*rr(ii)**2
+      end do
+
 ! find classical turning point for matching
-   mch=0
-   do ii=mmax,2,-1
-     if(cf(ii-1)<=0.d0 .and. cf(ii)>0.d0) then
-       mch=ii
-       exit
-     end if
-   end do
+      mch=0
+      do ii=mmax,2,-1
+         if(cf(ii-1)<=0.d0 .and. cf(ii)>0.d0) then
+            mch=ii
+            exit
+         end if
+      end do
 
-   if(mch==0) then
-    ierr=-1
-    return
-   end if
-  
+      if(mch==0) then
+         ierr=-1
+         return
+      end if
+
 ! start wavefunctions with series
-   do ii=1,5
-    gu(ii)=rr(ii)**gam
-    fu(ii)=cof*gu(ii)
+      do ii=1,5
+         gu(ii)=rr(ii)**gam
+         fu(ii)=cof*gu(ii)
 
-    fup(ii)= al*rr(ii)*(kap*fu(ii)/rr(ii) &
-&            + cci*(ee + vv(ii))*gu(ii))
+         fup(ii)= al*rr(ii)*(kap*fu(ii)/rr(ii) &
+         &            + cci*(ee + vv(ii))*gu(ii))
 
-    gup(ii)= al*rr(ii)*(-kap*gu(ii)/rr(ii) &
-&            + cci*(2.0d0*cc**2 - ee - vv(ii))*fu(ii))
-   end do
-  
+         gup(ii)= al*rr(ii)*(-kap*gu(ii)/rr(ii) &
+         &            + cci*(2.0d0*cc**2 - ee - vv(ii))*fu(ii))
+      end do
+
 ! outward integration using predictor once, corrector
 ! twice
-   node=0
-   do ii=5,mch-1
+      node=0
+      do ii=5,mch-1
 
-    fu(ii+1)=fu(ii)+aeo(fup,ii)
-    gu(ii+1)=gu(ii)+aeo(gup,ii)
+         fu(ii+1)=fu(ii)+aeo(fup,ii)
+         gu(ii+1)=gu(ii)+aeo(gup,ii)
 
-    do kk=1,2
-     fup(ii+1)= al*rr(ii+1)*(kap*fu(ii+1)/rr(ii+1) &
-&             - cci*(ee - vv(ii+1))*gu(ii+1))
+         do kk=1,2
+            fup(ii+1)= al*rr(ii+1)*(kap*fu(ii+1)/rr(ii+1) &
+            &             - cci*(ee - vv(ii+1))*gu(ii+1))
 
-     gup(ii+1)= al*rr(ii+1)*(-kap*gu(ii+1)/rr(ii+1) &
-&             + cci*(2.0d0*cc**2 + ee - vv(ii+1))*fu(ii+1))
+            gup(ii+1)= al*rr(ii+1)*(-kap*gu(ii+1)/rr(ii+1) &
+            &             + cci*(2.0d0*cc**2 + ee - vv(ii+1))*fu(ii+1))
 
-     fu(ii+1)=fu(ii)+aio(fup,ii)
-     gu(ii+1)=gu(ii)+aio(gup,ii)
-    end do
-    if(gu(ii+1)*gu(ii) .le. 0.0d0) node=node+1
-   end do
+            fu(ii+1)=fu(ii)+aio(fup,ii)
+            gu(ii+1)=gu(ii)+aio(gup,ii)
+         end do
+         if(gu(ii+1)*gu(ii) <= 0.0d0) node=node+1
+      end do
 
-   uout=gu(mch)
-   upout=gup(mch)
-  
-   if(node-nn+ll+1==0) then
-  
+      uout=gu(mch)
+      upout=gup(mch)
+
+      if(node-nn+ll+1==0) then
+
 ! start inward integration at 10*classical turning
 ! point with simple exponential
-  
-     nin=mch+2.3d0/al
-     if(nin+4>mmax) nin=mmax-4
-     xkap=dsqrt(sls/rr(nin)**2 + 2.0d0*(vv(nin)-ee))
-  
-     do ii=nin,nin+4
-       gu(ii)=exp(-xkap*(rr(ii)-rr(nin)))
-       fu(ii)=0.5d0*cci*(-xkap+kap/rr(ii))*gu(ii)
 
-       fup(ii)= al*rr(ii)*(kap*fu(ii)/rr(ii) &
-&               + cci*(ee + vv(ii))*gu(ii))
-       gup(ii)= al*rr(ii)*(-kap*gu(ii)/rr(ii) &
-&               + cci*(2.0d0*cc**2 - ee - vv(ii))*fu(ii))
-     end do
-  
+         nin=mch+2.3d0/al
+         if(nin+4>mmax) nin=mmax-4
+         xkap=dsqrt(sls/rr(nin)**2 + 2.0d0*(vv(nin)-ee))
+
+         do ii=nin,nin+4
+            gu(ii)=exp(-xkap*(rr(ii)-rr(nin)))
+            fu(ii)=0.5d0*cci*(-xkap+kap/rr(ii))*gu(ii)
+
+            fup(ii)= al*rr(ii)*(kap*fu(ii)/rr(ii) &
+            &               + cci*(ee + vv(ii))*gu(ii))
+            gup(ii)= al*rr(ii)*(-kap*gu(ii)/rr(ii) &
+            &               + cci*(2.0d0*cc**2 - ee - vv(ii))*fu(ii))
+         end do
+
 ! integrate inward
-     do ii=nin,mch+1,-1
+         do ii=nin,mch+1,-1
 
-      fu(ii-1)=fu(ii)+aei(fup,ii)
-      gu(ii-1)=gu(ii)+aei(gup,ii)
+            fu(ii-1)=fu(ii)+aei(fup,ii)
+            gu(ii-1)=gu(ii)+aei(gup,ii)
 
-      do kk=1,2
-       fup(ii-1)= al*rr(ii-1)*(kap*fu(ii-1)/rr(ii-1) &
-&               - cci*(ee - vv(ii-1))*gu(ii-1))
+            do kk=1,2
+               fup(ii-1)= al*rr(ii-1)*(kap*fu(ii-1)/rr(ii-1) &
+               &               - cci*(ee - vv(ii-1))*gu(ii-1))
 
-       gup(ii-1)= al*rr(ii-1)*(-kap*gu(ii-1)/rr(ii-1) &
-&               + cci*(2.0d0*cc**2 + ee - vv(ii-1))*fu(ii-1))
+               gup(ii-1)= al*rr(ii-1)*(-kap*gu(ii-1)/rr(ii-1) &
+               &               + cci*(2.0d0*cc**2 + ee - vv(ii-1))*fu(ii-1))
 
-       fu(ii-1)=fu(ii)+aii(fup,ii)
-       gu(ii-1)=gu(ii)+aii(gup,ii)
-      end do
-     end do
-  
+               fu(ii-1)=fu(ii)+aii(fup,ii)
+               gu(ii-1)=gu(ii)+aii(gup,ii)
+            end do
+         end do
+
 ! scale outside wf for continuity
-  
-     sc=uout/gu(mch)
-  
-     do ii=mch,nin
-       gup(ii)=sc*gup(ii)
-       gu(ii)=sc*gu(ii)
-       fup(ii)=sc*gup(ii)
-       fu(ii)=sc*fu(ii)
-     end do
-  
-     upin=gup(mch)
-  
+
+         sc=uout/gu(mch)
+
+         do ii=mch,nin
+            gup(ii)=sc*gup(ii)
+            gu(ii)=sc*gu(ii)
+            fup(ii)=sc*gup(ii)
+            fu(ii)=sc*fu(ii)
+         end do
+
+         upin=gup(mch)
+
 ! perform normalization sum
-  
-     ro=rr(1)/dsqrt(amesh)
-     sn=((1.0d0+cof**2)*ro**(2.0d0*gam+1.0d0))/(2.0d0*gam+1.0d0)
-  
-     do ii=1,nin-3
-       sn=sn+al*rr(ii)*(gu(ii)**2 + fu(ii)**2)
-     end do
-  
-     sn=sn + al*(23.0d0*rr(nin-2)*(gu(nin-2)**2 + fu(nin-2)**2) &
-&              + 28.0d0*rr(nin-1)*(gu(nin-1)**2 + fu(nin-1)**2) &
-&              +  9.0d0*rr(nin  )*(gu(nin  )**2 + fu(nin  )**2))/24.0d0
-  
+
+         ro=rr(1)/dsqrt(amesh)
+         sn=((1.0d0+cof**2)*ro**(2.0d0*gam+1.0d0))/(2.0d0*gam+1.0d0)
+
+         do ii=1,nin-3
+            sn=sn+al*rr(ii)*(gu(ii)**2 + fu(ii)**2)
+         end do
+
+         sn=sn + al*(23.0d0*rr(nin-2)*(gu(nin-2)**2 + fu(nin-2)**2) &
+         &              + 28.0d0*rr(nin-1)*(gu(nin-1)**2 + fu(nin-1)**2) &
+         &              +  9.0d0*rr(nin  )*(gu(nin  )**2 + fu(nin  )**2))/24.0d0
+
 ! normalize u
-  
-     cn=1.0d0/dsqrt(sn)
-     uout=cn*uout
-     upout=cn*upout
-     upin=cn*upin
-  
-     do ii=1,nin
-       gup(ii)=cn*gup(ii)
-       gu(ii)=cn*gu(ii)
-       fup(ii)=cn*fup(ii)
-       fu(ii)=cn*fu(ii)
-     end do
-     do ii=nin+1,mmax
-       gu(ii)=0.0d0
-       fu(ii)=0.0d0
-     end do
-  
+
+         cn=1.0d0/dsqrt(sn)
+         uout=cn*uout
+         upout=cn*upout
+         upin=cn*upin
+
+         do ii=1,nin
+            gup(ii)=cn*gup(ii)
+            gu(ii)=cn*gu(ii)
+            fup(ii)=cn*fup(ii)
+            fu(ii)=cn*fu(ii)
+         end do
+         do ii=nin+1,mmax
+            gu(ii)=0.0d0
+            fu(ii)=0.0d0
+         end do
+
 ! perturbation theory for energy shift based on large component
 ! continuity of small component should follow
-  
-     de=0.5d0*uout*(upout-upin)/(al*rr(mch))
-  
+
+         de=0.5d0*uout*(upout-upin)/(al*rr(mch))
+
 ! convergence test and possible exit
-  
-     if(dabs(de)<dmax1(dabs(ee),0.2d0)*eps) then
-       ierr = 0
-       exit
-     end if
-  
-     if(de>0.0d0) then 
-       emin=ee
-     else
-       emax=ee
-     end if
-     ee=ee+de
-     if(ee>emax .or. ee<emin) ee=0.5d0*(emax+emin)
-  
-   else if(node-nn+ll+1<0) then
+
+         if(dabs(de)<dmax1(dabs(ee),0.2d0)*eps) then
+            ierr = 0
+            exit
+         end if
+
+         if(de>0.0d0) then
+            emin=ee
+         else
+            emax=ee
+         end if
+         ee=ee+de
+         if(ee>emax .or. ee<emin) ee=0.5d0*(emax+emin)
+
+      else if(node-nn+ll+1<0) then
 ! too few nodes
-     emin=ee
-     ee=0.5d0*(emin+emax)
-  
-   else
+         emin=ee
+         ee=0.5d0*(emin+emax)
+
+      else
 ! too many nodes
-     emax=ee
-     ee=0.5d0*(emin+emax)
-   end if
-  
- end do
+         emax=ee
+         ee=0.5d0*(emin+emax)
+      end if
+
+   end do
 
 ! copy local arrays for output
- uu(:,1)=gu(:)
- up(:,1)=gup(:)
- uu(:,2)=fu(:)
- up(:,2)=fup(:)
+   uu(:,1)=gu(:)
+   up(:,1)=gup(:)
+   uu(:,2)=fu(:)
+   up(:,2)=fup(:)
 
 !fix sign to be positive at rr->oo
- if(uu(mch,1)<0.0d0) then
-   uu(:,:)=-uu(:,:)
-   up(:,:)=-up(:,:)
- end if
+   if(uu(mch,1)<0.0d0) then
+      uu(:,:)=-uu(:,:)
+      up(:,:)=-up(:,:)
+   end if
 
- deallocate(gu,fu,gup,fup)
- deallocate(cf)
- return
+   deallocate(gu,fu,gup,fup)
+   deallocate(cf)
+   return
 
- end subroutine ldiracfb
-
+end subroutine ldiracfb

--- a/src/ldiracfs.f90
+++ b/src/ldiracfs.f90
@@ -2,21 +2,21 @@
 ! Copyright (c) 1989-2012 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- subroutine ldiracfs(nn,ll,kap,ierr,ee,rr,zz,vv,uu,up,mmax,mch)
+subroutine ldiracfs(nn,ll,kap,ierr,ee,rr,zz,vv,uu,up,mmax,mch)
 
 ! Finds relativistic scattering states of an al-electron potential
 
@@ -33,146 +33,145 @@
 !mmax  size of log grid
 !mch matching mesh point for inward-outward integrations
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !Input variables
- real(dp) :: rr(mmax),vv(mmax)
- real(dp) :: zz
- integer :: ll,kap,mmax
+   real(dp) :: rr(mmax),vv(mmax)
+   real(dp) :: zz
+   integer :: ll,kap,mmax
 
 !Output variables
- real(dp) :: uu(mmax,2),up(mmax,2)
- real(dp) :: ee
- integer :: ierr,mch,nn
+   real(dp) :: uu(mmax,2),up(mmax,2)
+   real(dp) :: ee
+   integer :: ierr,mch,nn
 
 !Local Variables
 
- real(dp), allocatable :: gu(:),fu(:),gup(:),fup(:),cf(:)
+   real(dp), allocatable :: gu(:),fu(:),gup(:),fup(:),cf(:)
 
- real(dp) :: aei,aeo,aii,aio !functions in aeo.f90
- real(dp) :: cc,cci,gam,cof
- real(dp) :: de,emax,emin
- real(dp) :: eps,ro,sc
- real(dp) :: sls,sn,cn,uout,upout,xkap
- real(dp) :: amesh,al,als
- integer :: ii,kk,nint,nin,node
+   real(dp) :: aei,aeo,aii,aio  !functions in aeo.f90
+   real(dp) :: cc,cci,gam,cof
+   real(dp) :: de,emax,emin
+   real(dp) :: eps,ro,sc
+   real(dp) :: sls,sn,cn,uout,upout,xkap
+   real(dp) :: amesh,al,als
+   integer :: ii,kk,nint,nin,node
 
- cc=137.036d0
- cci=1.0d0/cc
+   cc=137.036d0
+   cci=1.0d0/cc
 
- al = 0.01d0 * dlog(rr(101) / rr(1))
- amesh = exp(al)
+   al = 0.01d0 * dlog(rr(101) / rr(1))
+   amesh = exp(al)
 
 ! convergence factor for solution of Dirac eq.  if calculated
 ! correction to eigenvalue is smaller in magnitude than eps times
 ! the magnitude of the current guess, the current guess is not changed.
- eps=1.0d-10
- ierr = 60
+   eps=1.0d-10
+   ierr = 60
 
 ! check arguments
- if(kap/=ll .and. kap/=-(ll+1)) then
-  write(6,'(/a,i4,a,i4)') 'ldiracfs: ERROR kap =',kap,' ll =',ll
-  ierr=2
-  return
- end if
- if(zz<1.0d0) then
-  write(6,'(/a,f12.8)') 'ldiracfs: ERROR zz =',zz
-  ierr=3
-  return
- end if
+   if(kap/=ll .and. kap/=-(ll+1)) then
+      write(6,'(/a,i4,a,i4)') 'ldiracfs: ERROR kap =',kap,' ll =',ll
+      ierr=2
+      return
+   end if
+   if(zz<1.0d0) then
+      write(6,'(/a,f12.8)') 'ldiracfs: ERROR zz =',zz
+      ierr=3
+      return
+   end if
 
- allocate(gu(mmax),fu(mmax),gup(mmax),fup(mmax),cf(mmax))
+   allocate(gu(mmax),fu(mmax),gup(mmax),fup(mmax),cf(mmax))
 
 ! null arrays
- gu(:)=0.0d0; fu(:)=0.0d0; gup(:)=0.0d0; fup(:)=0.0d0; cf(:)=0.0d0
+   gu(:)=0.0d0; fu(:)=0.0d0; gup(:)=0.0d0; fup(:)=0.0d0; cf(:)=0.0d0
 
- node=0
- ierr=0
+   node=0
+   ierr=0
 
- gam=sqrt(kap**2-(zz*cci)**2)
+   gam=sqrt(kap**2-(zz*cci)**2)
 
- cof=(kap+gam)*(cc/zz)
-  
+   cof=(kap+gam)*(cc/zz)
+
 ! start wavefunctions with series
- do ii=1,5
-  gu(ii)=rr(ii)**gam
-  fu(ii)=cof*gu(ii)
+   do ii=1,5
+      gu(ii)=rr(ii)**gam
+      fu(ii)=cof*gu(ii)
 
-  fup(ii)= al*rr(ii)*(kap*fu(ii)/rr(ii) &
-         + cci*(ee + vv(ii))*gu(ii))
+      fup(ii)= al*rr(ii)*(kap*fu(ii)/rr(ii) &
+                          + cci*(ee + vv(ii))*gu(ii))
 
-  gup(ii)= al*rr(ii)*(-kap*gu(ii)/rr(ii) &
-           + cci*(2.0d0*cc**2 - ee - vv(ii))*fu(ii))
- end do
-  
+      gup(ii)= al*rr(ii)*(-kap*gu(ii)/rr(ii) &
+                          + cci*(2.0d0*cc**2 - ee - vv(ii))*fu(ii))
+   end do
+
 ! outward integration using predictor once, corrector
 ! twice
- do ii=5,mch-1
+   do ii=5,mch-1
 
-  fu(ii+1)=fu(ii)+aeo(fup,ii)
-  gu(ii+1)=gu(ii)+aeo(gup,ii)
+      fu(ii+1)=fu(ii)+aeo(fup,ii)
+      gu(ii+1)=gu(ii)+aeo(gup,ii)
 
-  do kk=1,2
-   fup(ii+1)= al*rr(ii+1)*(kap*fu(ii+1)/rr(ii+1) &
-            - cci*(ee - vv(ii+1))*gu(ii+1))
+      do kk=1,2
+         fup(ii+1)= al*rr(ii+1)*(kap*fu(ii+1)/rr(ii+1) &
+                                 - cci*(ee - vv(ii+1))*gu(ii+1))
 
-   gup(ii+1)= al*rr(ii+1)*(-kap*gu(ii+1)/rr(ii+1) &
-            + cci*(2.0d0*cc**2 + ee - vv(ii+1))*fu(ii+1))
+         gup(ii+1)= al*rr(ii+1)*(-kap*gu(ii+1)/rr(ii+1) &
+                                 + cci*(2.0d0*cc**2 + ee - vv(ii+1))*fu(ii+1))
 
-   fu(ii+1)=fu(ii)+aio(fup,ii)
-   gu(ii+1)=gu(ii)+aio(gup,ii)
-  end do
-  if(gu(ii+1)*gu(ii) .le. 0.0d0) node=node+1
- end do
+         fu(ii+1)=fu(ii)+aio(fup,ii)
+         gu(ii+1)=gu(ii)+aio(gup,ii)
+      end do
+      if(gu(ii+1)*gu(ii) <= 0.0d0) node=node+1
+   end do
 
- uout=gu(mch)
- upout=gup(mch)
-  
-  
+   uout=gu(mch)
+   upout=gup(mch)
+
+
 ! perform normalization sum
-  
- ro=rr(1)/dsqrt(amesh)
- sn=((1.0d0+cof**2)*ro**(2.0d0*gam+1.0d0))/(2.0d0*gam+1.0d0)
-  
- do ii=1,mch-3
-   sn=sn+al*rr(ii)*(gu(ii)**2 + fu(ii)**2)
- end do
-  
- sn=sn + al*(23.0d0*rr(mch-2)*(gu(mch-2)**2 + fu(mch-2)**2) &
-           + 28.0d0*rr(mch-1)*(gu(mch-1)**2 + fu(mch-1)**2) &
-&              +  9.0d0*rr(mch  )*(gu(mch  )**2 + fu(mch  )**2))/24.0d0
-  
+
+   ro=rr(1)/dsqrt(amesh)
+   sn=((1.0d0+cof**2)*ro**(2.0d0*gam+1.0d0))/(2.0d0*gam+1.0d0)
+
+   do ii=1,mch-3
+      sn=sn+al*rr(ii)*(gu(ii)**2 + fu(ii)**2)
+   end do
+
+   sn=sn + al*(23.0d0*rr(mch-2)*(gu(mch-2)**2 + fu(mch-2)**2) &
+               + 28.0d0*rr(mch-1)*(gu(mch-1)**2 + fu(mch-1)**2) &
+   &              +  9.0d0*rr(mch  )*(gu(mch  )**2 + fu(mch  )**2))/24.0d0
+
 ! normalize u
-  
- cn=1.0d0/dsqrt(sn)
- uout=cn*uout
- upout=cn*upout
-  
- do ii=1,mch
-   gup(ii)=cn*gup(ii)
-   gu(ii)=cn*gu(ii)
-   fup(ii)=cn*fup(ii)
-   fu(ii)=cn*fu(ii)
- end do
- do ii=mch+1,mmax
-   gu(ii)=0.0d0
-   fu(ii)=0.0d0
- end do
+
+   cn=1.0d0/dsqrt(sn)
+   uout=cn*uout
+   upout=cn*upout
+
+   do ii=1,mch
+      gup(ii)=cn*gup(ii)
+      gu(ii)=cn*gu(ii)
+      fup(ii)=cn*fup(ii)
+      fu(ii)=cn*fu(ii)
+   end do
+   do ii=mch+1,mmax
+      gu(ii)=0.0d0
+      fu(ii)=0.0d0
+   end do
 
 ! copy local arrays for output
- uu(:,1)=gu(:)
- up(:,1)=gup(:)
- uu(:,2)=fu(:)
- up(:,2)=fup(:)
+   uu(:,1)=gu(:)
+   up(:,1)=gup(:)
+   uu(:,2)=fu(:)
+   up(:,2)=fup(:)
 
 !calculate effective principal quantum number as if this were a bound
 !state with a barrier at mch
- nn=node+ll+1
+   nn=node+ll+1
 
- deallocate(gu,fu,gup,fup)
- deallocate(cf)
- return
+   deallocate(gu,fu,gup,fup)
+   deallocate(cf)
+   return
 
- end subroutine ldiracfs
-
+end subroutine ldiracfs

--- a/src/linout.f90
+++ b/src/linout.f90
@@ -2,24 +2,24 @@
 ! Copyright (c) 1989-2017 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
 ! interpolates various arrays onto linear radial mesh to create file
 ! for Abinit input using pspcod=8
 
- subroutine linout(lmax,lloc,rc,vkb,evkb,nproj,rr,vpuns,rho,rhomod, &
+subroutine linout(lmax,lloc,rc,vkb,evkb,nproj,rr,vpuns,rho,rhomod, &
 &                  rhotae,rhoc,zz,zion,mmax,mxprj,iexc,icmod,nrl,drl,atsym, &
 &                  na,la,ncon,nbas,nvcnf,nacnf,lacnf,nc,nv,lpopt,ncnf, &
 &                  fa,rc0,ep,qcut,debl,facnf,dvloc0,fcfact,rcfact, &
@@ -33,7 +33,7 @@
 !evkb  coefficients of VKB projectors
 !nproj  number of vkb projectors for each l
 !rr  log radial grid
-!vpuns  unscreened semi-local pseudopotentials (vp(:,5) is local potential 
+!vpuns  unscreened semi-local pseudopotentials (vp(:,5) is local potential
 !  if linear combination is used)
 !rho  valence pseudocharge
 !rhomod  model core charge
@@ -54,221 +54,221 @@
 !  epsh1,epsh2,depsh,rlmax,psfile
 !psfile  should be 'psp8' or 'both'
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !Input variables
- integer :: lmax,lloc,iexc,mmax,mxprj,nrl,icmod
- integer :: nproj(6)
- real(dp) :: drl,fcfact,rcfact,zz,zion
- real(dp) :: rr(mmax),vpuns(mmax,5),rho(mmax),vkb(mmax,mxprj,4)
- real(dp) :: rhotae(mmax),rhoc(mmax)
- real(dp) :: rhomod(mmax,5)
- real(dp):: rc(6),evkb(mxprj,4)
- character*2 :: atsym
+   integer :: lmax,lloc,iexc,mmax,mxprj,nrl,icmod
+   integer :: nproj(6)
+   real(dp) :: drl,fcfact,rcfact,zz,zion
+   real(dp) :: rr(mmax),vpuns(mmax,5),rho(mmax),vkb(mmax,mxprj,4)
+   real(dp) :: rhotae(mmax),rhoc(mmax)
+   real(dp) :: rhomod(mmax,5)
+   real(dp):: rc(6),evkb(mxprj,4)
+   character(len=2) :: atsym
 
 !additional input for psp8 output to echo input file, all as defined
 ! in the main progam
- integer :: na(30),la(30),ncon(6),nbas(6)
- integer :: nvcnf(5),nacnf(30,5),lacnf(30,5)
- integer :: nc,nv,lpopt,ncnf
- real(dp) :: fa(30),rc0(6),ep(6),qcut(6),debl(6),facnf(30,5)
- real(dp) :: dvloc0,epsh1,epsh2,depsh,rlmax
- character*4 :: psfile
+   integer :: na(30),la(30),ncon(6),nbas(6)
+   integer :: nvcnf(5),nacnf(30,5),lacnf(30,5)
+   integer :: nc,nv,lpopt,ncnf
+   real(dp) :: fa(30),rc0(6),ep(6),qcut(6),debl(6),facnf(30,5)
+   real(dp) :: dvloc0,epsh1,epsh2,depsh,rlmax
+   character(len=4) :: psfile
 
 !Output variables - printing only
 
 !Local variables
- integer :: ii,iprj,jj,ll,l1,ixc_abinit
- integer :: dtime(8)
- real(dp), allocatable :: rhomodl(:,:)
- real(dp),allocatable :: rhol(:),rl(:),vkbl(:,:,:),vpl(:,:)
- real(dp),allocatable :: rhotael(:),rhocl(:)
- character*2 :: pspd(3)
+   integer :: ii,iprj,jj,ll,l1,ixc_abinit
+   integer :: dtime(8)
+   real(dp), allocatable :: rhomodl(:,:)
+   real(dp),allocatable :: rhol(:),rl(:),vkbl(:,:,:),vpl(:,:)
+   real(dp),allocatable :: rhotael(:),rhocl(:)
+   character(len=2) :: pspd(3)
 
 
- allocate(rhol(nrl),rl(nrl),vkbl(nrl,mxprj,4),vpl(nrl,5),rhomodl(nrl,5))
- allocate(rhotael(nrl),rhocl(nrl))
+   allocate(rhol(nrl),rl(nrl),vkbl(nrl,mxprj,4),vpl(nrl,5),rhomodl(nrl,5))
+   allocate(rhotael(nrl),rhocl(nrl))
 
 !
 ! interpolation of everything onto linear output mesh
- 
- do  ii=1,nrl
-   rl(ii)=drl*dble(ii-1)
- end do
+
+   do  ii=1,nrl
+      rl(ii)=drl*dble(ii-1)
+   end do
 !
- do l1=1,max(lmax+1,lloc+1)
-   call dpnint(rr,vpuns(1,l1),mmax,rl,vpl(1,l1),nrl)
+   do l1=1,max(lmax+1,lloc+1)
+      call dpnint(rr,vpuns(1,l1),mmax,rl,vpl(1,l1),nrl)
 
 ! override dpnint extrapolation to zero for vpl
-   vpl(1,l1)=vpuns(1,l1)
+      vpl(1,l1)=vpuns(1,l1)
 
-   if(l1 .ne. lloc + 1) then
-     do iprj=1,nproj(l1)
+      if(l1 /= lloc + 1) then
+         do iprj=1,nproj(l1)
 
-       call dpnint(rr,vkb(1,iprj,l1),mmax,rl,vkbl(1,iprj,l1),nrl)
+            call dpnint(rr,vkb(1,iprj,l1),mmax,rl,vkbl(1,iprj,l1),nrl)
 
-     end do
-   end if
- end do
+         end do
+      end if
+   end do
 
- call dpnint(rr,rho,mmax,rl,rhol,nrl)
- call dpnint(rr,rhotae,mmax,rl,rhotael,nrl)
- call dpnint(rr,rhoc,mmax,rl,rhocl,nrl)
+   call dpnint(rr,rho,mmax,rl,rhol,nrl)
+   call dpnint(rr,rhotae,mmax,rl,rhotael,nrl)
+   call dpnint(rr,rhoc,mmax,rl,rhocl,nrl)
 
- do jj=1,5
-   call dpnint(rr,rhomod(1,jj),mmax,rl,rhomodl(1,jj),nrl)
- end do
+   do jj=1,5
+      call dpnint(rr,rhomod(1,jj),mmax,rl,rhomodl(1,jj),nrl)
+   end do
 
 ! Output for Abinit input using pspcod=8
 
- if(iexc==1) then
-   ixc_abinit=4
- else if(iexc==2) then
-   ixc_abinit=5
- else if(iexc==3) then
-   ixc_abinit=2
- else if(iexc==4) then
-   ixc_abinit=11
- else if(iexc<0) then
-   ixc_abinit=iexc
- end if
+   if(iexc==1) then
+      ixc_abinit=4
+   else if(iexc==2) then
+      ixc_abinit=5
+   else if(iexc==3) then
+      ixc_abinit=2
+   else if(iexc==4) then
+      ixc_abinit=11
+   else if(iexc<0) then
+      ixc_abinit=iexc
+   end if
 
- call date_and_time(VALUES=dtime)
- ii=dtime(1)-2000
- if(ii<10) then
-   write(pspd(1),'(a,i1)') '0',ii
- else
-   write(pspd(1),'(i2)') ii
- end if
- ii=dtime(2)
- if(ii<10) then
-   write(pspd(2),'(a,i1)') '0',ii
- else
-   write(pspd(2),'(i2)') ii
- end if
- ii=dtime(3)
- if(ii<10) then
-   write(pspd(3),'(a,i1)') '0',ii
- else
-   write(pspd(3),'(i2)') ii
- end if
+   call date_and_time(VALUES=dtime)
+   ii=dtime(1)-2000
+   if(ii<10) then
+      write(pspd(1),'(a,i1)') '0',ii
+   else
+      write(pspd(1),'(i2)') ii
+   end if
+   ii=dtime(2)
+   if(ii<10) then
+      write(pspd(2),'(a,i1)') '0',ii
+   else
+      write(pspd(2),'(i2)') ii
+   end if
+   ii=dtime(3)
+   if(ii<10) then
+      write(pspd(3),'(a,i1)') '0',ii
+   else
+      write(pspd(3),'(i2)') ii
+   end if
 
- write(6,'(/a)') 'Begin PSPCODE8'
- write(6,'(3a,4f10.5)') atsym,'    ONCVPSP-4.0.1' &
-&  ,'  r_core=',(rc(l1),l1=1,lmax+1)
- write(6,'(2f12.4, 5a)') zz,zion, '      ', pspd,  &
-&  '    zatom,zion,pspd'
- write(6,'(i6,i8,i4,3i6, a)') 8, ixc_abinit,lmax,lloc, &
-&  nrl, 0, '    pspcod,pspxc,lmax,lloc,mmax,r2well'
- write(6,'(3f12.8, a)') rl(nrl),fcfact, 0.0,  &
-&  '    rchrg fchrg qchrg'
- write(6,'(5i6, a)') (nproj(l1),l1=1,5),  &
-&  '    nproj'
- write(6,'(2i6, a)') 1,1, &
-&  '           extension_switch'
+   write(6,'(/a)') 'Begin PSPCODE8'
+   write(6,'(3a,4f10.5)') atsym,'    ONCVPSP-4.0.1' &
+   &  ,'  r_core=',(rc(l1),l1=1,lmax+1)
+   write(6,'(2f12.4, 5a)') zz,zion, '      ', pspd,  &
+   &  '    zatom,zion,pspd'
+   write(6,'(i6,i8,i4,3i6, a)') 8, ixc_abinit,lmax,lloc, &
+   &  nrl, 0, '    pspcod,pspxc,lmax,lloc,mmax,r2well'
+   write(6,'(3f12.8, a)') rl(nrl),fcfact, 0.0,  &
+   &  '    rchrg fchrg qchrg'
+   write(6,'(5i6, a)') (nproj(l1),l1=1,5),  &
+   &  '    nproj'
+   write(6,'(2i6, a)') 1,1, &
+   &  '           extension_switch'
 
 ! write the VKB projectors and the local potential
- do l1=1,max(lmax+1,lloc+1)
-   ll=l1-1
-   if(ll==lloc) then
-     write(6,'(i4)') ll
-     do ii = 1,nrl
-       write(6,'(i6,1p,2e21.13)') ii,rl(ii),vpl(ii,l1)
-     end do
-   else if(nproj(l1)>0) then
-     write(6,'(i4,23x,1p,6e21.13)') ll,(evkb(jj,l1),jj=1,nproj(l1))
-     do ii = 1,nrl
-       if(rl(ii)<=rc(l1)+2.0d0*drl) then
-         write(6,'(i6,1p,6e21.13)') ii,rl(ii),(vkbl(ii,jj,l1),jj=1,nproj(l1))
-       else
-         write(6,'(i6,f6.2,6f4.0)') ii,rl(ii),(vkbl(ii,jj,l1),jj=1,nproj(l1))
-       end if
-     end do
-   endif
- end do
+   do l1=1,max(lmax+1,lloc+1)
+      ll=l1-1
+      if(ll==lloc) then
+         write(6,'(i4)') ll
+         do ii = 1,nrl
+            write(6,'(i6,1p,2e21.13)') ii,rl(ii),vpl(ii,l1)
+         end do
+      else if(nproj(l1)>0) then
+         write(6,'(i4,23x,1p,6e21.13)') ll,(evkb(jj,l1),jj=1,nproj(l1))
+         do ii = 1,nrl
+            if(rl(ii)<=rc(l1)+2.0d0*drl) then
+               write(6,'(i6,1p,6e21.13)') ii,rl(ii),(vkbl(ii,jj,l1),jj=1,nproj(l1))
+            else
+               write(6,'(i6,f6.2,6f4.0)') ii,rl(ii),(vkbl(ii,jj,l1),jj=1,nproj(l1))
+            end if
+         end do
+      endif
+   end do
 
 
 ! write the model core charge if called for
- if(fcfact>0.0d0) then
-   do ii=1,nrl
-     write(6,'(i6,1p,6e21.13)') ii,rl(ii),  &
-&      (rhomodl(ii,jj),jj=1,5)
-   end do
- end if
+   if(fcfact>0.0d0) then
+      do ii=1,nrl
+         write(6,'(i6,1p,6e21.13)') ii,rl(ii),  &
+         &      (rhomodl(ii,jj),jj=1,5)
+      end do
+   end if
 
 ! write pseudo valence, all-electron valence and all-electron core charges
- do ii=1,nrl
-   write(6,'(i6,1p,4e21.13)') ii,rl(ii),rhol(ii),rhotael(ii),rhocl(ii)
- end do
-
- write(6,'(a)') '<INPUT>'
- write(6,'(a/a/a/a)') &
-&    '#', &
-&    '#ONCVPSP  (Optimized Norm-Conservinng Vanderbilt PSeudopotential)', &
-&    '#scalar-relativistic version 4.0.1 0r/27/2018', &
-&    '#'
-
- write(6,'(a/a/a/a)') &
-&    '#While it is not required under the terms of the GNU GPL, it is',&
-&    '#suggested that you cite D. R. Hamann, Phys. Rev. B 88, 085117 (2013)', &
-&    '#in any publication utilizing these pseudopotentials.', &
-&    '#'
-
- write(6,'(a)') '# ATOM AND REFERENCE CONFIGURATION'
- write(6,'(a)') '# atsym  z   nc   nv     iexc    psfile'
- write(6,'(a,a,f6.2,2i5,i8,2a)') '  ',trim(atsym),zz,nc,nv,iexc, &
-&      '      ',trim(psfile)
- write(6,'(a/a)') '#','#   n    l    f'
- do ii=1,nc+nv
-   write(6,'(2i5,f8.2)') na(ii),la(ii),fa(ii)
- end do
-
- write(6,'(a/a/a)') '#','# PSEUDOPOTENTIAL AND OPTIMIZATION','# lmax'
- write(6,'(i5)')  lmax
- write(6,'(a/a)') '#','#   l,   rc,      ep,       ncon, nbas, qcut'
- do l1=1,lmax+1
-   write(6,'(i5,2f10.5,2i5,f10.5)') l1-1,rc0(l1),ep(l1),ncon(l1),&
-&        nbas(l1),qcut(l1)
- end do
-
- write(6,'(a/a/a,a)') '#','# LOCAL POTENTIAL','# lloc, lpopt,  rc(5),', &
-&      '   dvloc0'
- write(6,'(2i5,f10.5,a,f10.5)') lloc,lpopt,rc0(5),'   ',dvloc0
-
- write(6,'(a/a/a)') '#','# VANDERBILT-KLEINMAN-BYLANDER PROJECTORs', &
-&      '# l, nproj, debl'
- do l1=1,lmax+1
-   write(6,'(2i5,f10.5)') l1-1,nproj(l1),debl(l1)
- end do
-
- write(6,'(a/a/a)') '#','# MODEL CORE CHARGE', &
-&      '# icmod, fcfact, rcfact'
- write(6,'(i5,2f10.5)') icmod,fcfact,rcfact
-
- write(6,'(a/a/a)') '#','# LOG DERIVATIVE ANALYSIS', &
-&      '# epsh1, epsh2, depsh'
- write(6,'(3f8.2)') epsh1,epsh2,depsh
-
- write(6,'(a/a/a)') '#','# OUTPUT GRID','# rlmax, drl'
- write(6,'(2f8.2)') rlmax,drl
-
- write(6,'(a/a/a)') '#','# TEST CONFIGURATIONS','# ncnf'
- write(6,'(i5)') ncnf
- write(6,'(a/a)') '# nvcnf','#   n    l    f'
- do jj=2,ncnf+1
-   write(6,'(i5)') nvcnf(jj)
-   do ii=nc+1,nc+nvcnf(jj)
-     write(6,'(2i5,f8.2)') nacnf(ii,jj),lacnf(ii,jj),facnf(ii,jj)
+   do ii=1,nrl
+      write(6,'(i6,1p,4e21.13)') ii,rl(ii),rhol(ii),rhotael(ii),rhocl(ii)
    end do
-   write(6,'(a)') '#'
- end do
+
+   write(6,'(a)') '<INPUT>'
+   write(6,'(a/a/a/a)') &
+   &    '#', &
+   &    '#ONCVPSP  (Optimized Norm-Conservinng Vanderbilt PSeudopotential)', &
+   &    '#scalar-relativistic version 4.0.1 0r/27/2018', &
+   &    '#'
+
+   write(6,'(a/a/a/a)') &
+   &    '#While it is not required under the terms of the GNU GPL, it is',&
+   &    '#suggested that you cite D. R. Hamann, Phys. Rev. B 88, 085117 (2013)', &
+   &    '#in any publication utilizing these pseudopotentials.', &
+   &    '#'
+
+   write(6,'(a)') '# ATOM AND REFERENCE CONFIGURATION'
+   write(6,'(a)') '# atsym  z   nc   nv     iexc    psfile'
+   write(6,'(a,a,f6.2,2i5,i8,2a)') '  ',trim(atsym),zz,nc,nv,iexc, &
+   &      '      ',trim(psfile)
+   write(6,'(a/a)') '#','#   n    l    f'
+   do ii=1,nc+nv
+      write(6,'(2i5,f8.2)') na(ii),la(ii),fa(ii)
+   end do
+
+   write(6,'(a/a/a)') '#','# PSEUDOPOTENTIAL AND OPTIMIZATION','# lmax'
+   write(6,'(i5)')  lmax
+   write(6,'(a/a)') '#','#   l,   rc,      ep,       ncon, nbas, qcut'
+   do l1=1,lmax+1
+      write(6,'(i5,2f10.5,2i5,f10.5)') l1-1,rc0(l1),ep(l1),ncon(l1),&
+      &        nbas(l1),qcut(l1)
+   end do
+
+   write(6,'(a/a/a,a)') '#','# LOCAL POTENTIAL','# lloc, lpopt,  rc(5),', &
+   &      '   dvloc0'
+   write(6,'(2i5,f10.5,a,f10.5)') lloc,lpopt,rc0(5),'   ',dvloc0
+
+   write(6,'(a/a/a)') '#','# VANDERBILT-KLEINMAN-BYLANDER PROJECTORs', &
+   &      '# l, nproj, debl'
+   do l1=1,lmax+1
+      write(6,'(2i5,f10.5)') l1-1,nproj(l1),debl(l1)
+   end do
+
+   write(6,'(a/a/a)') '#','# MODEL CORE CHARGE', &
+   &      '# icmod, fcfact, rcfact'
+   write(6,'(i5,2f10.5)') icmod,fcfact,rcfact
+
+   write(6,'(a/a/a)') '#','# LOG DERIVATIVE ANALYSIS', &
+   &      '# epsh1, epsh2, depsh'
+   write(6,'(3f8.2)') epsh1,epsh2,depsh
+
+   write(6,'(a/a/a)') '#','# OUTPUT GRID','# rlmax, drl'
+   write(6,'(2f8.2)') rlmax,drl
+
+   write(6,'(a/a/a)') '#','# TEST CONFIGURATIONS','# ncnf'
+   write(6,'(i5)') ncnf
+   write(6,'(a/a)') '# nvcnf','#   n    l    f'
+   do jj=2,ncnf+1
+      write(6,'(i5)') nvcnf(jj)
+      do ii=nc+1,nc+nvcnf(jj)
+         write(6,'(2i5,f8.2)') nacnf(ii,jj),lacnf(ii,jj),facnf(ii,jj)
+      end do
+      write(6,'(a)') '#'
+   end do
 
 ! write termination signal
- write(6,'(a)')'</INPUT>'
- write(6,'(/a)') 'END_PSP'
-  
- deallocate(rhol,rl,vkbl,vpl,rhomodl,rhotael,rhocl)
+   write(6,'(a)')'</INPUT>'
+   write(6,'(/a)') 'END_PSP'
 
- return
- end subroutine linout
+   deallocate(rhol,rl,vkbl,vpl,rhomodl,rhotael,rhocl)
+
+   return
+end subroutine linout

--- a/src/linout_r.f90
+++ b/src/linout_r.f90
@@ -2,24 +2,24 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
 ! interpolates various arrays onto linear radial mesh to create file
 ! for Abinit input using pspcod=8, relativistic veresion with spin-orbit
 
- subroutine linout_r(lmax,lloc,rc,vsr,esr,vso,eso,nproj,rr,vpuns,rho,rhomod, &
+subroutine linout_r(lmax,lloc,rc,vsr,esr,vso,eso,nproj,rr,vpuns,rho,rhomod, &
 &                  rhotae,rhoc,zz,zion,mmax,mxprj,iexc,icmod,nrl,drl,atsym,soscale, &
 &                  na,la,ncon,nbas,nvcnf,nacnf,lacnf,nc,nv,lpopt,ncnf, &
 &                  fa,rc0,ep,qcut,debl,facnf,dvloc0,fcfact,rcfact, &
@@ -35,7 +35,7 @@
 !esr  energy  coefficients of vscal
 !vso  normalized spin-orbig projectors
 !eso  energy  coefficients of vso
-!vpuns  unscreened semi-local pseudopotentials (vpuns(:,5) is local potential 
+!vpuns  unscreened semi-local pseudopotentials (vpuns(:,5) is local potential
 !  if linear combination is used)
 !rho  valence pseudocharge
 !rhotae  all-electron valence charge
@@ -57,272 +57,272 @@
 !  epsh1,epsh2,depsh,rlmax,psfile
 
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !Input variables
- integer :: lmax,lloc,iexc,mmax,mxprj,nrl,icmod
- integer :: nproj(6)
- real(dp) :: drl,fcfact,rcfact,zz,zion,soscale
- real(dp) :: rr(mmax),vpuns(mmax,5),rho(mmax)
- real(dp) :: rhotae(mmax),rhoc(mmax)
- real(dp) :: vsr(mmax,2*mxprj,4),vso(mmax,2*mxprj,4)
- real(dp) :: esr(2*mxprj,4),eso(2*mxprj,4)
- real(dp) :: rhomod(mmax,5)
- real(dp):: rc(6)
- character*2 :: atsym
+   integer :: lmax,lloc,iexc,mmax,mxprj,nrl,icmod
+   integer :: nproj(6)
+   real(dp) :: drl,fcfact,rcfact,zz,zion,soscale
+   real(dp) :: rr(mmax),vpuns(mmax,5),rho(mmax)
+   real(dp) :: rhotae(mmax),rhoc(mmax)
+   real(dp) :: vsr(mmax,2*mxprj,4),vso(mmax,2*mxprj,4)
+   real(dp) :: esr(2*mxprj,4),eso(2*mxprj,4)
+   real(dp) :: rhomod(mmax,5)
+   real(dp):: rc(6)
+   character(len=2) :: atsym
 
 !additional input for psp8 output to echo input file, all as defined
 ! in the main progam
- integer :: na(30),la(30),ncon(6),nbas(6)
- integer :: nvcnf(5),nacnf(30,5),lacnf(30,5)
- integer :: nc,nv,lpopt,ncnf
- real(dp) :: fa(30),rc0(6),ep(6,2),qcut(6),debl(6,2),facnf(30,5)
- real(dp) :: dvloc0,epsh1,epsh2,depsh,rlmax
- character*4 :: psfile
+   integer :: na(30),la(30),ncon(6),nbas(6)
+   integer :: nvcnf(5),nacnf(30,5),lacnf(30,5)
+   integer :: nc,nv,lpopt,ncnf
+   real(dp) :: fa(30),rc0(6),ep(6,2),qcut(6),debl(6,2),facnf(30,5)
+   real(dp) :: dvloc0,epsh1,epsh2,depsh,rlmax
+   character(len=4) :: psfile
 
 !Output variables - printing only
 
 !Local variables
- integer :: ii,jj,ll,l1,ixc_abinit
- integer :: dtime(8),npr_sr(5),npr_so(5)
- real(dp) :: zero(20)
- real(dp), allocatable :: rhomodl(:,:)
- real(dp),allocatable :: rhol(:),rl(:),vpl(:,:)
- real(dp),allocatable :: rhotael(:),rhocl(:)
- real(dp), allocatable :: vsrl(:,:,:),vsol(:,:,:)
- character*2 :: pspd(3)
- logical :: nonzero
+   integer :: ii,jj,ll,l1,ixc_abinit
+   integer :: dtime(8),npr_sr(5),npr_so(5)
+   real(dp) :: zero(20)
+   real(dp), allocatable :: rhomodl(:,:)
+   real(dp),allocatable :: rhol(:),rl(:),vpl(:,:)
+   real(dp),allocatable :: rhotael(:),rhocl(:)
+   real(dp), allocatable :: vsrl(:,:,:),vsol(:,:,:)
+   character(len=2) :: pspd(3)
+   logical :: nonzero
 
- allocate(rhol(nrl),rl(nrl),vpl(nrl,5),rhomodl(nrl,5))
- allocate(rhotael(nrl),rhocl(nrl))
- allocate(vsrl(nrl,2*mxprj,4),vsol(nrl,2*mxprj,4))
+   allocate(rhol(nrl),rl(nrl),vpl(nrl,5),rhomodl(nrl,5))
+   allocate(rhotael(nrl),rhocl(nrl))
+   allocate(vsrl(nrl,2*mxprj,4),vsol(nrl,2*mxprj,4))
 
 ! set up projector number for sr_so calculations based on non-zero coefficients
-  npr_sr(:)=0 ; npr_so(:)=0
-  do l1=1,lmax+1
+   npr_sr(:)=0 ; npr_so(:)=0
+   do l1=1,lmax+1
 !  do ii=1,4
-   do ii=1,2*nproj(l1)
-    if(abs(esr(ii,l1))>0.0d0) npr_sr(l1)=npr_sr(l1)+1
-    if(abs(eso(ii,l1))>0.0d0) npr_so(l1)=npr_so(l1)+1
+      do ii=1,2*nproj(l1)
+         if(abs(esr(ii,l1))>0.0d0) npr_sr(l1)=npr_sr(l1)+1
+         if(abs(eso(ii,l1))>0.0d0) npr_so(l1)=npr_so(l1)+1
+      end do
+      write(6,'(a,3i4)') 'l1-1,npr_sr,npr_so',l1-1,npr_sr(l1),npr_so(l1)
    end do
-   write(6,'(a,3i4)') 'l1-1,npr_sr,npr_so',l1-1,npr_sr(l1),npr_so(l1)
-  end do
-   
+
 ! interpolation of everything onto linear output mesh
 !
- do  ii=1,nrl
-   rl(ii)=drl*dble(ii-1)
- end do
+   do  ii=1,nrl
+      rl(ii)=drl*dble(ii-1)
+   end do
 !
- vpl(:,:)=0.0d0
- l1=lloc+1
- call dpnint(rr,vpuns(1,l1),mmax,rl,vpl(1,l1),nrl)
+   vpl(:,:)=0.0d0
+   l1=lloc+1
+   call dpnint(rr,vpuns(1,l1),mmax,rl,vpl(1,l1),nrl)
 
 ! override dpnint extrapolation to zero for vpl
    vpl(1,l1)=vpuns(1,l1)
 
- do l1=1,lmax+1
-   if(l1 .ne. lloc+1) then
+   do l1=1,lmax+1
+      if(l1 /= lloc+1) then
 
-    do jj=1,npr_sr(l1)
-     call dpnint(rr,vsr(1,jj,l1),mmax,rl,vsrl(1,jj,l1),nrl)
-    end do
-    do jj=1,npr_so(l1)
-     call dpnint(rr,vso(1,jj,l1),mmax,rl,vsol(1,jj,l1),nrl)
-    end do
-   end if
- end do
+         do jj=1,npr_sr(l1)
+            call dpnint(rr,vsr(1,jj,l1),mmax,rl,vsrl(1,jj,l1),nrl)
+         end do
+         do jj=1,npr_so(l1)
+            call dpnint(rr,vso(1,jj,l1),mmax,rl,vsol(1,jj,l1),nrl)
+         end do
+      end if
+   end do
 
- 
- call dpnint(rr,rho,mmax,rl,rhol,nrl)
- call dpnint(rr,rhotae,mmax,rl,rhotael,nrl)
- call dpnint(rr,rhoc,mmax,rl,rhocl,nrl)
 
- do jj=1,5
-   call dpnint(rr,rhomod(1,jj),mmax,rl,rhomodl(1,jj),nrl)
- end do
+   call dpnint(rr,rho,mmax,rl,rhol,nrl)
+   call dpnint(rr,rhotae,mmax,rl,rhotael,nrl)
+   call dpnint(rr,rhoc,mmax,rl,rhocl,nrl)
+
+   do jj=1,5
+      call dpnint(rr,rhomod(1,jj),mmax,rl,rhomodl(1,jj),nrl)
+   end do
 
 ! Output for Abinit input using pspcod=8
 
- if(iexc==1) then
-   ixc_abinit=4
- else if(iexc==2) then
-   ixc_abinit=5
- else if(iexc==3) then
-   ixc_abinit=2
- else if(iexc==4) then
-   ixc_abinit=11
- else if(iexc<0) then
-   ixc_abinit=iexc
- end if
+   if(iexc==1) then
+      ixc_abinit=4
+   else if(iexc==2) then
+      ixc_abinit=5
+   else if(iexc==3) then
+      ixc_abinit=2
+   else if(iexc==4) then
+      ixc_abinit=11
+   else if(iexc<0) then
+      ixc_abinit=iexc
+   end if
 
- call date_and_time(VALUES=dtime)
- ii=dtime(1)-2000
- if(ii<10) then
-   write(pspd(1),'(a,i1)') '0',ii
- else
-   write(pspd(1),'(i2)') ii
- end if
- ii=dtime(2)
- if(ii<10) then
-   write(pspd(2),'(a,i1)') '0',ii
- else
-   write(pspd(2),'(i2)') ii
- end if
- ii=dtime(3)
- if(ii<10) then
-   write(pspd(3),'(a,i1)') '0',ii
- else
-   write(pspd(3),'(i2)') ii
- end if
+   call date_and_time(VALUES=dtime)
+   ii=dtime(1)-2000
+   if(ii<10) then
+      write(pspd(1),'(a,i1)') '0',ii
+   else
+      write(pspd(1),'(i2)') ii
+   end if
+   ii=dtime(2)
+   if(ii<10) then
+      write(pspd(2),'(a,i1)') '0',ii
+   else
+      write(pspd(2),'(i2)') ii
+   end if
+   ii=dtime(3)
+   if(ii<10) then
+      write(pspd(3),'(a,i1)') '0',ii
+   else
+      write(pspd(3),'(i2)') ii
+   end if
 
- write(6,'(/a)') 'Begin PSPCODE8'
- write(6,'(3a,4f10.5)') atsym,'    ONCVPSP-4.0.1' &
-&  ,'  r_core=',(rc(l1),l1=1,lmax+1)
- write(6,'(2f12.4, 5a)') zz,zion, '      ', pspd,  &
-&  '    zatom,zion,pspd'
- write(6,'(i6,i8,i4,3i6, a)') 8, ixc_abinit,lmax,lloc, &
-&  nrl, 0, '    pspcod,pspxc,lmax,lloc,mmax,r2well'
- write(6,'(3f12.8, a)') rl(nrl),fcfact, 0.0,  &
-&  '    rchrg fchrg qchrg'
- write(6,'(4i6, a)') npr_sr(1:4),'    nproj'
+   write(6,'(/a)') 'Begin PSPCODE8'
+   write(6,'(3a,4f10.5)') atsym,'    ONCVPSP-4.0.1' &
+   &  ,'  r_core=',(rc(l1),l1=1,lmax+1)
+   write(6,'(2f12.4, 5a)') zz,zion, '      ', pspd,  &
+   &  '    zatom,zion,pspd'
+   write(6,'(i6,i8,i4,3i6, a)') 8, ixc_abinit,lmax,lloc, &
+   &  nrl, 0, '    pspcod,pspxc,lmax,lloc,mmax,r2well'
+   write(6,'(3f12.8, a)') rl(nrl),fcfact, 0.0,  &
+   &  '    rchrg fchrg qchrg'
+   write(6,'(4i6, a)') npr_sr(1:4),'    nproj'
 
 ! this is where abinit is informed that we have spin-orbit
- write(6,'(2i6, a)') 3,1, &
-&  '           extension_switch'
- if(soscale==1.d0) then
-   write(6,'(3i6, a)') npr_so(2:4),'    nprojso'
- else
-   write(6,'(3i6, a,f6.2)') npr_so(2:4),'    nprojso  X,soscale', soscale
- end if
+   write(6,'(2i6, a)') 3,1, &
+   &  '           extension_switch'
+   if(soscale==1.d0) then
+      write(6,'(3i6, a)') npr_so(2:4),'    nprojso'
+   else
+      write(6,'(3i6, a,f6.2)') npr_so(2:4),'    nprojso  X,soscale', soscale
+   end if
 
 ! write scalar-relativistic projectors and local potential if it is one
 ! of the s-r potentials
- zero(:)=0.0d0
+   zero(:)=0.0d0
 
- do l1=1,lmax+1
-   ll=l1-1
-   if(ll==lloc) then
-     write(6,'(i4)') ll
-     do ii = 1,nrl
-       write(6,'(i6,1p,2e21.13)') ii,rl(ii),vpl(ii,l1)
-     end do
-   else
-     write(6,'(i4,23x,1p,10e21.13)') ll,(esr(jj,l1),jj=1,npr_sr(l1))
-     do ii = 1,nrl
-       if(rl(ii)<=rc(l1)+2.0d0*drl) then
-         write(6,'(i6,1p,11e21.13)') ii,rl(ii),(vsrl(ii,jj,l1),jj=1,npr_sr(l1))
-       else
-         write(6,'(i6,f6.2,10f4.0)') ii,rl(ii),(zero(jj),jj=1,npr_sr(l1))
-       end if
-     end do
-   end if
- end do
+   do l1=1,lmax+1
+      ll=l1-1
+      if(ll==lloc) then
+         write(6,'(i4)') ll
+         do ii = 1,nrl
+            write(6,'(i6,1p,2e21.13)') ii,rl(ii),vpl(ii,l1)
+         end do
+      else
+         write(6,'(i4,23x,1p,10e21.13)') ll,(esr(jj,l1),jj=1,npr_sr(l1))
+         do ii = 1,nrl
+            if(rl(ii)<=rc(l1)+2.0d0*drl) then
+               write(6,'(i6,1p,11e21.13)') ii,rl(ii),(vsrl(ii,jj,l1),jj=1,npr_sr(l1))
+            else
+               write(6,'(i6,f6.2,10f4.0)') ii,rl(ii),(zero(jj),jj=1,npr_sr(l1))
+            end if
+         end do
+      end if
+   end do
 
 ! write general local potential if called for
- if(lloc>lmax) then
-   write(6,'(i4)') lloc
-   do ii = 1,nrl
-     write(6,'(i6,1p,2e21.13)') ii,rl(ii),vpl(ii,lloc+1)
-   end do
- end if
+   if(lloc>lmax) then
+      write(6,'(i4)') lloc
+      do ii = 1,nrl
+         write(6,'(i6,1p,2e21.13)') ii,rl(ii),vpl(ii,lloc+1)
+      end do
+   end if
 
 ! write spin-orbit projectors
- do l1=2,lmax+1
-   ll=l1-1
-   if(npr_so(l1)>0) then
-     write(6,'(i4,23x,1p,20e21.13)') ll,(soscale*eso(jj,l1),jj=1,npr_so(l1))
-       do ii = 1,nrl
-         if(rl(ii)<=rc(l1)+2.0d0*drl) then
-           write(6,'(i6,1p,11e21.13)') ii,rl(ii),(vsol(ii,jj,l1),jj=1,npr_so(l1))
-         else
-           write(6,'(i6,f6.2,10f4.0)') ii,rl(ii),(zero(jj),jj=1,npr_so(l1))
-         end if
-       end do
-   end if
- end do
+   do l1=2,lmax+1
+      ll=l1-1
+      if(npr_so(l1)>0) then
+         write(6,'(i4,23x,1p,20e21.13)') ll,(soscale*eso(jj,l1),jj=1,npr_so(l1))
+         do ii = 1,nrl
+            if(rl(ii)<=rc(l1)+2.0d0*drl) then
+               write(6,'(i6,1p,11e21.13)') ii,rl(ii),(vsol(ii,jj,l1),jj=1,npr_so(l1))
+            else
+               write(6,'(i6,f6.2,10f4.0)') ii,rl(ii),(zero(jj),jj=1,npr_so(l1))
+            end if
+         end do
+      end if
+   end do
 
 ! write the model core charge if called for
- if(fcfact>0.0d0) then
-   do ii=1,nrl
-     write(6,'(i6,1p,6e21.13)') ii,rl(ii),  &
-&      (rhomodl(ii,jj),jj=1,5)
-   end do
- end if
+   if(fcfact>0.0d0) then
+      do ii=1,nrl
+         write(6,'(i6,1p,6e21.13)') ii,rl(ii),  &
+         &      (rhomodl(ii,jj),jj=1,5)
+      end do
+   end if
 
 ! write valence pseudo charge
- do ii=1,nrl
-   write(6,'(i6,1p,4e21.13)') ii,rl(ii),rhol(ii),rhotael(ii),rhocl(ii)
- end do
-
- write(6,'(a)') '<INPUT>'
- write(6,'(a/a/a/a)') &
-&    '#', &
-&    '#ONCVPSP  (Optimized Norm-Conservinng Vanderbilt PSeudopotential)', &
-&    '#relativistic version 4.0.1 03/03/2109', &
-&    '#'
-
- write(6,'(a/a/a/a)') &
-&    '#While it is not required under the terms of the GNU GPL, it is',&
-&    '#suggested that you cite D. R. Hamann, Phys. Rev. B 88, 085117 (2013)', &
-&    '#in any publication utilizing these pseudopotentials.', &
-&    '#'
-
- write(6,'(a)') '#Echo of input data for oncvpsp-4.0.1'
- write(6,'(a)') '# ATOM AND REFERENCE CONFIGURATION'
- write(6,'(a)') '# atsym  z   nc   nv     iexc    psfile'
- write(6,'(a,a,f6.2,2i5,i8,2a)') '  ',trim(atsym),zz,nc,nv,iexc, &
-&      '      ',trim(psfile)
- write(6,'(a/a)') '#','#   n    l    f        energy (Ha)'
- do ii=1,nc+nv
-   write(6,'(2i5,f8.2)') na(ii),la(ii),fa(ii)
- end do
- write(6,'(a/a/a)') '#','# PSEUDOPOTENTIAL AND OPTIMIZATION','# lmax'
- write(6,'(i5)')  lmax
- write(6,'(a/a)') '#','#   l,   rc,     ep,   ncon, nbas, qcut'
- do l1=1,lmax+1
-   write(6,'(i5,2f10.5,2i5,f10.5)') l1-1,rc0(l1),ep(l1,1),ncon(l1),nbas(l1),qcut(l1)
- end do
-
- write(6,'(a/a/a,a)') '#','# LOCAL POTENTIAL','# lloc, lpopt,  rc(5),', &
-&      '   dvloc0'
- write(6,'(2i5,f10.5,a,f10.5)') lloc,lpopt,rc0(5),'   ',dvloc0
-
- write(6,'(a/a/a)') '#','# VANDERBILT-KLEINMAN-BYLANDER PROJECTORs', &
-&      '# l, nproj, debl'
- do l1=1,lmax+1
-   write(6,'(2i5,f10.5)') l1-1,nproj(l1),debl(l1,1)
- end do
-
-write(6,'(a/a/a)') '#','# MODEL CORE CHARGE', &
-&      '# icmod, fcfact, rcfact'
- write(6,'(i5,2f10.5)') icmod,fcfact,rcfact
-
- write(6,'(a/a/a)') '#','# LOG DERIVATIVE ANALYSIS', &
-&      '# epsh1, epsh2, depsh'
- write(6,'(3f8.2)') epsh1,epsh2,depsh
-
- write(6,'(a/a/a)') '#','# OUTPUT GRID','# rlmax, drl'
- write(6,'(2f8.2)') rlmax,drl
-
- write(6,'(a/a/a)') '#','# TEST CONFIGURATIONS','# ncnf'
- write(6,'(i5)') ncnf
- write(6,'(a/a)') '# nvcnf','#   n    l    f'
- do jj=2,ncnf+1
-   write(6,'(i5)') nvcnf(jj)
-   do ii=nc+1,nc+nvcnf(jj)
-     write(6,'(2i5,f8.2)') nacnf(ii,jj),lacnf(ii,jj),facnf(ii,jj)
+   do ii=1,nrl
+      write(6,'(i6,1p,4e21.13)') ii,rl(ii),rhol(ii),rhotael(ii),rhocl(ii)
    end do
-   write(6,'(a)') '#'
- end do
-  
+
+   write(6,'(a)') '<INPUT>'
+   write(6,'(a/a/a/a)') &
+   &    '#', &
+   &    '#ONCVPSP  (Optimized Norm-Conservinng Vanderbilt PSeudopotential)', &
+   &    '#relativistic version 4.0.1 03/03/2109', &
+   &    '#'
+
+   write(6,'(a/a/a/a)') &
+   &    '#While it is not required under the terms of the GNU GPL, it is',&
+   &    '#suggested that you cite D. R. Hamann, Phys. Rev. B 88, 085117 (2013)', &
+   &    '#in any publication utilizing these pseudopotentials.', &
+   &    '#'
+
+   write(6,'(a)') '#Echo of input data for oncvpsp-4.0.1'
+   write(6,'(a)') '# ATOM AND REFERENCE CONFIGURATION'
+   write(6,'(a)') '# atsym  z   nc   nv     iexc    psfile'
+   write(6,'(a,a,f6.2,2i5,i8,2a)') '  ',trim(atsym),zz,nc,nv,iexc, &
+   &      '      ',trim(psfile)
+   write(6,'(a/a)') '#','#   n    l    f        energy (Ha)'
+   do ii=1,nc+nv
+      write(6,'(2i5,f8.2)') na(ii),la(ii),fa(ii)
+   end do
+   write(6,'(a/a/a)') '#','# PSEUDOPOTENTIAL AND OPTIMIZATION','# lmax'
+   write(6,'(i5)')  lmax
+   write(6,'(a/a)') '#','#   l,   rc,     ep,   ncon, nbas, qcut'
+   do l1=1,lmax+1
+      write(6,'(i5,2f10.5,2i5,f10.5)') l1-1,rc0(l1),ep(l1,1),ncon(l1),nbas(l1),qcut(l1)
+   end do
+
+   write(6,'(a/a/a,a)') '#','# LOCAL POTENTIAL','# lloc, lpopt,  rc(5),', &
+   &      '   dvloc0'
+   write(6,'(2i5,f10.5,a,f10.5)') lloc,lpopt,rc0(5),'   ',dvloc0
+
+   write(6,'(a/a/a)') '#','# VANDERBILT-KLEINMAN-BYLANDER PROJECTORs', &
+   &      '# l, nproj, debl'
+   do l1=1,lmax+1
+      write(6,'(2i5,f10.5)') l1-1,nproj(l1),debl(l1,1)
+   end do
+
+   write(6,'(a/a/a)') '#','# MODEL CORE CHARGE', &
+   &      '# icmod, fcfact, rcfact'
+   write(6,'(i5,2f10.5)') icmod,fcfact,rcfact
+
+   write(6,'(a/a/a)') '#','# LOG DERIVATIVE ANALYSIS', &
+   &      '# epsh1, epsh2, depsh'
+   write(6,'(3f8.2)') epsh1,epsh2,depsh
+
+   write(6,'(a/a/a)') '#','# OUTPUT GRID','# rlmax, drl'
+   write(6,'(2f8.2)') rlmax,drl
+
+   write(6,'(a/a/a)') '#','# TEST CONFIGURATIONS','# ncnf'
+   write(6,'(i5)') ncnf
+   write(6,'(a/a)') '# nvcnf','#   n    l    f'
+   do jj=2,ncnf+1
+      write(6,'(i5)') nvcnf(jj)
+      do ii=nc+1,nc+nvcnf(jj)
+         write(6,'(2i5,f8.2)') nacnf(ii,jj),lacnf(ii,jj),facnf(ii,jj)
+      end do
+      write(6,'(a)') '#'
+   end do
+
 ! write termination signal
- write(6,'(a)') '</INPUT>'
- write(6,'(/a)') 'END_PSP'
+   write(6,'(a)') '</INPUT>'
+   write(6,'(/a)') 'END_PSP'
 
- deallocate(rhol,rl,vpl,rhomodl,rhotael,rhocl)
- deallocate(vsrl,vsol)
+   deallocate(rhol,rl,vpl,rhomodl,rhotael,rhocl)
+   deallocate(vsrl,vsol)
 
- return
- end subroutine linout_r
+   return
+end subroutine linout_r

--- a/src/lschfb.f90
+++ b/src/lschfb.f90
@@ -2,21 +2,21 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- subroutine lschfb(nn,ll,ierr,ee,rr,vv,uu,up,zz,mmax,mch,srel)
+subroutine lschfb(nn,ll,ierr,ee,rr,vv,uu,up,zz,mmax,mch,srel)
 
 !Finds bound states of an all-electron atomic potential using
 !Pauli-type  scalar-relativistic Schroedinger equation
@@ -34,258 +34,258 @@
 !mch matching mesh point for inward-outward integrations
 !srel .true. for scalar-relativistic, .false. for non-relativistic
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !Input variables
- real(dp) :: rr(mmax),vv(mmax)
- real(dp) :: zz
- integer :: nn,ll
- integer :: mmax
- logical :: srel
+   real(dp) :: rr(mmax),vv(mmax)
+   real(dp) :: zz
+   integer :: nn,ll
+   integer :: mmax
+   logical :: srel
 
 !Output variables
- real(dp) :: uu(mmax),up(mmax)
- real(dp) :: ee
- integer :: ierr,mch
+   real(dp) :: uu(mmax),up(mmax)
+   real(dp) :: ee
+   integer :: ierr,mch
 
 !Local variables
 
- real(dp) :: aei,aeo,aii,aio,als !functions in aeo.f90
- real(dp) :: de,emax,emin
- real(dp) :: eps,fss,tfss,gamma,ro,sc
- real(dp) :: sls,sn,cn,uout,upin,upout,xkap
- real(dp) :: amesh,al,xx
- integer :: ii,it,nint,node,nin
+   real(dp) :: aei,aeo,aii,aio,als  !functions in aeo.f90
+   real(dp) :: de,emax,emin
+   real(dp) :: eps,fss,tfss,gamma,ro,sc
+   real(dp) :: sls,sn,cn,uout,upin,upout,xkap
+   real(dp) :: amesh,al,xx
+   integer :: ii,it,nint,node,nin
 
- real(dp), allocatable :: upp(:),cf(:),dv(:),fr(:),frp(:)
- allocate(upp(mmax),cf(mmax),dv(mmax),fr(mmax),frp(mmax))
+   real(dp), allocatable :: upp(:),cf(:),dv(:),fr(:),frp(:)
+   allocate(upp(mmax),cf(mmax),dv(mmax),fr(mmax),frp(mmax))
 
- al = 0.01d0 * dlog(rr(101) / rr(1))
- amesh = dexp(al)
+   al = 0.01d0 * dlog(rr(101) / rr(1))
+   amesh = dexp(al)
 
 ! convergence factor for solution of schroedinger eq.  if calculated
 ! correction to eigenvalue is smaller in magnitude than eps times
 ! the magnitude of the current guess, the current guess is not changed.
- eps=1.0d-10
- ierr = 60
+   eps=1.0d-10
+   ierr = 60
 
 ! check arguments
- if(ll>nn-1) then
-  write(6,'(/a,i4,a,i4)') 'lschfb: ERROR ll =',ll,' > nn =',nn
-  ierr=1
-  return
- end if
+   if(ll>nn-1) then
+      write(6,'(/a,i4,a,i4)') 'lschfb: ERROR ll =',ll,' > nn =',nn
+      ierr=1
+      return
+   end if
 
 ! relativistic - non-relativistic switch
- if(srel) then
-  fss=(1.0d0/137.036d0)**2
- else
-  fss=1.0d-12
- end if
-
- if(ll==0) gamma=dsqrt(1.0d0-fss*zz**2)
- if(ll>0) gamma=(ll*dsqrt(ll**2-fss*zz**2) + &
-& (ll+1)*dsqrt((ll+1)**2-fss*zz**2))/(2*ll+1)
-
- sls=ll*(ll+1)
-
- emax=vv(mmax)+0.5d0*sls/rr(mmax)**2
- emin=emax
- do ii=1,mmax
-   if(ll==0) then
-! ad-hock step to eliminate probelms from absurd emin for ll=0
-     emin=dmin1(emin,vv(ii)+0.25d0/rr(ii)**2)
+   if(srel) then
+      fss=(1.0d0/137.036d0)**2
    else
-     emin=dmin1(emin,vv(ii)+0.5d0*sls/rr(ii)**2)
+      fss=1.0d-12
    end if
- end do
- if(ee==0.0d0) ee=0.5d0*(emax+emin)
- if(ee<emin) ee=0.5d0*(emax+emin)
- if(ee>emax) ee=0.5d0*(emax+emin)
+
+   if(ll==0) gamma=dsqrt(1.0d0-fss*zz**2)
+   if(ll>0) gamma=(ll*dsqrt(ll**2-fss*zz**2) + &
+   & (ll+1)*dsqrt((ll+1)**2-fss*zz**2))/(2*ll+1)
+
+   sls=ll*(ll+1)
+
+   emax=vv(mmax)+0.5d0*sls/rr(mmax)**2
+   emin=emax
+   do ii=1,mmax
+      if(ll==0) then
+! ad-hock step to eliminate probelms from absurd emin for ll=0
+         emin=dmin1(emin,vv(ii)+0.25d0/rr(ii)**2)
+      else
+         emin=dmin1(emin,vv(ii)+0.5d0*sls/rr(ii)**2)
+      end if
+   end do
+   if(ee==0.0d0) ee=0.5d0*(emax+emin)
+   if(ee<emin) ee=0.5d0*(emax+emin)
+   if(ee>emax) ee=0.5d0*(emax+emin)
 
 ! null arrays to remove leftover garbage
- uu(:)=0.0d0
- up(:)=0.0d0
- upp(:)=0.0d0
+   uu(:)=0.0d0
+   up(:)=0.0d0
+   upp(:)=0.0d0
 
- als=al**2
+   als=al**2
 
 ! return point for bound state convergence
- do nint=1,60
-  
+   do nint=1,60
+
 ! coefficient array for u in differential eq.
-   do ii=1,mmax
-     cf(ii)=als*sls + 2.0d0*als*(vv(ii)-ee)*rr(ii)**2
-   end do
-  
+      do ii=1,mmax
+         cf(ii)=als*sls + 2.0d0*als*(vv(ii)-ee)*rr(ii)**2
+      end do
+
 ! calculate dv/dr for darwin correction
-   dv(:)=0.0d0
+      dv(:)=0.0d0
 
-   dv(1)=(-50.d0*vv(1)+96.d0*vv(2)-72.d0*vv(3)+32.d0*vv(4) &
-&         -6.d0*vv(5))/(24.d0*al*rr(1))
-   dv(2)=(-6.d0*vv(1)-20.d0*vv(2)+36.d0*vv(3)-12.d0*vv(4) &
-&         +2.d0*vv(5))/(24.d0*al*rr(2))
-  
-   do ii=3,mmax-2
-     dv(ii)=(2.d0*vv(ii-2)-16.d0*vv(ii-1)+16.d0*vv(ii+1) &
-&          -2.d0*vv(ii+2))/(24.d0*al*rr(ii))
-   end do
-  
+      dv(1)=(-50.d0*vv(1)+96.d0*vv(2)-72.d0*vv(3)+32.d0*vv(4) &
+      &         -6.d0*vv(5))/(24.d0*al*rr(1))
+      dv(2)=(-6.d0*vv(1)-20.d0*vv(2)+36.d0*vv(3)-12.d0*vv(4) &
+      &         +2.d0*vv(5))/(24.d0*al*rr(2))
+
+      do ii=3,mmax-2
+         dv(ii)=(2.d0*vv(ii-2)-16.d0*vv(ii-1)+16.d0*vv(ii+1) &
+         &          -2.d0*vv(ii+2))/(24.d0*al*rr(ii))
+      end do
+
 !  relativistic coefficient arrays for u (fr) and up (frp).
-   do ii=1,mmax
-     tfss=fss
-     fr(ii)=als*(rr(ii)**2)*(-tfss*(vv(ii)-ee)**2 + 0.5d0*tfss*dv(ii)/ &
-&     (rr(ii)*(1.0d0+0.5d0*tfss*(ee-vv(ii)))))
-     frp(ii)=-al*rr(ii)*0.5d0*tfss*dv(ii)/(1.0d0+0.5d0*tfss*(ee-vv(ii)))
-   end do
-  
-! find classical turning point for matching
-   mch=0
-   do ii=mmax,2,-1
-     if(cf(ii-1)<=0.d0 .and. cf(ii)>0.d0) then
-       mch=ii
-       exit
-     end if
-   end do
+      do ii=1,mmax
+         tfss=fss
+         fr(ii)=als*(rr(ii)**2)*(-tfss*(vv(ii)-ee)**2 + 0.5d0*tfss*dv(ii)/ &
+         &     (rr(ii)*(1.0d0+0.5d0*tfss*(ee-vv(ii)))))
+         frp(ii)=-al*rr(ii)*0.5d0*tfss*dv(ii)/(1.0d0+0.5d0*tfss*(ee-vv(ii)))
+      end do
 
-   if(mch==0) then
-    ierr=-1
-    return
-   end if
-  
+! find classical turning point for matching
+      mch=0
+      do ii=mmax,2,-1
+         if(cf(ii-1)<=0.d0 .and. cf(ii)>0.d0) then
+            mch=ii
+            exit
+         end if
+      end do
+
+      if(mch==0) then
+         ierr=-1
+         return
+      end if
+
 ! start wavefunction with series
-  
-   do ii=1,4
-     uu(ii)=rr(ii)**gamma
-     up(ii)=al*gamma*rr(ii)**gamma
-     upp(ii)=(al+frp(ii))*up(ii)+(cf(ii)+fr(ii))*uu(ii)
-   end do
-  
+
+      do ii=1,4
+         uu(ii)=rr(ii)**gamma
+         up(ii)=al*gamma*rr(ii)**gamma
+         upp(ii)=(al+frp(ii))*up(ii)+(cf(ii)+fr(ii))*uu(ii)
+      end do
+
 ! outward integration using predictor once, corrector
 ! twice
-   node=0
-  
-   do ii=4,mch-1
-     uu(ii+1)=uu(ii)+aeo(up,ii)
-     up(ii+1)=up(ii)+aeo(upp,ii)
-     do it=1,2
-       upp(ii+1)=(al+frp(ii+1))*up(ii+1)+(cf(ii+1)+fr(ii+1))*uu(ii+1)
-       up(ii+1)=up(ii)+aio(upp,ii)
-       uu(ii+1)=uu(ii)+aio(up,ii)
-     end do
-     if(uu(ii+1)*uu(ii) .le. 0.0d0) node=node+1
-   end do
-  
-   uout=uu(mch)
-   upout=up(mch)
-  
-  
-   if(node-nn+ll+1==0) then
-  
+      node=0
+
+      do ii=4,mch-1
+         uu(ii+1)=uu(ii)+aeo(up,ii)
+         up(ii+1)=up(ii)+aeo(upp,ii)
+         do it=1,2
+            upp(ii+1)=(al+frp(ii+1))*up(ii+1)+(cf(ii+1)+fr(ii+1))*uu(ii+1)
+            up(ii+1)=up(ii)+aio(upp,ii)
+            uu(ii+1)=uu(ii)+aio(up,ii)
+         end do
+         if(uu(ii+1)*uu(ii) <= 0.0d0) node=node+1
+      end do
+
+      uout=uu(mch)
+      upout=up(mch)
+
+
+      if(node-nn+ll+1==0) then
+
 ! start inward integration at 10*classical turning
 ! point with simple exponential
-  
-     nin=mch+2.3d0/al
-     if(nin+4>mmax) nin=mmax-4
-     xkap=dsqrt(sls/rr(nin)**2 + 2.0d0*(vv(nin)-ee))
-  
-     do ii=nin,nin+4
-       uu(ii)=exp(-xkap*(rr(ii)-rr(nin)))
-       up(ii)=-rr(ii)*al*xkap*uu(ii)
-       upp(ii)=(al+frp(ii))*up(ii)+(cf(ii)+fr(ii))*uu(ii)
-     end do
-  
+
+         nin=mch+2.3d0/al
+         if(nin+4>mmax) nin=mmax-4
+         xkap=dsqrt(sls/rr(nin)**2 + 2.0d0*(vv(nin)-ee))
+
+         do ii=nin,nin+4
+            uu(ii)=exp(-xkap*(rr(ii)-rr(nin)))
+            up(ii)=-rr(ii)*al*xkap*uu(ii)
+            upp(ii)=(al+frp(ii))*up(ii)+(cf(ii)+fr(ii))*uu(ii)
+         end do
+
 ! integrate inward
-  
-     do ii=nin,mch+1,-1
-       uu(ii-1)=uu(ii)+aei(up,ii)
-       up(ii-1)=up(ii)+aei(upp,ii)
-       do it=1,2
-         upp(ii-1)=(al+frp(ii-1))*up(ii-1)+(cf(ii-1)+fr(ii-1))*uu(ii-1)
-         up(ii-1)=up(ii)+aii(upp,ii)
-         uu(ii-1)=uu(ii)+aii(up,ii)
-       end do
-     end do
-  
+
+         do ii=nin,mch+1,-1
+            uu(ii-1)=uu(ii)+aei(up,ii)
+            up(ii-1)=up(ii)+aei(upp,ii)
+            do it=1,2
+               upp(ii-1)=(al+frp(ii-1))*up(ii-1)+(cf(ii-1)+fr(ii-1))*uu(ii-1)
+               up(ii-1)=up(ii)+aii(upp,ii)
+               uu(ii-1)=uu(ii)+aii(up,ii)
+            end do
+         end do
+
 ! scale outside wf for continuity
-  
-     sc=uout/uu(mch)
-  
-     do ii=mch,nin
-       up(ii)=sc*up(ii)
-       uu(ii)=sc*uu(ii)
-     end do
-  
-     upin=up(mch)
-  
+
+         sc=uout/uu(mch)
+
+         do ii=mch,nin
+            up(ii)=sc*up(ii)
+            uu(ii)=sc*uu(ii)
+         end do
+
+         upin=up(mch)
+
 ! perform normalization sum
-  
-     ro=rr(1)/dsqrt(amesh)
-     sn=ro**(2.0d0*gamma+1.0d0)/(2.0d0*gamma+1.0d0)
-  
-     do ii=1,nin-3
-       sn=sn+al*rr(ii)*uu(ii)**2
-     end do
-  
-     sn=sn + al*(23.0d0*rr(nin-2)*uu(nin-2)**2 &
-&              + 28.0d0*rr(nin-1)*uu(nin-1)**2 &
-&              +  9.0d0*rr(nin  )*uu(nin  )**2)/24.0d0
-  
+
+         ro=rr(1)/dsqrt(amesh)
+         sn=ro**(2.0d0*gamma+1.0d0)/(2.0d0*gamma+1.0d0)
+
+         do ii=1,nin-3
+            sn=sn+al*rr(ii)*uu(ii)**2
+         end do
+
+         sn=sn + al*(23.0d0*rr(nin-2)*uu(nin-2)**2 &
+         &              + 28.0d0*rr(nin-1)*uu(nin-1)**2 &
+         &              +  9.0d0*rr(nin  )*uu(nin  )**2)/24.0d0
+
 ! normalize u
-  
-     cn=1.0d0/dsqrt(sn)
-     uout=cn*uout
-     upout=cn*upout
-     upin=cn*upin
-  
-     do ii=1,nin
-       up(ii)=cn*up(ii)
-       uu(ii)=cn*uu(ii)
-     end do
-     do ii=nin+1,mmax
-       uu(ii)=0.0d0
-     end do
-  
+
+         cn=1.0d0/dsqrt(sn)
+         uout=cn*uout
+         upout=cn*upout
+         upin=cn*upin
+
+         do ii=1,nin
+            up(ii)=cn*up(ii)
+            uu(ii)=cn*uu(ii)
+         end do
+         do ii=nin+1,mmax
+            uu(ii)=0.0d0
+         end do
+
 ! perturbation theory for energy shift
-  
-     de=0.5d0*uout*(upout-upin)/(al*rr(mch))
-  
+
+         de=0.5d0*uout*(upout-upin)/(al*rr(mch))
+
 ! convergence test and possible exit
-  
-     if(dabs(de)<dmax1(dabs(ee),0.2d0)*eps) then
-       ierr = 0
-       exit
-     end if
-  
-     if(de>0.0d0) then 
-       emin=ee
-     else
-       emax=ee
-     end if
-     ee=ee+de
-     if(ee>emax .or. ee<emin) ee=0.5d0*(emax+emin)
-  
-   else if(node-nn+ll+1<0) then
+
+         if(dabs(de)<dmax1(dabs(ee),0.2d0)*eps) then
+            ierr = 0
+            exit
+         end if
+
+         if(de>0.0d0) then
+            emin=ee
+         else
+            emax=ee
+         end if
+         ee=ee+de
+         if(ee>emax .or. ee<emin) ee=0.5d0*(emax+emin)
+
+      else if(node-nn+ll+1<0) then
 ! too few nodes
-     emin=ee
-     ee=0.5d0*(emin+emax)
-  
-   else
+         emin=ee
+         ee=0.5d0*(emin+emax)
+
+      else
 ! too many nodes
-     emax=ee
-     ee=0.5d0*(emin+emax)
-   end if
-  
- end do
+         emax=ee
+         ee=0.5d0*(emin+emax)
+      end if
+
+   end do
 
 !fix sign to be positive at rr->oo
- if(uu(mch)<0.0d0) then
-   uu(:)=-uu(:)
-   up(:)=-up(:)
- end if
+   if(uu(mch)<0.0d0) then
+      uu(:)=-uu(:)
+      up(:)=-up(:)
+   end if
 
- deallocate(upp,cf,dv,fr,frp)
- return
+   deallocate(upp,cf,dv,fr,frp)
+   return
 
- end subroutine lschfb
+end subroutine lschfb

--- a/src/lschfs.f90
+++ b/src/lschfs.f90
@@ -2,21 +2,21 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- subroutine lschfs(nn,ll,ierr,ee,rr,vv,uu,up,zz,mmax,mch,srel)
+subroutine lschfs(nn,ll,ierr,ee,rr,vv,uu,up,zz,mmax,mch,srel)
 
 ! integrates radial Pauli-type scalar-relativistic equation
 ! on a logarithmic mesh
@@ -36,145 +36,145 @@
 !mch matching mesh point for inward-outward integrations
 !srel .true. for scalar-relativistic, .false. for non-relativistic
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !Input variables
- integer :: mmax
- real(dp) :: rr(mmax),vv(mmax)
- real(dp) :: zz
- integer :: ll,mch
- logical :: srel
- 
+   integer :: mmax
+   real(dp) :: rr(mmax),vv(mmax)
+   real(dp) :: zz
+   integer :: ll,mch
+   logical :: srel
+
 !Output variables
- real(dp) :: uu(mmax),up(mmax)
- real(dp) :: ee
- integer :: ierr,nn
+   real(dp) :: uu(mmax),up(mmax)
+   real(dp) :: ee
+   integer :: ierr,nn
 
 
 !Local variables
- real(dp) :: amesh,al
- real(dp) :: aeo, aio, als, cn
- real(dp) :: fss, tfss, gamma, ro, xx
- real(dp) :: sls, sn, uout, upout
- integer :: ii, it,node
+   real(dp) :: amesh,al
+   real(dp) :: aeo, aio, als, cn
+   real(dp) :: fss, tfss, gamma, ro, xx
+   real(dp) :: sls, sn, uout, upout
+   integer :: ii, it,node
 
- real(dp), allocatable :: upp(:),cf(:),dv(:),fr(:),frp(:)
- 
- allocate(upp(mmax),cf(mmax),dv(mmax),fr(mmax),frp(mmax))
+   real(dp), allocatable :: upp(:),cf(:),dv(:),fr(:),frp(:)
+
+   allocate(upp(mmax),cf(mmax),dv(mmax),fr(mmax),frp(mmax))
 
 
- al = 0.01d0 * log(rr(101) / rr(1))
- amesh = exp(al)
+   al = 0.01d0 * log(rr(101) / rr(1))
+   amesh = exp(al)
 
- ierr = 0
+   ierr = 0
 
 ! relativistic - non-relativistic switch
- if(srel) then
-  fss=(1.0d0/137.036d0)**2
- else
-  fss=1.0d-12
- end if
+   if(srel) then
+      fss=(1.0d0/137.036d0)**2
+   else
+      fss=1.0d-12
+   end if
 
- if(ll==0) gamma=sqrt(1.0d0-fss*zz**2)
- if(ll>0) gamma=(ll*sqrt(ll**2-fss*zz**2) &
-& +(ll+1)*sqrt((ll+1)**2-fss*zz**2))/(2*ll+1)
+   if(ll==0) gamma=sqrt(1.0d0-fss*zz**2)
+   if(ll>0) gamma=(ll*sqrt(ll**2-fss*zz**2) &
+   & +(ll+1)*sqrt((ll+1)**2-fss*zz**2))/(2*ll+1)
 
- sls=ll*(ll+1)
+   sls=ll*(ll+1)
 
 ! null arrays to remove leftover garbage
 
- uu(:)=0.0d0
- up(:)=0.0d0
- upp(:)=0.0d0
+   uu(:)=0.0d0
+   up(:)=0.0d0
+   upp(:)=0.0d0
 
- node=0
+   node=0
 
- als=al**2
+   als=al**2
 
 ! coefficient array for u in differential eq.
- do ii=1,mmax
-   cf(ii)=als*sls + 2.0d0*als*(vv(ii)-ee)*rr(ii)**2
- end do
+   do ii=1,mmax
+      cf(ii)=als*sls + 2.0d0*als*(vv(ii)-ee)*rr(ii)**2
+   end do
 
 ! calculate dv/dr for darwin correction
- dv(:)=0.0d0
- 
- dv(1)=(-50.d0*vv(1)+96.d0*vv(2)-72.d0*vv(3)+32.d0*vv(4) &
-&       -6.d0*vv(5))/(24.d0*al*rr(1))
- dv(2)=(-6.d0*vv(1)-20.d0*vv(2)+36.d0*vv(3)-12.d0*vv(4) &
-&       +2.d0*vv(5))/(24.d0*al*rr(2))
+   dv(:)=0.0d0
 
- do ii=3,mmax-2
-   dv(ii)=(2.d0*vv(ii-2)-16.d0*vv(ii-1)+16.d0*vv(ii+1) &
-&         -2.d0*vv(ii+2))/(24.d0*al*rr(ii))
- end do
+   dv(1)=(-50.d0*vv(1)+96.d0*vv(2)-72.d0*vv(3)+32.d0*vv(4) &
+   &       -6.d0*vv(5))/(24.d0*al*rr(1))
+   dv(2)=(-6.d0*vv(1)-20.d0*vv(2)+36.d0*vv(3)-12.d0*vv(4) &
+   &       +2.d0*vv(5))/(24.d0*al*rr(2))
+
+   do ii=3,mmax-2
+      dv(ii)=(2.d0*vv(ii-2)-16.d0*vv(ii-1)+16.d0*vv(ii+1) &
+      &         -2.d0*vv(ii+2))/(24.d0*al*rr(ii))
+   end do
 
 !  relativistic coefficient arrays for u (fr) and up (frp).
- do ii=1,mmax
-   tfss=fss
-   fr(ii)=als*(rr(ii)**2)*(-tfss*(vv(ii)-ee)**2 + 0.5d0*tfss*dv(ii)/ &
-&   (rr(ii)*(1.0d0+0.5d0*tfss*(ee-vv(ii)))))
-   frp(ii)=-al*rr(ii)*0.5d0*tfss*dv(ii)/(1.0d0+0.5d0*tfss*(ee-vv(ii)))
- end do
+   do ii=1,mmax
+      tfss=fss
+      fr(ii)=als*(rr(ii)**2)*(-tfss*(vv(ii)-ee)**2 + 0.5d0*tfss*dv(ii)/ &
+      &   (rr(ii)*(1.0d0+0.5d0*tfss*(ee-vv(ii)))))
+      frp(ii)=-al*rr(ii)*0.5d0*tfss*dv(ii)/(1.0d0+0.5d0*tfss*(ee-vv(ii)))
+   end do
 
 ! start wavefunction with series
 
- do ii=1,4
-   uu(ii)=rr(ii)**gamma
-   up(ii)=al*gamma*rr(ii)**gamma
-   upp(ii)=(al+frp(ii))*up(ii)+(cf(ii)+fr(ii))*uu(ii)
- end do
+   do ii=1,4
+      uu(ii)=rr(ii)**gamma
+      up(ii)=al*gamma*rr(ii)**gamma
+      upp(ii)=(al+frp(ii))*up(ii)+(cf(ii)+fr(ii))*uu(ii)
+   end do
 
 ! outward integration using predictor once, corrector
 ! twice
 
- do ii=4,mch-1
-   uu(ii+1)=uu(ii)+aeo(up,ii)
-   up(ii+1)=up(ii)+aeo(upp,ii)
-   do it=1,2
-     upp(ii+1)=(al+frp(ii+1))*up(ii+1)+(cf(ii+1)+fr(ii+1))*uu(ii+1)
-     up(ii+1)=up(ii)+aio(upp,ii)
-     uu(ii+1)=uu(ii)+aio(up,ii)
+   do ii=4,mch-1
+      uu(ii+1)=uu(ii)+aeo(up,ii)
+      up(ii+1)=up(ii)+aeo(upp,ii)
+      do it=1,2
+         upp(ii+1)=(al+frp(ii+1))*up(ii+1)+(cf(ii+1)+fr(ii+1))*uu(ii+1)
+         up(ii+1)=up(ii)+aio(upp,ii)
+         uu(ii+1)=uu(ii)+aio(up,ii)
+      end do
+      if(uu(ii+1)*uu(ii) <= 0.0d0) node=node+1
    end do
-   if(uu(ii+1)*uu(ii) .le. 0.0d0) node=node+1
- end do
 
- uout=uu(mch)
- upout=up(mch)
+   uout=uu(mch)
+   upout=up(mch)
 
 !perform normalization sum
 
- ro=rr(1)/dsqrt(amesh)
- sn=ro**(2.0d0*gamma+1.0d0)/(2.0d0*gamma+1.0d0)
+   ro=rr(1)/dsqrt(amesh)
+   sn=ro**(2.0d0*gamma+1.0d0)/(2.0d0*gamma+1.0d0)
 
- do ii=1,mch-3
-   sn=sn+al*rr(ii)*uu(ii)**2
- end do
+   do ii=1,mch-3
+      sn=sn+al*rr(ii)*uu(ii)**2
+   end do
 
- sn =sn + al*(23.0d0*rr(mch-2)*uu(mch-2)**2 &
-&           + 28.0d0*rr(mch-1)*uu(mch-1)**2 &
-&          +  9.0d0*rr(mch  )*uu(mch  )**2)/24.0d0
+   sn =sn + al*(23.0d0*rr(mch-2)*uu(mch-2)**2 &
+   &           + 28.0d0*rr(mch-1)*uu(mch-1)**2 &
+   &          +  9.0d0*rr(mch  )*uu(mch  )**2)/24.0d0
 
 !normalize u
 
- cn=1.0d0/dsqrt(sn)
- uout=cn*uout
- upout=cn*upout
+   cn=1.0d0/dsqrt(sn)
+   uout=cn*uout
+   upout=cn*upout
 
- do ii=1,mch
-   up(ii)=cn*up(ii)
-   uu(ii)=cn*uu(ii)
- end do
- do ii=mch+1,mmax
-   uu(ii)=0.0d0
- end do
+   do ii=1,mch
+      up(ii)=cn*up(ii)
+      uu(ii)=cn*uu(ii)
+   end do
+   do ii=mch+1,mmax
+      uu(ii)=0.0d0
+   end do
 
 !calculate effective principal quantum number as if this were a bound
 !state with a barrier at mch
- nn=node+ll+1
+   nn=node+ll+1
 
- deallocate(upp,cf,dv,fr,frp)
+   deallocate(upp,cf,dv,fr,frp)
 
- return
- end  subroutine lschfs
+   return
+end subroutine lschfs

--- a/src/lschkb.f90
+++ b/src/lschkb.f90
@@ -2,21 +2,21 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- subroutine lschkb(nn,ll,ierr,ee,vkb,rr,vv,uu,up,mmax,mch)
+subroutine lschkb(nn,ll,ierr,ee,vkb,rr,vv,uu,up,mmax,mch)
 
 ! outward integration of the inhomogeneous radial Schroedinger equation
 ! on a logarithmic mesh with local potential and one proector term
@@ -34,81 +34,81 @@
 !mmax  size of log grid
 !mch matching mesh point for inward-outward integrations
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !Input variables
- integer :: mmax,mch
- real(dp) :: rr(mmax),vv(mmax),vkb(mmax)
- real(dp) :: zz
- integer :: nn,ll
- 
+   integer :: mmax,mch
+   real(dp) :: rr(mmax),vv(mmax),vkb(mmax)
+   real(dp) :: zz
+   integer :: nn,ll
+
 !Output variables
- real(dp) :: uu(mmax),up(mmax)
- real(dp) :: ee
- integer :: ierr
+   real(dp) :: uu(mmax),up(mmax)
+   real(dp) :: ee
+   integer :: ierr
 
 
 !Local variables
- real(dp) :: amesh,al
- real(dp) :: aeo, aio, als, cn
- real(dp) :: sls, uout, upout
- real(dp) :: akb,ckb
- integer :: ii, it
+   real(dp) :: amesh,al
+   real(dp) :: aeo, aio, als, cn
+   real(dp) :: sls, uout, upout
+   real(dp) :: akb,ckb
+   integer :: ii, it
 
- real(dp), allocatable :: upp(:),cf(:)
- 
- allocate(upp(mmax),cf(mmax))
+   real(dp), allocatable :: upp(:),cf(:)
+
+   allocate(upp(mmax),cf(mmax))
 
 
- al = 0.01d0 * dlog(rr(101) / rr(1))
- amesh = dexp(al)
+   al = 0.01d0 * dlog(rr(101) / rr(1))
+   amesh = dexp(al)
 
- ierr = 0
+   ierr = 0
 
- sls=ll*(ll+1)
+   sls=ll*(ll+1)
 
 ! null arrays to remove leftover garbage
 
- uu(:)=0.0d0
- up(:)=0.0d0
- upp(:)=0.0d0
+   uu(:)=0.0d0
+   up(:)=0.0d0
+   upp(:)=0.0d0
 
- als=al**2
+   als=al**2
 
 ! coefficient array for uu in differential eq.
- do ii=1,mmax
-   cf(ii)=als*sls + 2.0d0*als*(vv(ii)-ee)*rr(ii)**2
- end do
+   do ii=1,mmax
+      cf(ii)=als*sls + 2.0d0*als*(vv(ii)-ee)*rr(ii)**2
+   end do
 
 ! start wavefunction with series based on projector
 
- ckb = 2.0d0*vkb(1)/rr(1)**(ll+1)
- akb = ckb/(6.0d0+4.0d0*ll)
- do ii=1,4
-   uu(ii)=akb*rr(ii)**(ll+3)
-   up(ii)= al*(ll+3)*uu(ii)
-   upp(ii)= als*(ll+3)**2*uu(ii)
- end do
+   ckb = 2.0d0*vkb(1)/rr(1)**(ll+1)
+   akb = ckb/(6.0d0+4.0d0*ll)
+   do ii=1,4
+      uu(ii)=akb*rr(ii)**(ll+3)
+      up(ii)= al*(ll+3)*uu(ii)
+      upp(ii)= als*(ll+3)**2*uu(ii)
+   end do
 
 ! outward integration using predictor once, corrector
 ! twice
 
- do ii=4,mch-1
-   uu(ii+1)=uu(ii)+aeo(up,ii)
-   up(ii+1)=up(ii)+aeo(upp,ii)
-   do it=1,2
-     upp(ii+1)=al*up(ii+1)+cf(ii+1)*uu(ii+1) &
-&            + 2.0d0*als*vkb(ii+1)*rr(ii+1)**2
-     up(ii+1)=up(ii)+aio(upp,ii)
-     uu(ii+1)=uu(ii)+aio(up,ii)
+   do ii=4,mch-1
+      uu(ii+1)=uu(ii)+aeo(up,ii)
+      up(ii+1)=up(ii)+aeo(upp,ii)
+      do it=1,2
+         upp(ii+1)=al*up(ii+1)+cf(ii+1)*uu(ii+1) &
+         &            + 2.0d0*als*vkb(ii+1)*rr(ii+1)**2
+         up(ii+1)=up(ii)+aio(upp,ii)
+         uu(ii+1)=uu(ii)+aio(up,ii)
+      end do
    end do
- end do
 
- uout=uu(mch)
- upout=up(mch)
+   uout=uu(mch)
+   upout=up(mch)
 
- deallocate(upp,cf)
+   deallocate(upp,cf)
 
- return
- end  subroutine lschkb
+   return
+end subroutine lschkb

--- a/src/lschpb.f90
+++ b/src/lschpb.f90
@@ -2,21 +2,21 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- subroutine lschpb(nn,ll,ierr,ee,rr,vv,uu,up,mmax,mch)
+subroutine lschpb(nn,ll,ierr,ee,rr,vv,uu,up,mmax,mch)
 
 ! Finds bound states of a semi-local pseudopotential
 
@@ -31,205 +31,205 @@
 !mmax  size of log grid
 !mch matching mesh point for inward-outward integrations
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !Input variables
- real(dp) :: rr(mmax),vv(mmax)
- integer :: nn,ll,mmax
+   real(dp) :: rr(mmax),vv(mmax)
+   integer :: nn,ll,mmax
 
 !Output variables
- real(dp) :: uu(mmax),up(mmax)
- real(dp) :: ee
- integer :: ierr,mch
+   real(dp) :: uu(mmax),up(mmax)
+   real(dp) :: ee
+   integer :: ierr,mch
 
 !Local Variables
 
- real(dp) :: aei,aeo,aii,aio !functions in aeo.f90
- real(dp) :: de,emax,emin
- real(dp) :: eps,exp,ro,sc
- real(dp) :: sls,sn,cn,uout,upin,upout,xkap
- real(dp) :: amesh,al,als
- integer :: ii, it,nint,node,nin
+   real(dp) :: aei,aeo,aii,aio  !functions in aeo.f90
+   real(dp) :: de,emax,emin
+   real(dp) :: eps,exp,ro,sc
+   real(dp) :: sls,sn,cn,uout,upin,upout,xkap
+   real(dp) :: amesh,al,als
+   integer :: ii, it,nint,node,nin
 
- real(dp), allocatable :: upp(:),cf(:)
- allocate(upp(mmax),cf(mmax))
+   real(dp), allocatable :: upp(:),cf(:)
+   allocate(upp(mmax),cf(mmax))
 
- al = 0.01d0 * dlog(rr(101) / rr(1))
- amesh = dexp(al)
+   al = 0.01d0 * dlog(rr(101) / rr(1))
+   amesh = dexp(al)
 
 ! convergence factor for solution of schroedinger eq.  if calculated
 ! correction to eigenvalue is smaller in magnitude than eps times
 ! the magnitude of the current guess, the current guess is not changed.
- eps=1.0d-10
- ierr = 60
+   eps=1.0d-10
+   ierr = 60
 
- sls=ll*(ll+1)
+   sls=ll*(ll+1)
 
- emax=vv(mmax)+0.5d0*sls/rr(mmax)**2
- emin=0.0d0
- do ii=1,mmax
-   emin=dmin1(emin,vv(ii)+0.5d0*sls/rr(ii)**2)
- end do
- emin=4.0d0*emin
- if(ee>emax) ee=1.25d0*emax
- if(ee<emin) ee=0.75d0*emin
- if(ee>emax) ee=0.5d0*(emax+emin)
+   emax=vv(mmax)+0.5d0*sls/rr(mmax)**2
+   emin=0.0d0
+   do ii=1,mmax
+      emin=dmin1(emin,vv(ii)+0.5d0*sls/rr(ii)**2)
+   end do
+   emin=4.0d0*emin
+   if(ee>emax) ee=1.25d0*emax
+   if(ee<emin) ee=0.75d0*emin
+   if(ee>emax) ee=0.5d0*(emax+emin)
 
 ! null arrays to remove leftover garbage
- uu(:)=0.0d0
- up(:)=0.0d0
- upp(:)=0.0d0
+   uu(:)=0.0d0
+   up(:)=0.0d0
+   upp(:)=0.0d0
 
- als=al**2
+   als=al**2
 
 ! return point for bound state convergence
- do nint=1,60
-  
+   do nint=1,60
+
 ! coefficient array for u in differential eq.
-   do ii=1,mmax
-     cf(ii)=als*sls + 2.0d0*als*(vv(ii)-ee)*rr(ii)**2
-   end do
-  
+      do ii=1,mmax
+         cf(ii)=als*sls + 2.0d0*als*(vv(ii)-ee)*rr(ii)**2
+      end do
+
 ! find classical turning point for matching
-   mch=0
-   do ii=mmax,2,-1
-     if(cf(ii-1)<=0.d0 .and. cf(ii)>0.d0) then
-       mch=ii
-       exit
-     end if
-   end do
-   if(mch==0) then
-    write(6,'(/a)') 'lschpb: ERROR no classical turning point'
-    stop
-   end if
-  
+      mch=0
+      do ii=mmax,2,-1
+         if(cf(ii-1)<=0.d0 .and. cf(ii)>0.d0) then
+            mch=ii
+            exit
+         end if
+      end do
+      if(mch==0) then
+         write(6,'(/a)') 'lschpb: ERROR no classical turning point'
+         stop
+      end if
+
 ! start wavefunction with series
-  
-   do ii=1,4
-     uu(ii)=rr(ii)**(ll+1)
-     up(ii)=al*(ll+1)*rr(ii)**(ll+1)
-     upp(ii)=al*up(ii)+cf(ii)*uu(ii)
-   end do
-  
+
+      do ii=1,4
+         uu(ii)=rr(ii)**(ll+1)
+         up(ii)=al*(ll+1)*rr(ii)**(ll+1)
+         upp(ii)=al*up(ii)+cf(ii)*uu(ii)
+      end do
+
 ! outward integration using predictor once, corrector
 ! twice
-   node=0
-  
-   do ii=4,mch-1
-     uu(ii+1)=uu(ii)+aeo(up,ii)
-     up(ii+1)=up(ii)+aeo(upp,ii)
-     do it=1,2
-       upp(ii+1)=al*up(ii+1)+cf(ii+1)*uu(ii+1)
-       up(ii+1)=up(ii)+aio(upp,ii)
-       uu(ii+1)=uu(ii)+aio(up,ii)
-     end do
-     if(uu(ii+1)*uu(ii) .le. 0.0d0) node=node+1
-   end do
-  
-   uout=uu(mch)
-   upout=up(mch)
-  
-  
-   if(node-nn+ll+1==0) then
-  
+      node=0
+
+      do ii=4,mch-1
+         uu(ii+1)=uu(ii)+aeo(up,ii)
+         up(ii+1)=up(ii)+aeo(upp,ii)
+         do it=1,2
+            upp(ii+1)=al*up(ii+1)+cf(ii+1)*uu(ii+1)
+            up(ii+1)=up(ii)+aio(upp,ii)
+            uu(ii+1)=uu(ii)+aio(up,ii)
+         end do
+         if(uu(ii+1)*uu(ii) <= 0.0d0) node=node+1
+      end do
+
+      uout=uu(mch)
+      upout=up(mch)
+
+
+      if(node-nn+ll+1==0) then
+
 ! start inward integration at 10*classical turning
 ! point with simple exponential
-  
-     nin=mch+2.3d0/al
-     if(nin+4>mmax) nin=mmax-4
-     xkap=dsqrt(sls/rr(nin)**2 + 2.0d0*(vv(nin)-ee))
-  
-     do ii=nin,nin+4
-       uu(ii)=exp(-xkap*(rr(ii)-rr(nin)))
-       up(ii)=-rr(ii)*al*xkap*uu(ii)
-       upp(ii)=al*up(ii)+cf(ii)*uu(ii)
-     end do
-  
+
+         nin=mch+2.3d0/al
+         if(nin+4>mmax) nin=mmax-4
+         xkap=dsqrt(sls/rr(nin)**2 + 2.0d0*(vv(nin)-ee))
+
+         do ii=nin,nin+4
+            uu(ii)=exp(-xkap*(rr(ii)-rr(nin)))
+            up(ii)=-rr(ii)*al*xkap*uu(ii)
+            upp(ii)=al*up(ii)+cf(ii)*uu(ii)
+         end do
+
 ! integrate inward
-  
-     do ii=nin,mch+1,-1
-       uu(ii-1)=uu(ii)+aei(up,ii)
-       up(ii-1)=up(ii)+aei(upp,ii)
-       do it=1,2
-         upp(ii-1)=al*up(ii-1)+cf(ii-1)*uu(ii-1)
-         up(ii-1)=up(ii)+aii(upp,ii)
-         uu(ii-1)=uu(ii)+aii(up,ii)
-       end do
-     end do
-  
+
+         do ii=nin,mch+1,-1
+            uu(ii-1)=uu(ii)+aei(up,ii)
+            up(ii-1)=up(ii)+aei(upp,ii)
+            do it=1,2
+               upp(ii-1)=al*up(ii-1)+cf(ii-1)*uu(ii-1)
+               up(ii-1)=up(ii)+aii(upp,ii)
+               uu(ii-1)=uu(ii)+aii(up,ii)
+            end do
+         end do
+
 ! scale outside wf for continuity
-  
-     sc=uout/uu(mch)
-  
-     do ii=mch,nin
-       up(ii)=sc*up(ii)
-       uu(ii)=sc*uu(ii)
-     end do
-  
-     upin=up(mch)
-  
+
+         sc=uout/uu(mch)
+
+         do ii=mch,nin
+            up(ii)=sc*up(ii)
+            uu(ii)=sc*uu(ii)
+         end do
+
+         upin=up(mch)
+
 ! perform normalization sum
-  
-     ro=rr(1)/dsqrt(amesh)
-     sn=ro**(2*ll+3)/dfloat(2*ll+3)
-  
-     do ii=1,nin-3
-       sn=sn+al*rr(ii)*uu(ii)**2
-     end do
-  
-     sn=sn + al*(23.0d0*rr(nin-2)*uu(nin-2)**2 &
-&              + 28.0d0*rr(nin-1)*uu(nin-1)**2 &
-&              +  9.0d0*rr(nin  )*uu(nin  )**2)/24.0d0
-  
+
+         ro=rr(1)/dsqrt(amesh)
+         sn=ro**(2*ll+3)/dfloat(2*ll+3)
+
+         do ii=1,nin-3
+            sn=sn+al*rr(ii)*uu(ii)**2
+         end do
+
+         sn=sn + al*(23.0d0*rr(nin-2)*uu(nin-2)**2 &
+         &              + 28.0d0*rr(nin-1)*uu(nin-1)**2 &
+         &              +  9.0d0*rr(nin  )*uu(nin  )**2)/24.0d0
+
 ! normalize u
-  
-     cn=1.0d0/dsqrt(sn)
-     uout=cn*uout
-     upout=cn*upout
-     upin=cn*upin
-  
-     do ii=1,nin
-       up(ii)=cn*up(ii)
-       uu(ii)=cn*uu(ii)
-     end do
-     do ii=nin+1,mmax
-       uu(ii)=0.0d0
-     end do
-  
+
+         cn=1.0d0/dsqrt(sn)
+         uout=cn*uout
+         upout=cn*upout
+         upin=cn*upin
+
+         do ii=1,nin
+            up(ii)=cn*up(ii)
+            uu(ii)=cn*uu(ii)
+         end do
+         do ii=nin+1,mmax
+            uu(ii)=0.0d0
+         end do
+
 ! perturbation theory for energy shift
-  
-     de=0.5d0*uout*(upout-upin)/(al*rr(mch))
-  
+
+         de=0.5d0*uout*(upout-upin)/(al*rr(mch))
+
 ! convergence test and possible exit
-  
-     if(dabs(de)<dmax1(dabs(ee),0.2d0)*eps) then
-       ierr = 0
-       exit
-     end if
-  
-     if(de>0.0d0) then 
-       emin=ee
-     else
-       emax=ee
-     end if
-     ee=ee+de
-     if(ee>emax .or. ee<emin) ee=0.5d0*(emax+emin)
-  
-   else if(node-nn+ll+1<0) then
+
+         if(dabs(de)<dmax1(dabs(ee),0.2d0)*eps) then
+            ierr = 0
+            exit
+         end if
+
+         if(de>0.0d0) then
+            emin=ee
+         else
+            emax=ee
+         end if
+         ee=ee+de
+         if(ee>emax .or. ee<emin) ee=0.5d0*(emax+emin)
+
+      else if(node-nn+ll+1<0) then
 ! too few nodes
-     emin=ee
-     ee=0.5d0*(emin+emax)
-  
-   else
+         emin=ee
+         ee=0.5d0*(emin+emax)
+
+      else
 ! too many nodes
-     emax=ee
-     ee=0.5d0*(emin+emax)
-   end if
-  
- end do
+         emax=ee
+         ee=0.5d0*(emin+emax)
+      end if
 
- deallocate(upp,cf)
- return
+   end do
 
- end subroutine lschpb
+   deallocate(upp,cf)
+   return
+
+end subroutine lschpb

--- a/src/lschps.f90
+++ b/src/lschps.f90
@@ -2,21 +2,21 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- subroutine lschps(nn,ll,ierr,ee,rr,vv,uu,up,mmax,mch)
+subroutine lschps(nn,ll,ierr,ee,rr,vv,uu,up,mmax,mch)
 
 ! outward integration of Srcroedinger equation for semi-local pseudopotential
 ! on a logarithmic mesh
@@ -32,105 +32,105 @@
 !mmax  size of log grid
 !mch matching mesh point for inward-outward integrations
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !Input variables
- integer :: mmax,mch
- real(dp) :: rr(mmax),vv(mmax)
- real(dp) :: zz
- integer :: nn,ll
- 
+   integer :: mmax,mch
+   real(dp) :: rr(mmax),vv(mmax)
+   real(dp) :: zz
+   integer :: nn,ll
+
 !Output variables
- real(dp) :: uu(mmax),up(mmax)
- real(dp) :: ee
- integer :: ierr
+   real(dp) :: uu(mmax),up(mmax)
+   real(dp) :: ee
+   integer :: ierr
 
 
 !Local variables
- real(dp) :: amesh,al
- real(dp) :: aeo, aio, als, cn
- real(dp) :: ro, xx
- real(dp) :: sls, sn, uout, upout
- integer :: ii, it
+   real(dp) :: amesh,al
+   real(dp) :: aeo, aio, als, cn
+   real(dp) :: ro, xx
+   real(dp) :: sls, sn, uout, upout
+   integer :: ii, it
 
- real(dp), allocatable :: upp(:),cf(:)
- 
- allocate(upp(mmax),cf(mmax))
+   real(dp), allocatable :: upp(:),cf(:)
+
+   allocate(upp(mmax),cf(mmax))
 
 
- al = 0.01d0 * dlog(rr(101) / rr(1))
- amesh = dexp(al)
+   al = 0.01d0 * dlog(rr(101) / rr(1))
+   amesh = dexp(al)
 
- ierr = 0
+   ierr = 0
 
- sls=ll*(ll+1)
+   sls=ll*(ll+1)
 
 ! null arrays to remove leftover garbage
 
- uu(:)=0.0d0
- up(:)=0.0d0
- upp(:)=0.0d0
+   uu(:)=0.0d0
+   up(:)=0.0d0
+   upp(:)=0.0d0
 
- als=al**2
+   als=al**2
 
 ! coefficient array for u in differential eq.
- do ii=1,mmax
-   cf(ii)=als*sls + 2.0d0*als*(vv(ii)-ee)*rr(ii)**2
- end do
+   do ii=1,mmax
+      cf(ii)=als*sls + 2.0d0*als*(vv(ii)-ee)*rr(ii)**2
+   end do
 
 ! start wavefunction with series
 
- do ii=1,4
-   uu(ii)=rr(ii)**(ll+1)
-   up(ii)=al*(ll+1)*rr(ii)**(ll+1)
-   upp(ii)=al*up(ii)+cf(ii)*uu(ii)
- end do
+   do ii=1,4
+      uu(ii)=rr(ii)**(ll+1)
+      up(ii)=al*(ll+1)*rr(ii)**(ll+1)
+      upp(ii)=al*up(ii)+cf(ii)*uu(ii)
+   end do
 
 ! outward integration using predictor once, corrector
 ! twice
 
- do ii=4,mch-1
-   uu(ii+1)=uu(ii)+aeo(up,ii)
-   up(ii+1)=up(ii)+aeo(upp,ii)
-   do it=1,2
-     upp(ii+1)=al*up(ii+1)+cf(ii+1)*uu(ii+1)
-     up(ii+1)=up(ii)+aio(upp,ii)
-     uu(ii+1)=uu(ii)+aio(up,ii)
+   do ii=4,mch-1
+      uu(ii+1)=uu(ii)+aeo(up,ii)
+      up(ii+1)=up(ii)+aeo(upp,ii)
+      do it=1,2
+         upp(ii+1)=al*up(ii+1)+cf(ii+1)*uu(ii+1)
+         up(ii+1)=up(ii)+aio(upp,ii)
+         uu(ii+1)=uu(ii)+aio(up,ii)
+      end do
    end do
- end do
 
- uout=uu(mch)
- upout=up(mch)
+   uout=uu(mch)
+   upout=up(mch)
 
 !perform normalization sum
 
- ro=rr(1)/dsqrt(amesh)
- sn=ro**(2*ll+3)/(2*ll+3)
+   ro=rr(1)/dsqrt(amesh)
+   sn=ro**(2*ll+3)/(2*ll+3)
 
- do ii=1,mch-3
-   sn=sn+al*rr(ii)*uu(ii)**2
- end do
+   do ii=1,mch-3
+      sn=sn+al*rr(ii)*uu(ii)**2
+   end do
 
- sn =sn + al*(23.0d0*rr(mch-2)*uu(mch-2)**2 &
-&           + 28.0d0*rr(mch-1)*uu(mch-1)**2 &
-&          +  9.0d0*rr(mch  )*uu(mch  )**2)/24.0d0
+   sn =sn + al*(23.0d0*rr(mch-2)*uu(mch-2)**2 &
+   &           + 28.0d0*rr(mch-1)*uu(mch-1)**2 &
+   &          +  9.0d0*rr(mch  )*uu(mch  )**2)/24.0d0
 
 !normalize u
 
- cn=1.0d0/dsqrt(sn)
- uout=cn*uout
- upout=cn*upout
+   cn=1.0d0/dsqrt(sn)
+   uout=cn*uout
+   upout=cn*upout
 
- do ii=1,mch
-   up(ii)=cn*up(ii)
-   uu(ii)=cn*uu(ii)
- end do
- do ii=mch+1,mmax
-   uu(ii)=0.0d0
- end do
+   do ii=1,mch
+      up(ii)=cn*up(ii)
+      uu(ii)=cn*uu(ii)
+   end do
+   do ii=mch+1,mmax
+      uu(ii)=0.0d0
+   end do
 
- deallocate(upp,cf)
+   deallocate(upp,cf)
 
- return
- end  subroutine lschps
+   return
+end subroutine lschps

--- a/src/lschpsbar.f90
+++ b/src/lschpsbar.f90
@@ -2,21 +2,21 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- subroutine lschpsbar(nn,ll,ierr,ee,emin,emax,rr,vv,uu,up,mmax,mbar,tht)
+subroutine lschpsbar(nn,ll,ierr,ee,emin,emax,rr,vv,uu,up,mmax,mbar,tht)
 
 ! Finds bound states of a semi-local pseudopotential
 
@@ -34,264 +34,264 @@
 !mbar  mesh point for infinite barrier
 !tht  phast-shift angle for boundary condition, units of pi
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
- real(dp), parameter :: pi=3.141592653589793238462643383279502884197_dp
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
+   real(dp), parameter :: pi=3.141592653589793238462643383279502884197_dp
 
 
 !Input variables
- real(dp) :: rr(mmax),vv(mmax)
- real(dp) :: emin,emax,tht
- integer :: nn,ll,mmax,mbar
+   real(dp) :: rr(mmax),vv(mmax)
+   real(dp) :: emin,emax,tht
+   integer :: nn,ll,mmax,mbar
 
 !Output variables
- real(dp) :: uu(mmax),up(mmax)
- real(dp) :: ee
- integer :: ierr
+   real(dp) :: uu(mmax),up(mmax)
+   real(dp) :: ee
+   integer :: ierr
 
 !Local Variables
 
- real(dp) :: aei,aeo,aii,aio !functions in aeo.f90
- real(dp) :: de,uumax
- real(dp) :: eps,ro,sc,stht,ctht
- real(dp) :: sls,sn,cn,uout,upin,upout,ur,xkap,xkap2,xx
- real(dp) :: amesh,al,als
- integer :: ii,imin,it,mch,mchb,nint,node,nin
- logical :: maxset
+   real(dp) :: aei,aeo,aii,aio  !functions in aeo.f90
+   real(dp) :: de,uumax
+   real(dp) :: eps,ro,sc,stht,ctht
+   real(dp) :: sls,sn,cn,uout,upin,upout,ur,xkap,xkap2,xx
+   real(dp) :: amesh,al,als
+   integer :: ii,imin,it,mch,mchb,nint,node,nin
+   logical :: maxset
 
- real(dp), allocatable :: upp(:),cf(:)
- allocate(upp(mmax),cf(mmax))
+   real(dp), allocatable :: upp(:),cf(:)
+   allocate(upp(mmax),cf(mmax))
 
- al = 0.01d0 * dlog(rr(101) / rr(1))
- amesh = dexp(al)
- stht=sin(pi*tht)
- ctht=cos(pi*tht)
+   al = 0.01d0 * dlog(rr(101) / rr(1))
+   amesh = dexp(al)
+   stht=sin(pi*tht)
+   ctht=cos(pi*tht)
 
- nin=0
- mch=0
- mchb=0
+   nin=0
+   mch=0
+   mchb=0
 ! convergence factor for solution of schroedinger eq.  if calculated
 ! correction to eigenvalue is smaller in magnitude than eps times
 ! the magnitude of the current guess, the current guess is not changed.
- eps=1.0d-8
- ierr = 60
+   eps=1.0d-8
+   ierr = 60
 
- sls=ll*(ll+1)
+   sls=ll*(ll+1)
 
- if(emin==0.0d0) then
-   emin=emax
-   do ii=1,mbar
-     if(emin>vv(ii)+0.5d0*sls/rr(ii)**2) then
-       emin=vv(ii)+0.5d0*sls/rr(ii)**2
-       imin=ii
-     end if
-   end do
- end if
+   if(emin==0.0d0) then
+      emin=emax
+      do ii=1,mbar
+         if(emin>vv(ii)+0.5d0*sls/rr(ii)**2) then
+            emin=vv(ii)+0.5d0*sls/rr(ii)**2
+            imin=ii
+         end if
+      end do
+   end if
 ! avoid error in classical turning point search
- imin=max(imin,2)
+   imin=max(imin,2)
 
- if(ee<emin) ee=dmin1(emin+5.0d0, 0.5d0*(emin+emax))
- node=0
- de=0.0d0
- mch=0
+   if(ee<emin) ee=dmin1(emin+5.0d0, 0.5d0*(emin+emax))
+   node=0
+   de=0.0d0
+   mch=0
 
 ! null arrays to remove leftover garbage
- uu(:)=0.0d0
- up(:)=0.0d0
- upp(:)=0.0d0
- cf(:)=0.0d0
+   uu(:)=0.0d0
+   up(:)=0.0d0
+   upp(:)=0.0d0
+   cf(:)=0.0d0
 !maxset=.false.
 
- als=al**2
+   als=al**2
 ! return point for bound state convergence
- do nint=1,60
+   do nint=1,60
 
-   uu(:)=0.0d0 ; up(:)=0.0d0 ; upp(:)=0.0d0
+      uu(:)=0.0d0 ; up(:)=0.0d0 ; upp(:)=0.0d0
 
-   do ii=1,mmax
-     cf(ii)=als*sls + 2.0d0*als*(vv(ii)-ee)*rr(ii)**2
-   end do
+      do ii=1,mmax
+         cf(ii)=als*sls + 2.0d0*als*(vv(ii)-ee)*rr(ii)**2
+      end do
 
 ! find classical turning point for matching
-   mch=mbar-1
-   if(cf(mbar)>0.0d0) then
-     do ii=mbar-1,imin,-1
-       if(cf(ii)<=0.d0) then
-         mch=ii
-         exit
-       end if
-     end do
-   end if
+      mch=mbar-1
+      if(cf(mbar)>0.0d0) then
+         do ii=mbar-1,imin,-1
+            if(cf(ii)<=0.d0) then
+               mch=ii
+               exit
+            end if
+         end do
+      end if
 
-   de=0.0d0
+      de=0.0d0
 ! start wavefunction with series
 
-   do ii=1,4
-     uu(ii)=rr(ii)**(ll+1)
-     up(ii)=al*(ll+1)*rr(ii)**(ll+1)
-     upp(ii)=al*up(ii)+cf(ii)*uu(ii)
-   end do
-  
+      do ii=1,4
+         uu(ii)=rr(ii)**(ll+1)
+         up(ii)=al*(ll+1)*rr(ii)**(ll+1)
+         upp(ii)=al*up(ii)+cf(ii)*uu(ii)
+      end do
+
 ! outward integration using predictor once, corrector
 ! twice
-   node=0
-   uumax=0.0d0
-   do ii=4,mch-1
-     uu(ii+1)=uu(ii)+aeo(up,ii)
-     up(ii+1)=up(ii)+aeo(upp,ii)
-     do it=1,2
-       upp(ii+1)=al*up(ii+1)+cf(ii+1)*uu(ii+1)
-       up(ii+1)=up(ii)+aio(upp,ii)
-       uu(ii+1)=uu(ii)+aio(up,ii)
-     end do
-     uumax=dmax1(uumax,abs(uu(ii+1)))
-   end do
+      node=0
+      uumax=0.0d0
+      do ii=4,mch-1
+         uu(ii+1)=uu(ii)+aeo(up,ii)
+         up(ii+1)=up(ii)+aeo(upp,ii)
+         do it=1,2
+            upp(ii+1)=al*up(ii+1)+cf(ii+1)*uu(ii+1)
+            up(ii+1)=up(ii)+aio(upp,ii)
+            uu(ii+1)=uu(ii)+aio(up,ii)
+         end do
+         uumax=dmax1(uumax,abs(uu(ii+1)))
+      end do
 
-   do ii=4,mch-1
-     if(abs(uu(ii+1))>eps*uumax .or. abs(uu(ii))>eps*uumax) then
-       if(uu(ii+1)*uu(ii) < 0.0d0) node=node+1
-     end if
-   end do
-   
-   mchb=mch
-   uout=uu(mchb)
-   upout=up(mchb)
-  
-   de=0.0d0
-   if(node-nn+ll+1==0) then
+      do ii=4,mch-1
+         if(abs(uu(ii+1))>eps*uumax .or. abs(uu(ii))>eps*uumax) then
+            if(uu(ii+1)*uu(ii) < 0.0d0) node=node+1
+         end if
+      end do
+
+      mchb=mch
+      uout=uu(mchb)
+      upout=up(mchb)
+
+      de=0.0d0
+      if(node-nn+ll+1==0) then
 
 ! start inward integration at 10*classical turning
 ! point with simple exponential
 
-     nin=mch+2.3d0/al
-     if(nin<mbar-4) then
-       if(nin+4>mmax) nin=mmax-4
-       xkap=dsqrt(sls/rr(nin)**2 + 2.0d0*(vv(nin)-ee))
+         nin=mch+2.3d0/al
+         if(nin<mbar-4) then
+            if(nin+4>mmax) nin=mmax-4
+            xkap=dsqrt(sls/rr(nin)**2 + 2.0d0*(vv(nin)-ee))
 
-       do ii=nin,nin+4
-         uu(ii)=exp(-xkap*(rr(ii)-rr(nin)))
-         up(ii)=-rr(ii)*al*xkap*uu(ii)
-         upp(ii)=al*up(ii)+cf(ii)*uu(ii)
-       end do
+            do ii=nin,nin+4
+               uu(ii)=exp(-xkap*(rr(ii)-rr(nin)))
+               up(ii)=-rr(ii)*al*xkap*uu(ii)
+               upp(ii)=al*up(ii)+cf(ii)*uu(ii)
+            end do
 
-     else
+         else
 
-       nin=mbar
-    
+            nin=mbar
+
 !   start inward integration at barrier
 !   point with sinh or sin
-    
-       xkap2=sls/rr(mbar)**2 + 2.0d0*(vv(mbar)-ee)
-       xkap=dsqrt(dabs(xkap2))
+
+            xkap2=sls/rr(mbar)**2 + 2.0d0*(vv(mbar)-ee)
+            xkap=dsqrt(dabs(xkap2))
 
 
-       do ii=mbar,mbar+4
-         xx=xkap*(rr(ii)-rr(mbar))
+            do ii=mbar,mbar+4
+               xx=xkap*(rr(ii)-rr(mbar))
 
-         if(xkap2>0) then
-           uu(ii)=rr(ii)*(ctht*sinh(-xx)/xkap + stht*cosh(-xx))
+               if(xkap2>0) then
+                  uu(ii)=rr(ii)*(ctht*sinh(-xx)/xkap + stht*cosh(-xx))
 
-           up(ii)=al*rr(ii)**2*(-ctht*cosh(-xx) - xkap*stht*sinh(-xx)) &
-&                 +al*uu(ii)
-         else
-           uu(ii)=rr(ii)*(ctht*sin(-xx)/xkap + stht*cos(-xx))
+                  up(ii)=al*rr(ii)**2*(-ctht*cosh(-xx) - xkap*stht*sinh(-xx)) &
+                  &                 +al*uu(ii)
+               else
+                  uu(ii)=rr(ii)*(ctht*sin(-xx)/xkap + stht*cos(-xx))
 
-           up(ii)=al*rr(ii)**2*(-ctht*cos(-xx) + xkap*stht*sin(-xx)) &
-&                 +al*uu(ii)
-         end if
-         upp(ii)=al*up(ii)+cf(mbar)*uu(ii)
-       end do
+                  up(ii)=al*rr(ii)**2*(-ctht*cos(-xx) + xkap*stht*sin(-xx)) &
+                  &                 +al*uu(ii)
+               end if
+               upp(ii)=al*up(ii)+cf(mbar)*uu(ii)
+            end do
 
-     end if !nin<mbar
+         end if  !nin<mbar
 
 ! integrate inward
-  
-     do ii=nin,mchb+1,-1
-       uu(ii-1)=uu(ii)+aei(up,ii)
-       up(ii-1)=up(ii)+aei(upp,ii)
-       do it=1,2
-         upp(ii-1)=al*up(ii-1)+cf(ii-1)*uu(ii-1)
-         up(ii-1)=up(ii)+aii(upp,ii)
-         uu(ii-1)=uu(ii)+aii(up,ii)
-       end do
-     end do
 
-     do ii=nin+1,mmax
-       uu(ii)=0.0d0
-       up(ii)=0.0d0
-       upp(ii)=0.0d0
-     end do
-  
+         do ii=nin,mchb+1,-1
+            uu(ii-1)=uu(ii)+aei(up,ii)
+            up(ii-1)=up(ii)+aei(upp,ii)
+            do it=1,2
+               upp(ii-1)=al*up(ii-1)+cf(ii-1)*uu(ii-1)
+               up(ii-1)=up(ii)+aii(upp,ii)
+               uu(ii-1)=uu(ii)+aii(up,ii)
+            end do
+         end do
+
+         do ii=nin+1,mmax
+            uu(ii)=0.0d0
+            up(ii)=0.0d0
+            upp(ii)=0.0d0
+         end do
+
 ! scale outside wf for continuity
-  
-     sc=uout/uu(mchb)
-  
-     do ii=mchb,nin
-       up(ii)=sc*up(ii)
-       uu(ii)=sc*uu(ii)
-     end do
-  
-     upin=up(mchb)
-  
+
+         sc=uout/uu(mchb)
+
+         do ii=mchb,nin
+            up(ii)=sc*up(ii)
+            uu(ii)=sc*uu(ii)
+         end do
+
+         upin=up(mchb)
+
 ! perform normalization sum
 
-     ro=rr(1)/dsqrt(amesh)
-     sn=ro**(2*ll+3)/dfloat(2*ll+3)
-     do ii=1,nin-3
-       sn=sn+al*rr(ii)*uu(ii)**2
-     end do
-  
-     sn=sn + al*(23.0d0*rr(nin-2)*uu(nin-2)**2 &
-&              + 28.0d0*rr(nin-1)*uu(nin-1)**2 &
-&              +  9.0d0*rr(nin  )*uu(nin  )**2)/24.0d0
-  
+         ro=rr(1)/dsqrt(amesh)
+         sn=ro**(2*ll+3)/dfloat(2*ll+3)
+         do ii=1,nin-3
+            sn=sn+al*rr(ii)*uu(ii)**2
+         end do
+
+         sn=sn + al*(23.0d0*rr(nin-2)*uu(nin-2)**2 &
+         &              + 28.0d0*rr(nin-1)*uu(nin-1)**2 &
+         &              +  9.0d0*rr(nin  )*uu(nin  )**2)/24.0d0
+
 ! normalize u
-  
-     cn=1.0d0/dsqrt(sn)
-     uout=cn*uout
-     upout=cn*upout
-     upin=cn*upin
-  
-     do ii=1,nin
-       up(ii)=cn*up(ii)
-       uu(ii)=cn*uu(ii)
-     end do
-     do ii=nin+1,mmax
-       uu(ii)=0.0d0
-     end do
-  
+
+         cn=1.0d0/dsqrt(sn)
+         uout=cn*uout
+         upout=cn*upout
+         upin=cn*upin
+
+         do ii=1,nin
+            up(ii)=cn*up(ii)
+            uu(ii)=cn*uu(ii)
+         end do
+         do ii=nin+1,mmax
+            uu(ii)=0.0d0
+         end do
+
 ! perturbation theory for energy shift
-  
-     de=0.5d0*uout*(upout-upin)/(al*rr(mchb))
+
+         de=0.5d0*uout*(upout-upin)/(al*rr(mchb))
 
 ! convergence test and possible exit
 
-  
-     if(dabs(de)<dmax1(dabs(ee),0.2d0)*eps) then
-       ierr = 0
-       exit
-     end if
-  
-     if(de>0.0d0) then
-       emin=ee
-     else
-       emax=ee
-     end if
-     ee=ee+de
-     if(ee>emax .or. ee<emin) ee=0.5d0*(emax+emin)
-   else if(node-nn+ll+1<0) then
+
+         if(dabs(de)<dmax1(dabs(ee),0.2d0)*eps) then
+            ierr = 0
+            exit
+         end if
+
+         if(de>0.0d0) then
+            emin=ee
+         else
+            emax=ee
+         end if
+         ee=ee+de
+         if(ee>emax .or. ee<emin) ee=0.5d0*(emax+emin)
+      else if(node-nn+ll+1<0) then
 ! too few nodes
-     emin=ee
-     ee=0.5d0*(emin+emax)
-   else
+         emin=ee
+         ee=0.5d0*(emin+emax)
+      else
 ! too many nodes
-     emax=ee
-     ee=0.5d0*(emin+emax)
-   end if
-  
- end do !nint
+         emax=ee
+         ee=0.5d0*(emin+emax)
+      end if
 
- deallocate(upp,cf)
- return
+   end do  !nint
 
- end subroutine lschpsbar
+   deallocate(upp,cf)
+   return
+
+end subroutine lschpsbar

--- a/src/lschpse.f90
+++ b/src/lschpse.f90
@@ -2,21 +2,21 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- subroutine lschpse(nn,ll,ierr,ee,uld,rr,vv,uu,up,mmax,mch)
+subroutine lschpse(nn,ll,ierr,ee,uld,rr,vv,uu,up,mmax,mch)
 
 ! integrates radial Schroedinger equation for pseudopotential
 ! on a logarithmic mesh finding energy at which desired log derivative
@@ -34,159 +34,159 @@
 !mmax  size of log grid
 !mch matching mesh point for inward-outward integrations
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !Input variables
- integer :: mmax,mch
- real(dp) :: rr(mmax),vv(mmax)
- real(dp) :: uld
- integer :: nn,ll
+   integer :: mmax,mch
+   real(dp) :: rr(mmax),vv(mmax)
+   real(dp) :: uld
+   integer :: nn,ll
 
 !Output variables
- real(dp) :: uu(mmax),up(mmax)
- real(dp) :: ee
- integer :: ierr
+   real(dp) :: uu(mmax),up(mmax)
+   real(dp) :: ee
+   integer :: ierr
 
 !Local variables
- real(dp) :: aei, aeo, aii, aio, als, cn
- real(dp) :: de, emax, emin
- real(dp) :: eps, ro, sc
- real(dp) :: amesh,al,xx
- real(dp) :: sls, sn, uout, upin, upout
- real(dp) ::  xkap
- integer :: ii,  it, nin, nint, node
+   real(dp) :: aei, aeo, aii, aio, als, cn
+   real(dp) :: de, emax, emin
+   real(dp) :: eps, ro, sc
+   real(dp) :: amesh,al,xx
+   real(dp) :: sls, sn, uout, upin, upout
+   real(dp) ::  xkap
+   integer :: ii,  it, nin, nint, node
 
- real(dp), allocatable :: upp(:),cf(:)
- allocate(upp(mmax),cf(mmax))
+   real(dp), allocatable :: upp(:),cf(:)
+   allocate(upp(mmax),cf(mmax))
 
- al = 0.01d0 * dlog(rr(101) / rr(1))
- amesh = dexp(al)
+   al = 0.01d0 * dlog(rr(101) / rr(1))
+   amesh = dexp(al)
 
 ! convergence factor for solution of schroedinger eq.  if calculated
 ! correction to eigenvalue is smaller in magnitude than eps times
 ! the magnitude of the current guess, the current guess is not changed.
- eps=1.0d-10
- ierr = 60
+   eps=1.0d-10
+   ierr = 60
 
- sls=ll*(ll+1)
+   sls=ll*(ll+1)
 
- emin=0.0d0
- do ii=1,mmax
-   emin=dmin1(emin,rr(ii)+0.5d0*sls/rr(ii)**2)
- end do
- emax=ee +  10.0d0
- emin=emin - 10.0d0
+   emin=0.0d0
+   do ii=1,mmax
+      emin=dmin1(emin,rr(ii)+0.5d0*sls/rr(ii)**2)
+   end do
+   emax=ee +  10.0d0
+   emin=emin - 10.0d0
 
 ! null arrays to remove leftover garbage
- uu(:)=0.0d0
- up(:)=0.0d0
- upp(:)=0.0d0
+   uu(:)=0.0d0
+   up(:)=0.0d0
+   upp(:)=0.0d0
 
- als=al**2
+   als=al**2
 
 ! return point for bound state convergence
- do nint=1,60
-  
-! coefficient array for u in differential eq.
-   do ii=1,mmax
-     cf(ii)=als*sls + 2.0d0*als*(vv(ii)-ee)*rr(ii)**2
-   end do
+   do nint=1,60
 
-   nin=mch
-  
+! coefficient array for u in differential eq.
+      do ii=1,mmax
+         cf(ii)=als*sls + 2.0d0*als*(vv(ii)-ee)*rr(ii)**2
+      end do
+
+      nin=mch
+
 ! start wavefunction with series
-  
-   do ii=1,4
-     uu(ii)=rr(ii)**(ll+1)
-     up(ii)=al*(ll+1)*rr(ii)**(ll+1)
-     upp(ii)=al*up(ii)+cf(ii)*uu(ii)
-   end do
-  
+
+      do ii=1,4
+         uu(ii)=rr(ii)**(ll+1)
+         up(ii)=al*(ll+1)*rr(ii)**(ll+1)
+         upp(ii)=al*up(ii)+cf(ii)*uu(ii)
+      end do
+
 ! outward integration using predictor once, corrector
 ! twice
-   node=0
-  
-   do ii=4,mch-1
-     uu(ii+1)=uu(ii)+aeo(up,ii)
-     up(ii+1)=up(ii)+aeo(upp,ii)
-     do it=1,2
-       upp(ii+1)=al*up(ii+1)+cf(ii+1)*uu(ii+1)
-       up(ii+1)=up(ii)+aio(upp,ii)
-       uu(ii+1)=uu(ii)+aio(up,ii)
-     end do
-     if(uu(ii+1)*uu(ii) .le. 0.0d0) node=node+1
-   end do
-  
-   uout=uu(mch)
-   upout=up(mch)
-  
-  
-   if(node-nn+ll+1==0) then
-  
-     upin=uld*uout
-  
+      node=0
+
+      do ii=4,mch-1
+         uu(ii+1)=uu(ii)+aeo(up,ii)
+         up(ii+1)=up(ii)+aeo(upp,ii)
+         do it=1,2
+            upp(ii+1)=al*up(ii+1)+cf(ii+1)*uu(ii+1)
+            up(ii+1)=up(ii)+aio(upp,ii)
+            uu(ii+1)=uu(ii)+aio(up,ii)
+         end do
+         if(uu(ii+1)*uu(ii) <= 0.0d0) node=node+1
+      end do
+
+      uout=uu(mch)
+      upout=up(mch)
+
+
+      if(node-nn+ll+1==0) then
+
+         upin=uld*uout
+
 ! perform normalization sum
-  
-     ro=rr(1)/dsqrt(amesh)
-     sn=ro**(2*ll+3)/dfloat(2*ll+3)
-  
-     do ii=1,nin-3
-       sn=sn+al*rr(ii)*uu(ii)**2
-     end do
-  
-     sn=sn + al*(23.0d0*rr(nin-2)*uu(nin-2)**2 &
-&              + 28.0d0*rr(nin-1)*uu(nin-1)**2 &
-&              +  9.0d0*rr(nin  )*uu(nin  )**2)/24.0d0
-  
+
+         ro=rr(1)/dsqrt(amesh)
+         sn=ro**(2*ll+3)/dfloat(2*ll+3)
+
+         do ii=1,nin-3
+            sn=sn+al*rr(ii)*uu(ii)**2
+         end do
+
+         sn=sn + al*(23.0d0*rr(nin-2)*uu(nin-2)**2 &
+         &              + 28.0d0*rr(nin-1)*uu(nin-1)**2 &
+         &              +  9.0d0*rr(nin  )*uu(nin  )**2)/24.0d0
+
 ! normalize u
-  
-     cn=1.0d0/dsqrt(sn)
-     uout=cn*uout
-     upout=cn*upout
-     upin=cn*upin
-  
-     do ii=1,nin
-       up(ii)=cn*up(ii)
-       uu(ii)=cn*uu(ii)
-     end do
-     do ii=nin+1,mmax
-       uu(ii)=0.0d0
-     end do
-  
+
+         cn=1.0d0/dsqrt(sn)
+         uout=cn*uout
+         upout=cn*upout
+         upin=cn*upin
+
+         do ii=1,nin
+            up(ii)=cn*up(ii)
+            uu(ii)=cn*uu(ii)
+         end do
+         do ii=nin+1,mmax
+            uu(ii)=0.0d0
+         end do
+
 ! perturbation theory for energy shift
-  
-     de=0.5d0*uout*(upout-upin)/(al*rr(mch))
-  
+
+         de=0.5d0*uout*(upout-upin)/(al*rr(mch))
+
 ! convergence test and possible exit
-  
-     if(dabs(de)<dmax1(dabs(ee),0.2d0)*eps) then
-       ierr = 0
-       exit
-     end if
-  
-     if(de>0.0d0) then 
-       emin=ee
-     else
-       emax=ee
-     end if
-     ee=ee+de
-     if(ee>emax .or. ee<emin) ee=0.5d0*(emax+emin)
-  
-   else if(node-nn+ll+1<0) then
+
+         if(dabs(de)<dmax1(dabs(ee),0.2d0)*eps) then
+            ierr = 0
+            exit
+         end if
+
+         if(de>0.0d0) then
+            emin=ee
+         else
+            emax=ee
+         end if
+         ee=ee+de
+         if(ee>emax .or. ee<emin) ee=0.5d0*(emax+emin)
+
+      else if(node-nn+ll+1<0) then
 ! too few nodes
-     emin=ee
-     ee=0.5d0*(emin+emax)
-  
-   else
+         emin=ee
+         ee=0.5d0*(emin+emax)
+
+      else
 ! too many nodes
-     emax=ee
-     ee=0.5d0*(emin+emax)
-   end if
-  
- end do
+         emax=ee
+         ee=0.5d0*(emin+emax)
+      end if
 
- deallocate(upp,cf)
- return
+   end do
 
- end subroutine lschpse
+   deallocate(upp,cf)
+   return
+
+end subroutine lschpse

--- a/src/lschvkbb.f90
+++ b/src/lschvkbb.f90
@@ -2,21 +2,21 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- subroutine lschvkbb(nn,ll,nvkb,ierr,ee,emin,emax, &
+subroutine lschvkbb(nn,ll,nvkb,ierr,ee,emin,emax, &
 &   rr,vloc,vkb,evkb,uu,up,mmax,mch)
 
 ! Finds bound states of a  pseudopotential with
@@ -39,217 +39,217 @@
 !mmax  size of log grid
 !mch matching mesh point for inward-outward integrations
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !Input Variables
- real(dp) :: emin,emax
- real(dp) :: rr(mmax),vloc(mmax),vkb(mmax,nvkb),evkb(nvkb)
- integer :: nn,ll,nvkb,mmax
+   real(dp) :: emin,emax
+   real(dp) :: rr(mmax),vloc(mmax),vkb(mmax,nvkb),evkb(nvkb)
+   integer :: nn,ll,nvkb,mmax
 
 !Output variables
- real(dp) :: uu(mmax),up(mmax)
- real(dp) :: ee  !in/out, really - needs starting guess
- integer :: ierr,mch
+   real(dp) :: uu(mmax),up(mmax)
+   real(dp) :: ee  !in/out, really - needs starting guess
+   integer :: ierr,mch
 
 
 !Local variables
- real(dp) :: aei,aeo,aii,aio,cn
- real(dp) :: de
- real(dp) :: eps,ro,sc
- real(dp) :: sls,sn,uout,upin,upout
- real(dp) :: amesh,al,als
- real(dp) :: rc,xkap
- integer :: ii,it,jj,nin,nint,node
+   real(dp) :: aei,aeo,aii,aio,cn
+   real(dp) :: de
+   real(dp) :: eps,ro,sc
+   real(dp) :: sls,sn,uout,upin,upout
+   real(dp) :: amesh,al,als
+   real(dp) :: rc,xkap
+   integer :: ii,it,jj,nin,nint,node
 
- real(dp), allocatable :: upp(:),cf(:)
- allocate(upp(mmax),cf(mmax))
+   real(dp), allocatable :: upp(:),cf(:)
+   allocate(upp(mmax),cf(mmax))
 
- al = 0.01d0 * dlog(rr(101) / rr(1))
- amesh = dexp(al)
- node=0
+   al = 0.01d0 * dlog(rr(101) / rr(1))
+   amesh = dexp(al)
+   node=0
 
 ! convergence factor for solution of schroedinger eq.  if calculated
 ! correction to eigenvalue is smaller in magnitude than eps times
 ! the magnitude of the current guess, the current guess is not changed.
 !eps=1.0d-10
- eps=1.0d-8
- ierr = 100
+   eps=1.0d-8
+   ierr = 100
 
- sls=ll*(ll+1)
+   sls=ll*(ll+1)
 
 
- if(ee>emax) ee=1.25d0*emax
- if(ee<emin) ee=0.75d0*emin
- if(ee>emax) ee=0.5d0*(emax+emin)
+   if(ee>emax) ee=1.25d0*emax
+   if(ee<emin) ee=0.75d0*emin
+   if(ee>emax) ee=0.5d0*(emax+emin)
 
 ! null arrays to remove leftover garbage
- uu(:)=0.0d0
- up(:)=0.0d0
- upp(:)=0.0d0
+   uu(:)=0.0d0
+   up(:)=0.0d0
+   upp(:)=0.0d0
 
- als=al**2
+   als=al**2
 
 ! return point for bound state convergence
- do nint=1,100
+   do nint=1,100
 
 ! coefficient array for u in differential eq.
-   do ii=1,mmax
-     cf(ii)=als*sls + 2.0d0*als*(vloc(ii)-ee)*rr(ii)**2
-   end do
-  
+      do ii=1,mmax
+         cf(ii)=als*sls + 2.0d0*als*(vloc(ii)-ee)*rr(ii)**2
+      end do
+
 ! find classical turning point for matching
-   mch=1
-   do ii=mmax,2,-1
-     if(cf(ii-1)<=0.d0 .and. cf(ii)>0.d0) then
-       mch=ii
-       exit
-     end if
-   end do
+      mch=1
+      do ii=mmax,2,-1
+         if(cf(ii-1)<=0.d0 .and. cf(ii)>0.d0) then
+            mch=ii
+            exit
+         end if
+      end do
 
-   if(mch==1 .and. nvkb==0) then
-    write(6,'(/a)') 'lschvkbb: ERROR no classical turning point'
-    write(6,'(a,i2,a,i6)') 'lschvkbb: ERROR nvkb=',nvkb,'mch=',mch
-    write(6,'(a,i2,a,f8.4,a)') 'lschvkbb: ERROR l=',ll,'  e=',ee
+      if(mch==1 .and. nvkb==0) then
+         write(6,'(/a)') 'lschvkbb: ERROR no classical turning point'
+         write(6,'(a,i2,a,i6)') 'lschvkbb: ERROR nvkb=',nvkb,'mch=',mch
+         write(6,'(a,i2,a,f8.4,a)') 'lschvkbb: ERROR l=',ll,'  e=',ee
 !   stop
-   end if
+      end if
 
-   if(nvkb>0) then
+      if(nvkb>0) then
 ! find cutoff radius for projectors
-     rc=0.0d0
-     do ii=mmax,1,-1
-       if(abs(vkb(ii,1))>0.0d0) then
-         rc=rr(ii)
-         exit
-       end if
-     end do
+         rc=0.0d0
+         do ii=mmax,1,-1
+            if(abs(vkb(ii,1))>0.0d0) then
+               rc=rr(ii)
+               exit
+            end if
+         end do
 
-     if(mch==1) rc=1.25d0*rc
+         if(mch==1) rc=1.25d0*rc
 
 ! adjust matching radius if necessary
-     if(rr(mch)<rc) then
-      do ii=mch,mmax
-       if(rr(ii)>rc) then
-        mch=ii
-        exit
-       end if
-      end do
-     end if
-   end if
+         if(rr(mch)<rc) then
+            do ii=mch,mmax
+               if(rr(ii)>rc) then
+                  mch=ii
+                  exit
+               end if
+            end do
+         end if
+      end if
 ! outward integration
-   call vkboutwf(ll,nvkb,ee,vkb,evkb,rr,vloc,uu,up,node,mmax,mch)
-  
-   uout=uu(mch)
-   upout=up(mch)
+      call vkboutwf(ll,nvkb,ee,vkb,evkb,rr,vloc,uu,up,node,mmax,mch)
 
-   if(node-nn+ll+1==0) then
-  
+      uout=uu(mch)
+      upout=up(mch)
+
+      if(node-nn+ll+1==0) then
+
 ! start inward integration at 10*classical turning
 ! point with simple exponential
-  
-     nin=mch+2.3d0/al
-     if(nin+4>mmax) nin=mmax-4
-     xkap=dsqrt(sls/rr(nin)**2 + 2.0d0*(vloc(nin)-ee))
-  
-     do ii=nin,nin+4
-       uu(ii)=exp(-xkap*(rr(ii)-rr(nin)))
-       up(ii)=-rr(ii)*al*xkap*uu(ii)
-       upp(ii)=al*up(ii)+cf(ii)*uu(ii)
-     end do
-  
+
+         nin=mch+2.3d0/al
+         if(nin+4>mmax) nin=mmax-4
+         xkap=dsqrt(sls/rr(nin)**2 + 2.0d0*(vloc(nin)-ee))
+
+         do ii=nin,nin+4
+            uu(ii)=exp(-xkap*(rr(ii)-rr(nin)))
+            up(ii)=-rr(ii)*al*xkap*uu(ii)
+            upp(ii)=al*up(ii)+cf(ii)*uu(ii)
+         end do
+
 ! integrate inward
-  
-     do ii=nin,mch+1,-1
-       uu(ii-1)=uu(ii)+aei(up,ii)
-       up(ii-1)=up(ii)+aei(upp,ii)
-       do it=1,2
-         upp(ii-1)=al*up(ii-1)+cf(ii-1)*uu(ii-1)
-         up(ii-1)=up(ii)+aii(upp,ii)
-         uu(ii-1)=uu(ii)+aii(up,ii)
-       end do
-     end do
-  
+
+         do ii=nin,mch+1,-1
+            uu(ii-1)=uu(ii)+aei(up,ii)
+            up(ii-1)=up(ii)+aei(upp,ii)
+            do it=1,2
+               upp(ii-1)=al*up(ii-1)+cf(ii-1)*uu(ii-1)
+               up(ii-1)=up(ii)+aii(upp,ii)
+               uu(ii-1)=uu(ii)+aii(up,ii)
+            end do
+         end do
+
 ! scale outside wf for continuity
-  
-     sc=uout/uu(mch)
-  
-     do ii=mch,nin
-       up(ii)=sc*up(ii)
-       uu(ii)=sc*uu(ii)
-     end do
-  
-     upin=up(mch)
-  
+
+         sc=uout/uu(mch)
+
+         do ii=mch,nin
+            up(ii)=sc*up(ii)
+            uu(ii)=sc*uu(ii)
+         end do
+
+         upin=up(mch)
+
 ! perform normalization sum
-  
-     ro=rr(1)/dsqrt(amesh)
-     sn=ro**(2*ll+3)/dfloat(2*ll+3)
-  
-     do ii=1,nin-3
-       sn=sn+al*rr(ii)*uu(ii)**2
-     end do
-  
-     sn=sn + al*(23.0d0*rr(nin-2)*uu(nin-2)**2 &
-&              + 28.0d0*rr(nin-1)*uu(nin-1)**2 &
-&              +  9.0d0*rr(nin  )*uu(nin  )**2)/24.0d0
-  
+
+         ro=rr(1)/dsqrt(amesh)
+         sn=ro**(2*ll+3)/dfloat(2*ll+3)
+
+         do ii=1,nin-3
+            sn=sn+al*rr(ii)*uu(ii)**2
+         end do
+
+         sn=sn + al*(23.0d0*rr(nin-2)*uu(nin-2)**2 &
+         &              + 28.0d0*rr(nin-1)*uu(nin-1)**2 &
+         &              +  9.0d0*rr(nin  )*uu(nin  )**2)/24.0d0
+
 ! normalize u
-  
-     cn=1.0d0/dsqrt(sn)
-     uout=cn*uout
-     upout=cn*upout
-     upin=cn*upin
-  
-     do ii=1,nin
-       up(ii)=cn*up(ii)
-       uu(ii)=cn*uu(ii)
-     end do
-     do ii=nin+1,mmax
-       uu(ii)=0.0d0
-     end do
-  
+
+         cn=1.0d0/dsqrt(sn)
+         uout=cn*uout
+         upout=cn*upout
+         upin=cn*upin
+
+         do ii=1,nin
+            up(ii)=cn*up(ii)
+            uu(ii)=cn*uu(ii)
+         end do
+         do ii=nin+1,mmax
+            uu(ii)=0.0d0
+         end do
+
 ! perturbation theory for energy shift
-  
-     de=0.5d0*uout*(upout-upin)/(al*rr(mch))
-  
+
+         de=0.5d0*uout*(upout-upin)/(al*rr(mch))
+
 ! convergence test and possible exit
-  
-     if(dabs(de)<dmax1(dabs(ee),0.2d0)*eps) then
-       ierr = 0
-       exit
-     end if
-  
-     if(de>0.0d0) then 
+
+         if(dabs(de)<dmax1(dabs(ee),0.2d0)*eps) then
+            ierr = 0
+            exit
+         end if
+
+         if(de>0.0d0) then
 !      emin=ee
-       emin=0.5d0*(emin+ee)
-     else
+            emin=0.5d0*(emin+ee)
+         else
 !      emax=ee
-       emax=0.5d0*(emax+ee)
-     end if
-     ee=ee+de
-     if(ee>emax .or. ee<emin) ee=0.5d0*(emax+emin)
-  
-   else if(node-nn+ll+1<0) then
+            emax=0.5d0*(emax+ee)
+         end if
+         ee=ee+de
+         if(ee>emax .or. ee<emin) ee=0.5d0*(emax+emin)
+
+      else if(node-nn+ll+1<0) then
 ! too few nodes
 !    emin=ee
-     emin=0.5d0*(emin+ee)
-     ee=0.5d0*(emin+emax)
-  
-   else
+         emin=0.5d0*(emin+ee)
+         ee=0.5d0*(emin+emax)
+
+      else
 ! too many nodes
 !    emax=ee
-     emax=0.5d0*(emax+ee)
-     ee=0.5d0*(emin+emax)
-   end if
-  
- end do
+         emax=0.5d0*(emax+ee)
+         ee=0.5d0*(emin+emax)
+      end if
+
+   end do
 !fix sign to be positive at rr->oo
- if(uu(mch)<0.0d0) then
-   uu(:)=-uu(:)
-   up(:)=-up(:)
- end if
+   if(uu(mch)<0.0d0) then
+      uu(:)=-uu(:)
+      up(:)=-up(:)
+   end if
 
- deallocate(upp,cf)
- return
+   deallocate(upp,cf)
+   return
 
- end subroutine lschvkbb
+end subroutine lschvkbb

--- a/src/lschvkbbe.f90
+++ b/src/lschvkbbe.f90
@@ -2,25 +2,25 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- subroutine lschvkbbe(nn,ll,nvkb,ierr,ee,uld,emin,emax, &
+subroutine lschvkbbe(nn,ll,nvkb,ierr,ee,uld,emin,emax, &
 &   rr,vloc,vkb,evkb,uu,up,mmax,mch)
 
 ! integrates radial schroedinger equation for pseudopotential with
-! Vanderbilt-Kleinman-Bylander non-local projectors finding energy at 
+! Vanderbilt-Kleinman-Bylander non-local projectors finding energy at
 ! which desired log derivative uld is matched at point mch
 
 
@@ -41,136 +41,136 @@
 !mmax  size of log grid
 !mch matching mesh point for inward-outward integrations
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !Input Variables
- real(dp) :: emin,emax,uld
- real(dp) :: rr(mmax),vloc(mmax),vkb(mmax,nvkb),evkb(nvkb)
- integer :: nn,ll,nvkb,mmax
+   real(dp) :: emin,emax,uld
+   real(dp) :: rr(mmax),vloc(mmax),vkb(mmax,nvkb),evkb(nvkb)
+   integer :: nn,ll,nvkb,mmax
 
 !Output variables
- real(dp) :: uu(mmax),up(mmax)
- real(dp) :: ee  !in/out, really - needs starting guess
- integer :: ierr,mch
+   real(dp) :: uu(mmax),up(mmax)
+   real(dp) :: ee  !in/out, really - needs starting guess
+   integer :: ierr,mch
 
 
 !Local variables
- real(dp) :: aei,aeo,aii,aio,cn
- real(dp) :: de
- real(dp) :: eps,ro,sc
- real(dp) :: sls,sn,uout,upin,upout
- real(dp) :: amesh,al,als
- real(dp) :: rc,xkap
- integer :: ii,it,nin,nint,node
+   real(dp) :: aei,aeo,aii,aio,cn
+   real(dp) :: de
+   real(dp) :: eps,ro,sc
+   real(dp) :: sls,sn,uout,upin,upout
+   real(dp) :: amesh,al,als
+   real(dp) :: rc,xkap
+   integer :: ii,it,nin,nint,node
 
- real(dp), allocatable :: upp(:),cf(:)
- allocate(upp(mmax),cf(mmax))
+   real(dp), allocatable :: upp(:),cf(:)
+   allocate(upp(mmax),cf(mmax))
 
- al = 0.01d0 * dlog(rr(101) / rr(1))
- amesh = dexp(al)
+   al = 0.01d0 * dlog(rr(101) / rr(1))
+   amesh = dexp(al)
 
 ! convergence factor for solution of schroedinger eq.  if calculated
 ! correction to eigenvalue is smaller in magnitude than eps times
 ! the magnitude of the current guess, the current guess is not changed.
- eps=1.0d-10
- ierr = 60
+   eps=1.0d-10
+   ierr = 60
 
- sls=ll*(ll+1)
+   sls=ll*(ll+1)
 
 
- if(ee>emax) ee=1.25d0*emax
- if(ee<emin) ee=0.75d0*emin
- if(ee>emax) ee=0.5d0*(emax+emin)
+   if(ee>emax) ee=1.25d0*emax
+   if(ee<emin) ee=0.75d0*emin
+   if(ee>emax) ee=0.5d0*(emax+emin)
 
 ! null arrays to remove leftover garbage
- uu(:)=0.0d0
- up(:)=0.0d0
- upp(:)=0.0d0
+   uu(:)=0.0d0
+   up(:)=0.0d0
+   upp(:)=0.0d0
 
- als=al**2
+   als=al**2
 
 ! return point for bound state convergence
- do nint=1,60
-  
-! coefficient array for u in differential eq.
-   do ii=1,mmax
-     cf(ii)=als*sls + 2.0d0*als*(vloc(ii)-ee)*rr(ii)**2
-   end do
+   do nint=1,60
 
-   nin=mch
+! coefficient array for u in differential eq.
+      do ii=1,mmax
+         cf(ii)=als*sls + 2.0d0*als*(vloc(ii)-ee)*rr(ii)**2
+      end do
+
+      nin=mch
 
 ! outward integration
-   call vkboutwf(ll,nvkb,ee,vkb,evkb,rr,vloc,uu,up,node,mmax,mch)
-  
-   uout=uu(mch)
-   upout=up(mch)
-  
-   if(node-nn+ll+1==0) then
-  
-     upin=uld*uout
-  
+      call vkboutwf(ll,nvkb,ee,vkb,evkb,rr,vloc,uu,up,node,mmax,mch)
+
+      uout=uu(mch)
+      upout=up(mch)
+
+      if(node-nn+ll+1==0) then
+
+         upin=uld*uout
+
 ! perform normalization sum
-  
-     ro=rr(1)/dsqrt(amesh)
-     sn=ro**(2*ll+3)/dfloat(2*ll+3)
-  
-     do ii=1,nin-3
-       sn=sn+al*rr(ii)*uu(ii)**2
-     end do
-  
-     sn=sn + al*(23.0d0*rr(nin-2)*uu(nin-2)**2 &
-&              + 28.0d0*rr(nin-1)*uu(nin-1)**2 &
-&              +  9.0d0*rr(nin  )*uu(nin  )**2)/24.0d0
-  
+
+         ro=rr(1)/dsqrt(amesh)
+         sn=ro**(2*ll+3)/dfloat(2*ll+3)
+
+         do ii=1,nin-3
+            sn=sn+al*rr(ii)*uu(ii)**2
+         end do
+
+         sn=sn + al*(23.0d0*rr(nin-2)*uu(nin-2)**2 &
+         &              + 28.0d0*rr(nin-1)*uu(nin-1)**2 &
+         &              +  9.0d0*rr(nin  )*uu(nin  )**2)/24.0d0
+
 ! normalize u
-  
-     cn=1.0d0/dsqrt(sn)
-     uout=cn*uout
-     upout=cn*upout
-     upin=cn*upin
-  
-     do ii=1,nin
-       up(ii)=cn*up(ii)
-       uu(ii)=cn*uu(ii)
-     end do
-     do ii=nin+1,mmax
-       uu(ii)=0.0d0
-     end do
-  
+
+         cn=1.0d0/dsqrt(sn)
+         uout=cn*uout
+         upout=cn*upout
+         upin=cn*upin
+
+         do ii=1,nin
+            up(ii)=cn*up(ii)
+            uu(ii)=cn*uu(ii)
+         end do
+         do ii=nin+1,mmax
+            uu(ii)=0.0d0
+         end do
+
 ! perturbation theory for energy shift
-  
-     de=0.5d0*uout*(upout-upin)/(al*rr(mch))
 
-  
+         de=0.5d0*uout*(upout-upin)/(al*rr(mch))
+
+
 ! convergence test and possible exit
-  
-     if(dabs(de)<dmax1(dabs(ee),0.2d0)*eps) then
-       ierr = 0
-       exit
-     end if
-  
-     if(de>0.0d0) then 
-       emin=ee
-     else
-       emax=ee
-     end if
-     ee=ee+de
-     if(ee>emax .or. ee<emin) ee=0.5d0*(emax+emin)
-  
-   else if(node-nn+ll+1<0) then
+
+         if(dabs(de)<dmax1(dabs(ee),0.2d0)*eps) then
+            ierr = 0
+            exit
+         end if
+
+         if(de>0.0d0) then
+            emin=ee
+         else
+            emax=ee
+         end if
+         ee=ee+de
+         if(ee>emax .or. ee<emin) ee=0.5d0*(emax+emin)
+
+      else if(node-nn+ll+1<0) then
 ! too few nodes
-     emin=ee
-     ee=0.5d0*(emin+emax)
-  
-   else
+         emin=ee
+         ee=0.5d0*(emin+emax)
+
+      else
 ! too many nodes
-     emax=ee
-     ee=0.5d0*(emin+emax)
-   end if
- end do
+         emax=ee
+         ee=0.5d0*(emin+emax)
+      end if
+   end do
 
- deallocate(upp,cf)
- return
+   deallocate(upp,cf)
+   return
 
- end subroutine lschvkbbe
+end subroutine lschvkbbe

--- a/src/lschvkbs.f90
+++ b/src/lschvkbs.f90
@@ -2,23 +2,23 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- subroutine lschvkbs(ll,ivkb,ee,rr,vloc,vkb,evkb,uu,up,mmax,mch)
+subroutine lschvkbs(ll,ivkb,ee,rr,vloc,vkb,evkb,uu,up,mmax,mch)
 
-! Normalized scattering state for pseudopotential, fully non-local unless 
+! Normalized scattering state for pseudopotential, fully non-local unless
 ! ivkb=0, which should only happen if ll=lloc
 
 !ll  angular-momentum quantum number
@@ -33,59 +33,59 @@
 !mmax  size of log grid
 !mch  index of radius to which uu is computed
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !Input variables
- integer :: mmax,mch
- real(dp) :: rr(mmax),vloc(mmax),vkb(mmax,2),evkb(2)
- real(dp) :: ee
- integer :: ivkb,ll
- 
+   integer :: mmax,mch
+   real(dp) :: rr(mmax),vloc(mmax),vkb(mmax,2),evkb(2)
+   real(dp) :: ee
+   integer :: ivkb,ll
+
 !Output variables
- real(dp) :: uu(mmax),up(mmax)
+   real(dp) :: uu(mmax),up(mmax)
 
 
 !Local variables
- real(dp) :: amesh,al
- real(dp) :: cn,ro,sn
- integer :: ii,node
+   real(dp) :: amesh,al
+   real(dp) :: cn,ro,sn
+   integer :: ii,node
 
 
- al = 0.01d0 * dlog(rr(101) / rr(1))
- amesh = dexp(al)
+   al = 0.01d0 * dlog(rr(101) / rr(1))
+   amesh = dexp(al)
 
 ! null arrays to remove leftover garbage
 
- uu(:)=0.0d0
- up(:)=0.0d0
+   uu(:)=0.0d0
+   up(:)=0.0d0
 
- call vkboutwf(ll,ivkb,ee,vkb,evkb,rr,vloc,uu,up,node,mmax,mch)
+   call vkboutwf(ll,ivkb,ee,vkb,evkb,rr,vloc,uu,up,node,mmax,mch)
 
 !perform normalization sum
 
- ro=rr(1)/dsqrt(amesh)
- sn=ro**(2*ll+3)/(2*ll+3)
+   ro=rr(1)/dsqrt(amesh)
+   sn=ro**(2*ll+3)/(2*ll+3)
 
- do ii=1,mch-3
-   sn=sn+al*rr(ii)*uu(ii)**2
- end do
+   do ii=1,mch-3
+      sn=sn+al*rr(ii)*uu(ii)**2
+   end do
 
- sn =sn + al*(23.0d0*rr(mch-2)*uu(mch-2)**2 &
-&           + 28.0d0*rr(mch-1)*uu(mch-1)**2 &
-&          +  9.0d0*rr(mch  )*uu(mch  )**2)/24.0d0
+   sn =sn + al*(23.0d0*rr(mch-2)*uu(mch-2)**2 &
+   &           + 28.0d0*rr(mch-1)*uu(mch-1)**2 &
+   &          +  9.0d0*rr(mch  )*uu(mch  )**2)/24.0d0
 
 !normalize u
 
- cn=1.0d0/dsqrt(sn)
+   cn=1.0d0/dsqrt(sn)
 
- do ii=1,mch
-   up(ii)=cn*up(ii)
-   uu(ii)=cn*uu(ii)
- end do
- do ii=mch+1,mmax
-   uu(ii)=0.0d0
- end do
+   do ii=1,mch
+      up(ii)=cn*up(ii)
+      uu(ii)=cn*uu(ii)
+   end do
+   do ii=mch+1,mmax
+      uu(ii)=0.0d0
+   end do
 
- return
- end  subroutine lschvkbs
+   return
+end subroutine lschvkbs

--- a/src/m_libxc_list.F90
+++ b/src/m_libxc_list.F90
@@ -4,212 +4,212 @@ module m_libxc_list
 ! in a derived type record.
 !
 ! Copyright (c) Alberto Garcia, 2014, 2015
-! 
+!
 
-type, public :: libxc_kind_t
-   character(len=24) :: str
-end type libxc_kind_t
+   type, public :: libxc_kind_t
+      character(len=24) :: str
+   end type libxc_kind_t
 
-type(libxc_kind_t), parameter :: EXCH = libxc_kind_t("XC_EXCHANGE")
-type(libxc_kind_t), parameter :: CORR = libxc_kind_t("XC_CORRELATION")
-type(libxc_kind_t), parameter :: EXCH_CORR =  &
-                                 libxc_kind_t("XC_EXCHANGE_CORRELATION")
+   type(libxc_kind_t), parameter :: EXCH = libxc_kind_t("XC_EXCHANGE")
+   type(libxc_kind_t), parameter :: CORR = libxc_kind_t("XC_CORRELATION")
+   type(libxc_kind_t), parameter :: EXCH_CORR =  &
+      libxc_kind_t("XC_EXCHANGE_CORRELATION")
 
 !character(len=*), parameter :: EXCH = "XC_EXCHANGE"
 !character(len=*), parameter :: CORR = "XC_CORRELATION"
 !character(len=*), parameter :: EXCH_CORR = "XC_EXCHANGE_CORRELATION"
 
-type, public :: libxc_t
-   character(len=40)  :: name
-   integer            :: code
-   type(libxc_kind_t) :: xc_kind
+   type, public :: libxc_t
+      character(len=40)  :: name
+      integer            :: code
+      type(libxc_kind_t) :: xc_kind
 !   character(len=40)  :: xc_kind
-end type libxc_t
+   end type libxc_t
 
-type(libxc_t), parameter, public  ::                  &
-   XC_EMPTY = libxc_t("XC_EMPTY", 0 , EXCH_CORR),  &
-   XC_NOT_IMPL = libxc_t("XC_NOT_IMPL", -1 , EXCH_CORR)
+   type(libxc_t), parameter, public  ::                  &
+      XC_EMPTY = libxc_t("XC_EMPTY", 0 , EXCH_CORR),  &
+      XC_NOT_IMPL = libxc_t("XC_NOT_IMPL", -1 , EXCH_CORR)
 
 ! Exchange
 
-type(libxc_t), parameter  ::                  &
-   XC_LDA_X = libxc_t("XC_LDA_X", 1 , EXCH),  &
-   XC_LDA_X_2D = libxc_t("XC_LDA_X_2D", 19 , EXCH),  &
-   XC_LDA_X_1D = libxc_t("XC_LDA_X_1D", 21 , EXCH),  &
-   XC_GGA_X_Q2D = libxc_t("XC_GGA_X_Q2D", 48 , EXCH),  &
-   XC_GGA_X_PBE_MOL = libxc_t("XC_GGA_X_PBE_MOL", 49 , EXCH),  &
-   XC_GGA_X_AK13 = libxc_t("XC_GGA_X_AK13", 56 , EXCH),  &
-   XC_GGA_X_LV_RPW86 = libxc_t("XC_GGA_X_LV_RPW86", 58 , EXCH),  &
-   XC_GGA_X_PBE_TCA = libxc_t("XC_GGA_X_PBE_TCA", 59 , EXCH),  &
-   XC_GGA_X_PBEINT = libxc_t("XC_GGA_X_PBEINT", 60 , EXCH),  &
-   XC_GGA_X_VMT84_GE = libxc_t("XC_GGA_X_VMT84_GE", 68 , EXCH),  &
-   XC_GGA_X_VMT84_PBE = libxc_t("XC_GGA_X_VMT84_PBE", 69 , EXCH),  &
-   XC_GGA_X_VMT_GE = libxc_t("XC_GGA_X_VMT_GE", 70 , EXCH),  &
-   XC_GGA_X_VMT_PBE = libxc_t("XC_GGA_X_VMT_PBE", 71 , EXCH),  &
-   XC_GGA_X_N12 = libxc_t("XC_GGA_X_N12", 82 , EXCH),  &
-   XC_GGA_X_SSB_SW = libxc_t("XC_GGA_X_SSB_SW", 90 , EXCH),  &
-   XC_GGA_X_SSB = libxc_t("XC_GGA_X_SSB", 91 , EXCH),  &
-   XC_GGA_X_SSB_D = libxc_t("XC_GGA_X_SSB_D", 92 , EXCH),  &
-   XC_GGA_X_BPCCAC = libxc_t("XC_GGA_X_BPCCAC", 98 , EXCH),  &
-   XC_GGA_X_PBE = libxc_t("XC_GGA_X_PBE", 101 , EXCH),  &
-   XC_GGA_X_PBE_R = libxc_t("XC_GGA_X_PBE_R", 102 , EXCH),  &
-   XC_GGA_X_B86 = libxc_t("XC_GGA_X_B86", 103 , EXCH),  &
-   XC_GGA_X_HERMAN = libxc_t("XC_GGA_X_HERMAN", 104 , EXCH),  &
-   XC_GGA_X_B86_MGC = libxc_t("XC_GGA_X_B86_MGC", 105 , EXCH),  &
-   XC_GGA_X_B88 = libxc_t("XC_GGA_X_B88", 106 , EXCH),  &
-   XC_GGA_X_G96 = libxc_t("XC_GGA_X_G96", 107 , EXCH),  &
-   XC_GGA_X_PW86 = libxc_t("XC_GGA_X_PW86", 108 , EXCH),  &
-   XC_GGA_X_PW91 = libxc_t("XC_GGA_X_PW91", 109 , EXCH),  &
-   XC_GGA_X_OPTX = libxc_t("XC_GGA_X_OPTX", 110 , EXCH),  &
-   XC_GGA_X_DK87_R1 = libxc_t("XC_GGA_X_DK87_R1", 111 , EXCH),  &
-   XC_GGA_X_DK87_R2 = libxc_t("XC_GGA_X_DK87_R2", 112 , EXCH),  &
-   XC_GGA_X_LG93 = libxc_t("XC_GGA_X_LG93", 113 , EXCH),  &
-   XC_GGA_X_FT97_A = libxc_t("XC_GGA_X_FT97_A", 114 , EXCH),  &
-   XC_GGA_X_FT97_B = libxc_t("XC_GGA_X_FT97_B", 115 , EXCH),  &
-   XC_GGA_X_PBE_SOL = libxc_t("XC_GGA_X_PBE_SOL", 116 , EXCH),  &
-   XC_GGA_X_RPBE = libxc_t("XC_GGA_X_RPBE", 117 , EXCH),  &
-   XC_GGA_X_WC = libxc_t("XC_GGA_X_WC", 118 , EXCH),  &
-   XC_GGA_X_MPW91 = libxc_t("XC_GGA_X_MPW91", 119 , EXCH),  &
-   XC_GGA_X_AM05 = libxc_t("XC_GGA_X_AM05", 120 , EXCH),  &
-   XC_GGA_X_PBEA = libxc_t("XC_GGA_X_PBEA", 121 , EXCH),  &
-   XC_GGA_X_MPBE = libxc_t("XC_GGA_X_MPBE", 122 , EXCH),  &
-   XC_GGA_X_XPBE = libxc_t("XC_GGA_X_XPBE", 123 , EXCH),  &
-   XC_GGA_X_2D_B86_MGC = libxc_t("XC_GGA_X_2D_B86_MGC", 124 , EXCH),  &
-   XC_GGA_X_BAYESIAN = libxc_t("XC_GGA_X_BAYESIAN", 125 , EXCH),  &
-   XC_GGA_X_PBE_JSJR = libxc_t("XC_GGA_X_PBE_JSJR", 126 , EXCH),  &
-   XC_GGA_X_2D_B88 = libxc_t("XC_GGA_X_2D_B88", 127 , EXCH),  &
-   XC_GGA_X_2D_B86 = libxc_t("XC_GGA_X_2D_B86", 128 , EXCH),  &
-   XC_GGA_X_2D_PBE = libxc_t("XC_GGA_X_2D_PBE", 129 , EXCH),  &
-   XC_GGA_X_OPTB88_VDW = libxc_t("XC_GGA_X_OPTB88_VDW", 139 , EXCH),  &
-   XC_GGA_X_PBEK1_VDW = libxc_t("XC_GGA_X_PBEK1_VDW", 140 , EXCH),  &
-   XC_GGA_X_OPTPBE_VDW = libxc_t("XC_GGA_X_OPTPBE_VDW", 141 , EXCH),  &
-   XC_GGA_X_RGE2 = libxc_t("XC_GGA_X_RGE2", 142 , EXCH),  &
-   XC_GGA_X_RPW86 = libxc_t("XC_GGA_X_RPW86", 144 , EXCH),  &
-   XC_GGA_X_KT1 = libxc_t("XC_GGA_X_KT1", 145 , EXCH),  &
-   XC_GGA_X_MB88 = libxc_t("XC_GGA_X_MB88", 149 , EXCH),  &
-   XC_GGA_X_SOGGA = libxc_t("XC_GGA_X_SOGGA", 150 , EXCH),  &
-   XC_GGA_X_SOGGA11 = libxc_t("XC_GGA_X_SOGGA11", 151 , EXCH),  &
-   XC_GGA_X_C09X = libxc_t("XC_GGA_X_C09X", 158 , EXCH),  &
-   XC_GGA_X_LB = libxc_t("XC_GGA_X_LB", 160 , EXCH),  &
-   XC_GGA_X_LBM = libxc_t("XC_GGA_X_LBM", 182 , EXCH),  &
-   XC_GGA_X_OL2 = libxc_t("XC_GGA_X_OL2", 183 , EXCH),  &
-   XC_GGA_X_APBE = libxc_t("XC_GGA_X_APBE", 184 , EXCH),  &
-   XC_GGA_X_HTBS = libxc_t("XC_GGA_X_HTBS", 191 , EXCH),  &
-   XC_GGA_X_AIRY = libxc_t("XC_GGA_X_AIRY", 192 , EXCH),  &
-   XC_GGA_X_LAG = libxc_t("XC_GGA_X_LAG", 193 , EXCH),  &
-   XC_GGA_X_WPBEH = libxc_t("XC_GGA_X_WPBEH", 524 , EXCH),  &
-   XC_GGA_X_HJS_PBE = libxc_t("XC_GGA_X_HJS_PBE", 525 , EXCH),  &
-   XC_GGA_X_HJS_PBE_SOL = libxc_t("XC_GGA_X_HJS_PBE_SOL", 526 , EXCH),  &
-   XC_GGA_X_HJS_B88 = libxc_t("XC_GGA_X_HJS_B88", 527 , EXCH),  &
-   XC_GGA_X_HJS_B97X = libxc_t("XC_GGA_X_HJS_B97X", 528 , EXCH),  &
-   XC_GGA_X_ITYH = libxc_t("XC_GGA_X_ITYH", 529 , EXCH),  &
-   XC_GGA_X_SFAT = libxc_t("XC_GGA_X_SFAT", 530 , EXCH)
+   type(libxc_t), parameter  ::                  &
+      XC_LDA_X = libxc_t("XC_LDA_X", 1 , EXCH),  &
+      XC_LDA_X_2D = libxc_t("XC_LDA_X_2D", 19 , EXCH),  &
+      XC_LDA_X_1D = libxc_t("XC_LDA_X_1D", 21 , EXCH),  &
+      XC_GGA_X_Q2D = libxc_t("XC_GGA_X_Q2D", 48 , EXCH),  &
+      XC_GGA_X_PBE_MOL = libxc_t("XC_GGA_X_PBE_MOL", 49 , EXCH),  &
+      XC_GGA_X_AK13 = libxc_t("XC_GGA_X_AK13", 56 , EXCH),  &
+      XC_GGA_X_LV_RPW86 = libxc_t("XC_GGA_X_LV_RPW86", 58 , EXCH),  &
+      XC_GGA_X_PBE_TCA = libxc_t("XC_GGA_X_PBE_TCA", 59 , EXCH),  &
+      XC_GGA_X_PBEINT = libxc_t("XC_GGA_X_PBEINT", 60 , EXCH),  &
+      XC_GGA_X_VMT84_GE = libxc_t("XC_GGA_X_VMT84_GE", 68 , EXCH),  &
+      XC_GGA_X_VMT84_PBE = libxc_t("XC_GGA_X_VMT84_PBE", 69 , EXCH),  &
+      XC_GGA_X_VMT_GE = libxc_t("XC_GGA_X_VMT_GE", 70 , EXCH),  &
+      XC_GGA_X_VMT_PBE = libxc_t("XC_GGA_X_VMT_PBE", 71 , EXCH),  &
+      XC_GGA_X_N12 = libxc_t("XC_GGA_X_N12", 82 , EXCH),  &
+      XC_GGA_X_SSB_SW = libxc_t("XC_GGA_X_SSB_SW", 90 , EXCH),  &
+      XC_GGA_X_SSB = libxc_t("XC_GGA_X_SSB", 91 , EXCH),  &
+      XC_GGA_X_SSB_D = libxc_t("XC_GGA_X_SSB_D", 92 , EXCH),  &
+      XC_GGA_X_BPCCAC = libxc_t("XC_GGA_X_BPCCAC", 98 , EXCH),  &
+      XC_GGA_X_PBE = libxc_t("XC_GGA_X_PBE", 101 , EXCH),  &
+      XC_GGA_X_PBE_R = libxc_t("XC_GGA_X_PBE_R", 102 , EXCH),  &
+      XC_GGA_X_B86 = libxc_t("XC_GGA_X_B86", 103 , EXCH),  &
+      XC_GGA_X_HERMAN = libxc_t("XC_GGA_X_HERMAN", 104 , EXCH),  &
+      XC_GGA_X_B86_MGC = libxc_t("XC_GGA_X_B86_MGC", 105 , EXCH),  &
+      XC_GGA_X_B88 = libxc_t("XC_GGA_X_B88", 106 , EXCH),  &
+      XC_GGA_X_G96 = libxc_t("XC_GGA_X_G96", 107 , EXCH),  &
+      XC_GGA_X_PW86 = libxc_t("XC_GGA_X_PW86", 108 , EXCH),  &
+      XC_GGA_X_PW91 = libxc_t("XC_GGA_X_PW91", 109 , EXCH),  &
+      XC_GGA_X_OPTX = libxc_t("XC_GGA_X_OPTX", 110 , EXCH),  &
+      XC_GGA_X_DK87_R1 = libxc_t("XC_GGA_X_DK87_R1", 111 , EXCH),  &
+      XC_GGA_X_DK87_R2 = libxc_t("XC_GGA_X_DK87_R2", 112 , EXCH),  &
+      XC_GGA_X_LG93 = libxc_t("XC_GGA_X_LG93", 113 , EXCH),  &
+      XC_GGA_X_FT97_A = libxc_t("XC_GGA_X_FT97_A", 114 , EXCH),  &
+      XC_GGA_X_FT97_B = libxc_t("XC_GGA_X_FT97_B", 115 , EXCH),  &
+      XC_GGA_X_PBE_SOL = libxc_t("XC_GGA_X_PBE_SOL", 116 , EXCH),  &
+      XC_GGA_X_RPBE = libxc_t("XC_GGA_X_RPBE", 117 , EXCH),  &
+      XC_GGA_X_WC = libxc_t("XC_GGA_X_WC", 118 , EXCH),  &
+      XC_GGA_X_MPW91 = libxc_t("XC_GGA_X_MPW91", 119 , EXCH),  &
+      XC_GGA_X_AM05 = libxc_t("XC_GGA_X_AM05", 120 , EXCH),  &
+      XC_GGA_X_PBEA = libxc_t("XC_GGA_X_PBEA", 121 , EXCH),  &
+      XC_GGA_X_MPBE = libxc_t("XC_GGA_X_MPBE", 122 , EXCH),  &
+      XC_GGA_X_XPBE = libxc_t("XC_GGA_X_XPBE", 123 , EXCH),  &
+      XC_GGA_X_2D_B86_MGC = libxc_t("XC_GGA_X_2D_B86_MGC", 124 , EXCH),  &
+      XC_GGA_X_BAYESIAN = libxc_t("XC_GGA_X_BAYESIAN", 125 , EXCH),  &
+      XC_GGA_X_PBE_JSJR = libxc_t("XC_GGA_X_PBE_JSJR", 126 , EXCH),  &
+      XC_GGA_X_2D_B88 = libxc_t("XC_GGA_X_2D_B88", 127 , EXCH),  &
+      XC_GGA_X_2D_B86 = libxc_t("XC_GGA_X_2D_B86", 128 , EXCH),  &
+      XC_GGA_X_2D_PBE = libxc_t("XC_GGA_X_2D_PBE", 129 , EXCH),  &
+      XC_GGA_X_OPTB88_VDW = libxc_t("XC_GGA_X_OPTB88_VDW", 139 , EXCH),  &
+      XC_GGA_X_PBEK1_VDW = libxc_t("XC_GGA_X_PBEK1_VDW", 140 , EXCH),  &
+      XC_GGA_X_OPTPBE_VDW = libxc_t("XC_GGA_X_OPTPBE_VDW", 141 , EXCH),  &
+      XC_GGA_X_RGE2 = libxc_t("XC_GGA_X_RGE2", 142 , EXCH),  &
+      XC_GGA_X_RPW86 = libxc_t("XC_GGA_X_RPW86", 144 , EXCH),  &
+      XC_GGA_X_KT1 = libxc_t("XC_GGA_X_KT1", 145 , EXCH),  &
+      XC_GGA_X_MB88 = libxc_t("XC_GGA_X_MB88", 149 , EXCH),  &
+      XC_GGA_X_SOGGA = libxc_t("XC_GGA_X_SOGGA", 150 , EXCH),  &
+      XC_GGA_X_SOGGA11 = libxc_t("XC_GGA_X_SOGGA11", 151 , EXCH),  &
+      XC_GGA_X_C09X = libxc_t("XC_GGA_X_C09X", 158 , EXCH),  &
+      XC_GGA_X_LB = libxc_t("XC_GGA_X_LB", 160 , EXCH),  &
+      XC_GGA_X_LBM = libxc_t("XC_GGA_X_LBM", 182 , EXCH),  &
+      XC_GGA_X_OL2 = libxc_t("XC_GGA_X_OL2", 183 , EXCH),  &
+      XC_GGA_X_APBE = libxc_t("XC_GGA_X_APBE", 184 , EXCH),  &
+      XC_GGA_X_HTBS = libxc_t("XC_GGA_X_HTBS", 191 , EXCH),  &
+      XC_GGA_X_AIRY = libxc_t("XC_GGA_X_AIRY", 192 , EXCH),  &
+      XC_GGA_X_LAG = libxc_t("XC_GGA_X_LAG", 193 , EXCH),  &
+      XC_GGA_X_WPBEH = libxc_t("XC_GGA_X_WPBEH", 524 , EXCH),  &
+      XC_GGA_X_HJS_PBE = libxc_t("XC_GGA_X_HJS_PBE", 525 , EXCH),  &
+      XC_GGA_X_HJS_PBE_SOL = libxc_t("XC_GGA_X_HJS_PBE_SOL", 526 , EXCH),  &
+      XC_GGA_X_HJS_B88 = libxc_t("XC_GGA_X_HJS_B88", 527 , EXCH),  &
+      XC_GGA_X_HJS_B97X = libxc_t("XC_GGA_X_HJS_B97X", 528 , EXCH),  &
+      XC_GGA_X_ITYH = libxc_t("XC_GGA_X_ITYH", 529 , EXCH),  &
+      XC_GGA_X_SFAT = libxc_t("XC_GGA_X_SFAT", 530 , EXCH)
 
 ! Correlation
 
-type(libxc_t), parameter  ::                  &
-   XC_LDA_C_WIGNER = libxc_t("XC_LDA_C_WIGNER", 2 , CORR),  &
-   XC_LDA_C_RPA = libxc_t("XC_LDA_C_RPA", 3 , CORR),  &
-   XC_LDA_C_HL = libxc_t("XC_LDA_C_HL", 4 , CORR),  &
-   XC_LDA_C_GL = libxc_t("XC_LDA_C_GL", 5 , CORR),  &
-   XC_LDA_C_XALPHA = libxc_t("XC_LDA_C_XALPHA", 6 , CORR),  &
-   XC_LDA_C_VWN = libxc_t("XC_LDA_C_VWN", 7 , CORR),  &
-   XC_LDA_C_VWN_RPA = libxc_t("XC_LDA_C_VWN_RPA", 8 , CORR),  &
-   XC_LDA_C_PZ = libxc_t("XC_LDA_C_PZ", 9 , CORR),  &
-   XC_LDA_C_PZ_MOD = libxc_t("XC_LDA_C_PZ_MOD", 10 , CORR),  &
-   XC_LDA_C_OB_PZ = libxc_t("XC_LDA_C_OB_PZ", 11 , CORR),  &
-   XC_LDA_C_PW = libxc_t("XC_LDA_C_PW", 12 , CORR),  &
-   XC_LDA_C_PW_MOD = libxc_t("XC_LDA_C_PW_MOD", 13 , CORR),  &
-   XC_LDA_C_OB_PW = libxc_t("XC_LDA_C_OB_PW", 14 , CORR),  &
-   XC_LDA_C_2D_AMGB = libxc_t("XC_LDA_C_2D_AMGB", 15 , CORR),  &
-   XC_LDA_C_2D_PRM = libxc_t("XC_LDA_C_2D_PRM", 16 , CORR),  &
-   XC_LDA_C_vBH = libxc_t("XC_LDA_C_vBH", 17 , CORR),  &
-   XC_LDA_C_1D_CSC = libxc_t("XC_LDA_C_1D_CSC", 18 , CORR),  &
-   XC_LDA_C_ML1 = libxc_t("XC_LDA_C_ML1", 22 , CORR),  &
-   XC_LDA_C_ML2 = libxc_t("XC_LDA_C_ML2", 23 , CORR),  &
-   XC_LDA_C_GOMBAS = libxc_t("XC_LDA_C_GOMBAS", 24 , CORR),  &
-   XC_LDA_C_PW_RPA = libxc_t("XC_LDA_C_PW_RPA", 25 , CORR),  &
-   XC_LDA_C_1D_LOOS = libxc_t("XC_LDA_C_1D_LOOS", 26 , CORR),  &
-   XC_LDA_C_RC04 = libxc_t("XC_LDA_C_RC04", 27 , CORR),  &
-   XC_LDA_C_VWN_1 = libxc_t("XC_LDA_C_VWN_1", 28 , CORR),  &
-   XC_LDA_C_VWN_2 = libxc_t("XC_LDA_C_VWN_2", 29 , CORR),  &
-   XC_LDA_C_VWN_3 = libxc_t("XC_LDA_C_VWN_3", 30 , CORR),  &
-   XC_LDA_C_VWN_4 = libxc_t("XC_LDA_C_VWN_4", 31 , CORR),  &
-   XC_GGA_C_Q2D = libxc_t("XC_GGA_C_Q2D", 47 , CORR),  &
-   XC_GGA_C_ZPBEINT = libxc_t("XC_GGA_C_ZPBEINT", 61 , CORR),  &
-   XC_GGA_C_PBEINT = libxc_t("XC_GGA_C_PBEINT", 62 , CORR),  &
-   XC_GGA_C_ZPBESOL = libxc_t("XC_GGA_C_ZPBESOL", 63 , CORR),  &
-   XC_GGA_C_N12_SX = libxc_t("XC_GGA_C_N12_SX", 79 , CORR),  &
-   XC_GGA_C_N12 = libxc_t("XC_GGA_C_N12", 80 , CORR),  &
-   XC_GGA_C_VPBE = libxc_t("XC_GGA_C_VPBE", 83 , CORR),  &
-   XC_GGA_C_OP_XALPHA = libxc_t("XC_GGA_C_OP_XALPHA", 84 , CORR),  &
-   XC_GGA_C_OP_G96 = libxc_t("XC_GGA_C_OP_G96", 85 , CORR),  &
-   XC_GGA_C_OP_PBE = libxc_t("XC_GGA_C_OP_PBE", 86 , CORR),  &
-   XC_GGA_C_OP_B88 = libxc_t("XC_GGA_C_OP_B88", 87 , CORR),  &
-   XC_GGA_C_FT97 = libxc_t("XC_GGA_C_FT97", 88 , CORR),  &
-   XC_GGA_C_SPBE = libxc_t("XC_GGA_C_SPBE", 89 , CORR),  &
-   XC_GGA_C_REVTCA = libxc_t("XC_GGA_C_REVTCA", 99 , CORR),  &
-   XC_GGA_C_TCA = libxc_t("XC_GGA_C_TCA", 100 , CORR),  &
-   XC_GGA_C_PBE = libxc_t("XC_GGA_C_PBE", 130 , CORR),  &
-   XC_GGA_C_LYP = libxc_t("XC_GGA_C_LYP", 131 , CORR),  &
-   XC_GGA_C_P86 = libxc_t("XC_GGA_C_P86", 132 , CORR),  &
-   XC_GGA_C_PBE_SOL = libxc_t("XC_GGA_C_PBE_SOL", 133 , CORR),  &
-   XC_GGA_C_PW91 = libxc_t("XC_GGA_C_PW91", 134 , CORR),  &
-   XC_GGA_C_AM05 = libxc_t("XC_GGA_C_AM05", 135 , CORR),  &
-   XC_GGA_C_XPBE = libxc_t("XC_GGA_C_XPBE", 136 , CORR),  &
-   XC_GGA_C_LM = libxc_t("XC_GGA_C_LM", 137 , CORR),  &
-   XC_GGA_C_PBE_JRGX = libxc_t("XC_GGA_C_PBE_JRGX", 138 , CORR),  &
-   XC_GGA_C_RGE2 = libxc_t("XC_GGA_C_RGE2", 143 , CORR),  &
-   XC_GGA_C_WL = libxc_t("XC_GGA_C_WL", 147 , CORR),  &
-   XC_GGA_C_WI = libxc_t("XC_GGA_C_WI", 148 , CORR),  &
-   XC_GGA_C_SOGGA11 = libxc_t("XC_GGA_C_SOGGA11", 152 , CORR),  &
-   XC_GGA_C_WI0 = libxc_t("XC_GGA_C_WI0", 153 , CORR),  &
-   XC_GGA_C_SOGGA11_X = libxc_t("XC_GGA_C_SOGGA11_X", 159 , CORR),  &
-   XC_GGA_C_APBE = libxc_t("XC_GGA_C_APBE", 186 , CORR),  &
-   XC_GGA_C_OPTC = libxc_t("XC_GGA_C_OPTC", 200 , CORR)
+   type(libxc_t), parameter  ::                  &
+      XC_LDA_C_WIGNER = libxc_t("XC_LDA_C_WIGNER", 2 , CORR),  &
+      XC_LDA_C_RPA = libxc_t("XC_LDA_C_RPA", 3 , CORR),  &
+      XC_LDA_C_HL = libxc_t("XC_LDA_C_HL", 4 , CORR),  &
+      XC_LDA_C_GL = libxc_t("XC_LDA_C_GL", 5 , CORR),  &
+      XC_LDA_C_XALPHA = libxc_t("XC_LDA_C_XALPHA", 6 , CORR),  &
+      XC_LDA_C_VWN = libxc_t("XC_LDA_C_VWN", 7 , CORR),  &
+      XC_LDA_C_VWN_RPA = libxc_t("XC_LDA_C_VWN_RPA", 8 , CORR),  &
+      XC_LDA_C_PZ = libxc_t("XC_LDA_C_PZ", 9 , CORR),  &
+      XC_LDA_C_PZ_MOD = libxc_t("XC_LDA_C_PZ_MOD", 10 , CORR),  &
+      XC_LDA_C_OB_PZ = libxc_t("XC_LDA_C_OB_PZ", 11 , CORR),  &
+      XC_LDA_C_PW = libxc_t("XC_LDA_C_PW", 12 , CORR),  &
+      XC_LDA_C_PW_MOD = libxc_t("XC_LDA_C_PW_MOD", 13 , CORR),  &
+      XC_LDA_C_OB_PW = libxc_t("XC_LDA_C_OB_PW", 14 , CORR),  &
+      XC_LDA_C_2D_AMGB = libxc_t("XC_LDA_C_2D_AMGB", 15 , CORR),  &
+      XC_LDA_C_2D_PRM = libxc_t("XC_LDA_C_2D_PRM", 16 , CORR),  &
+      XC_LDA_C_vBH = libxc_t("XC_LDA_C_vBH", 17 , CORR),  &
+      XC_LDA_C_1D_CSC = libxc_t("XC_LDA_C_1D_CSC", 18 , CORR),  &
+      XC_LDA_C_ML1 = libxc_t("XC_LDA_C_ML1", 22 , CORR),  &
+      XC_LDA_C_ML2 = libxc_t("XC_LDA_C_ML2", 23 , CORR),  &
+      XC_LDA_C_GOMBAS = libxc_t("XC_LDA_C_GOMBAS", 24 , CORR),  &
+      XC_LDA_C_PW_RPA = libxc_t("XC_LDA_C_PW_RPA", 25 , CORR),  &
+      XC_LDA_C_1D_LOOS = libxc_t("XC_LDA_C_1D_LOOS", 26 , CORR),  &
+      XC_LDA_C_RC04 = libxc_t("XC_LDA_C_RC04", 27 , CORR),  &
+      XC_LDA_C_VWN_1 = libxc_t("XC_LDA_C_VWN_1", 28 , CORR),  &
+      XC_LDA_C_VWN_2 = libxc_t("XC_LDA_C_VWN_2", 29 , CORR),  &
+      XC_LDA_C_VWN_3 = libxc_t("XC_LDA_C_VWN_3", 30 , CORR),  &
+      XC_LDA_C_VWN_4 = libxc_t("XC_LDA_C_VWN_4", 31 , CORR),  &
+      XC_GGA_C_Q2D = libxc_t("XC_GGA_C_Q2D", 47 , CORR),  &
+      XC_GGA_C_ZPBEINT = libxc_t("XC_GGA_C_ZPBEINT", 61 , CORR),  &
+      XC_GGA_C_PBEINT = libxc_t("XC_GGA_C_PBEINT", 62 , CORR),  &
+      XC_GGA_C_ZPBESOL = libxc_t("XC_GGA_C_ZPBESOL", 63 , CORR),  &
+      XC_GGA_C_N12_SX = libxc_t("XC_GGA_C_N12_SX", 79 , CORR),  &
+      XC_GGA_C_N12 = libxc_t("XC_GGA_C_N12", 80 , CORR),  &
+      XC_GGA_C_VPBE = libxc_t("XC_GGA_C_VPBE", 83 , CORR),  &
+      XC_GGA_C_OP_XALPHA = libxc_t("XC_GGA_C_OP_XALPHA", 84 , CORR),  &
+      XC_GGA_C_OP_G96 = libxc_t("XC_GGA_C_OP_G96", 85 , CORR),  &
+      XC_GGA_C_OP_PBE = libxc_t("XC_GGA_C_OP_PBE", 86 , CORR),  &
+      XC_GGA_C_OP_B88 = libxc_t("XC_GGA_C_OP_B88", 87 , CORR),  &
+      XC_GGA_C_FT97 = libxc_t("XC_GGA_C_FT97", 88 , CORR),  &
+      XC_GGA_C_SPBE = libxc_t("XC_GGA_C_SPBE", 89 , CORR),  &
+      XC_GGA_C_REVTCA = libxc_t("XC_GGA_C_REVTCA", 99 , CORR),  &
+      XC_GGA_C_TCA = libxc_t("XC_GGA_C_TCA", 100 , CORR),  &
+      XC_GGA_C_PBE = libxc_t("XC_GGA_C_PBE", 130 , CORR),  &
+      XC_GGA_C_LYP = libxc_t("XC_GGA_C_LYP", 131 , CORR),  &
+      XC_GGA_C_P86 = libxc_t("XC_GGA_C_P86", 132 , CORR),  &
+      XC_GGA_C_PBE_SOL = libxc_t("XC_GGA_C_PBE_SOL", 133 , CORR),  &
+      XC_GGA_C_PW91 = libxc_t("XC_GGA_C_PW91", 134 , CORR),  &
+      XC_GGA_C_AM05 = libxc_t("XC_GGA_C_AM05", 135 , CORR),  &
+      XC_GGA_C_XPBE = libxc_t("XC_GGA_C_XPBE", 136 , CORR),  &
+      XC_GGA_C_LM = libxc_t("XC_GGA_C_LM", 137 , CORR),  &
+      XC_GGA_C_PBE_JRGX = libxc_t("XC_GGA_C_PBE_JRGX", 138 , CORR),  &
+      XC_GGA_C_RGE2 = libxc_t("XC_GGA_C_RGE2", 143 , CORR),  &
+      XC_GGA_C_WL = libxc_t("XC_GGA_C_WL", 147 , CORR),  &
+      XC_GGA_C_WI = libxc_t("XC_GGA_C_WI", 148 , CORR),  &
+      XC_GGA_C_SOGGA11 = libxc_t("XC_GGA_C_SOGGA11", 152 , CORR),  &
+      XC_GGA_C_WI0 = libxc_t("XC_GGA_C_WI0", 153 , CORR),  &
+      XC_GGA_C_SOGGA11_X = libxc_t("XC_GGA_C_SOGGA11_X", 159 , CORR),  &
+      XC_GGA_C_APBE = libxc_t("XC_GGA_C_APBE", 186 , CORR),  &
+      XC_GGA_C_OPTC = libxc_t("XC_GGA_C_OPTC", 200 , CORR)
 
 ! Exchange and correlation
-type(libxc_t), parameter  ::                  &
-   XC_LDA_XC_TETER93 = libxc_t("XC_LDA_XC_TETER93", 20 , EXCH_CORR),  &
-   XC_GGA_XC_OPBE_D = libxc_t("XC_GGA_XC_OPBE_D", 65 , EXCH_CORR),  &
-   XC_GGA_XC_OPWLYP_D = libxc_t("XC_GGA_XC_OPWLYP_D", 66 , EXCH_CORR),  &
-   XC_GGA_XC_OBLYP_D = libxc_t("XC_GGA_XC_OBLYP_D", 67 , EXCH_CORR),  &
-   XC_GGA_XC_HCTH_407P = libxc_t("XC_GGA_XC_HCTH_407P", 93 , EXCH_CORR),  &
-   XC_GGA_XC_HCTH_P76 = libxc_t("XC_GGA_XC_HCTH_P76", 94 , EXCH_CORR),  &
-   XC_GGA_XC_HCTH_P14 = libxc_t("XC_GGA_XC_HCTH_P14", 95 , EXCH_CORR),  &
-   XC_GGA_XC_B97_GGA1 = libxc_t("XC_GGA_XC_B97_GGA1", 96 , EXCH_CORR),  &
-   XC_GGA_XC_HCTH_A = libxc_t("XC_GGA_XC_HCTH_A", 97 , EXCH_CORR),  &
-   XC_GGA_XC_KT2 = libxc_t("XC_GGA_XC_KT2", 146 , EXCH_CORR),  &
-   XC_GGA_XC_TH1 = libxc_t("XC_GGA_XC_TH1", 154 , EXCH_CORR),  &
-   XC_GGA_XC_TH2 = libxc_t("XC_GGA_XC_TH2", 155 , EXCH_CORR),  &
-   XC_GGA_XC_TH3 = libxc_t("XC_GGA_XC_TH3", 156 , EXCH_CORR),  &
-   XC_GGA_XC_TH4 = libxc_t("XC_GGA_XC_TH4", 157 , EXCH_CORR),  &
-   XC_GGA_XC_HCTH_93 = libxc_t("XC_GGA_XC_HCTH_93", 161 , EXCH_CORR),  &
-   XC_GGA_XC_HCTH_120 = libxc_t("XC_GGA_XC_HCTH_120", 162 , EXCH_CORR),  &
-   XC_GGA_XC_HCTH_147 = libxc_t("XC_GGA_XC_HCTH_147", 163 , EXCH_CORR),  &
-   XC_GGA_XC_HCTH_407 = libxc_t("XC_GGA_XC_HCTH_407", 164 , EXCH_CORR),  &
-   XC_GGA_XC_EDF1 = libxc_t("XC_GGA_XC_EDF1", 165 , EXCH_CORR),  &
-   XC_GGA_XC_XLYP = libxc_t("XC_GGA_XC_XLYP", 166 , EXCH_CORR),  &
-   XC_GGA_XC_B97 = libxc_t("XC_GGA_XC_B97", 167 , EXCH_CORR),  &
-   XC_GGA_XC_B97_1 = libxc_t("XC_GGA_XC_B97_1", 168 , EXCH_CORR),  &
-   XC_GGA_XC_B97_2 = libxc_t("XC_GGA_XC_B97_2", 169 , EXCH_CORR),  &
-   XC_GGA_XC_B97_D = libxc_t("XC_GGA_XC_B97_D", 170 , EXCH_CORR),  &
-   XC_GGA_XC_B97_K = libxc_t("XC_GGA_XC_B97_K", 171 , EXCH_CORR),  &
-   XC_GGA_XC_B97_3 = libxc_t("XC_GGA_XC_B97_3", 172 , EXCH_CORR),  &
-   XC_GGA_XC_PBE1W = libxc_t("XC_GGA_XC_PBE1W", 173 , EXCH_CORR),  &
-   XC_GGA_XC_MPWLYP1W = libxc_t("XC_GGA_XC_MPWLYP1W", 174 , EXCH_CORR),  &
-   XC_GGA_XC_PBELYP1W = libxc_t("XC_GGA_XC_PBELYP1W", 175 , EXCH_CORR),  &
-   XC_GGA_XC_SB98_1a = libxc_t("XC_GGA_XC_SB98_1a", 176 , EXCH_CORR),  &
-   XC_GGA_XC_SB98_1b = libxc_t("XC_GGA_XC_SB98_1b", 177 , EXCH_CORR),  &
-   XC_GGA_XC_SB98_1c = libxc_t("XC_GGA_XC_SB98_1c", 178 , EXCH_CORR),  &
-   XC_GGA_XC_SB98_2a = libxc_t("XC_GGA_XC_SB98_2a", 179 , EXCH_CORR),  &
-   XC_GGA_XC_SB98_2b = libxc_t("XC_GGA_XC_SB98_2b", 180 , EXCH_CORR),  &
-   XC_GGA_XC_SB98_2c = libxc_t("XC_GGA_XC_SB98_2c", 181 , EXCH_CORR),  &
-   XC_GGA_XC_MOHLYP = libxc_t("XC_GGA_XC_MOHLYP", 194 , EXCH_CORR),  &
-   XC_GGA_XC_MOHLYP2 = libxc_t("XC_GGA_XC_MOHLYP2", 195 , EXCH_CORR),  &
-   XC_GGA_XC_TH_FL = libxc_t("XC_GGA_XC_TH_FL", 196 , EXCH_CORR),  &
-   XC_GGA_XC_TH_FC = libxc_t("XC_GGA_XC_TH_FC", 197 , EXCH_CORR),  &
-   XC_GGA_XC_TH_FCFO = libxc_t("XC_GGA_XC_TH_FCFO", 198 , EXCH_CORR),  &
-   XC_GGA_XC_TH_FCO = libxc_t("XC_GGA_XC_TH_FCO", 199 , EXCH_CORR)
+   type(libxc_t), parameter  ::                  &
+      XC_LDA_XC_TETER93 = libxc_t("XC_LDA_XC_TETER93", 20 , EXCH_CORR),  &
+      XC_GGA_XC_OPBE_D = libxc_t("XC_GGA_XC_OPBE_D", 65 , EXCH_CORR),  &
+      XC_GGA_XC_OPWLYP_D = libxc_t("XC_GGA_XC_OPWLYP_D", 66 , EXCH_CORR),  &
+      XC_GGA_XC_OBLYP_D = libxc_t("XC_GGA_XC_OBLYP_D", 67 , EXCH_CORR),  &
+      XC_GGA_XC_HCTH_407P = libxc_t("XC_GGA_XC_HCTH_407P", 93 , EXCH_CORR),  &
+      XC_GGA_XC_HCTH_P76 = libxc_t("XC_GGA_XC_HCTH_P76", 94 , EXCH_CORR),  &
+      XC_GGA_XC_HCTH_P14 = libxc_t("XC_GGA_XC_HCTH_P14", 95 , EXCH_CORR),  &
+      XC_GGA_XC_B97_GGA1 = libxc_t("XC_GGA_XC_B97_GGA1", 96 , EXCH_CORR),  &
+      XC_GGA_XC_HCTH_A = libxc_t("XC_GGA_XC_HCTH_A", 97 , EXCH_CORR),  &
+      XC_GGA_XC_KT2 = libxc_t("XC_GGA_XC_KT2", 146 , EXCH_CORR),  &
+      XC_GGA_XC_TH1 = libxc_t("XC_GGA_XC_TH1", 154 , EXCH_CORR),  &
+      XC_GGA_XC_TH2 = libxc_t("XC_GGA_XC_TH2", 155 , EXCH_CORR),  &
+      XC_GGA_XC_TH3 = libxc_t("XC_GGA_XC_TH3", 156 , EXCH_CORR),  &
+      XC_GGA_XC_TH4 = libxc_t("XC_GGA_XC_TH4", 157 , EXCH_CORR),  &
+      XC_GGA_XC_HCTH_93 = libxc_t("XC_GGA_XC_HCTH_93", 161 , EXCH_CORR),  &
+      XC_GGA_XC_HCTH_120 = libxc_t("XC_GGA_XC_HCTH_120", 162 , EXCH_CORR),  &
+      XC_GGA_XC_HCTH_147 = libxc_t("XC_GGA_XC_HCTH_147", 163 , EXCH_CORR),  &
+      XC_GGA_XC_HCTH_407 = libxc_t("XC_GGA_XC_HCTH_407", 164 , EXCH_CORR),  &
+      XC_GGA_XC_EDF1 = libxc_t("XC_GGA_XC_EDF1", 165 , EXCH_CORR),  &
+      XC_GGA_XC_XLYP = libxc_t("XC_GGA_XC_XLYP", 166 , EXCH_CORR),  &
+      XC_GGA_XC_B97 = libxc_t("XC_GGA_XC_B97", 167 , EXCH_CORR),  &
+      XC_GGA_XC_B97_1 = libxc_t("XC_GGA_XC_B97_1", 168 , EXCH_CORR),  &
+      XC_GGA_XC_B97_2 = libxc_t("XC_GGA_XC_B97_2", 169 , EXCH_CORR),  &
+      XC_GGA_XC_B97_D = libxc_t("XC_GGA_XC_B97_D", 170 , EXCH_CORR),  &
+      XC_GGA_XC_B97_K = libxc_t("XC_GGA_XC_B97_K", 171 , EXCH_CORR),  &
+      XC_GGA_XC_B97_3 = libxc_t("XC_GGA_XC_B97_3", 172 , EXCH_CORR),  &
+      XC_GGA_XC_PBE1W = libxc_t("XC_GGA_XC_PBE1W", 173 , EXCH_CORR),  &
+      XC_GGA_XC_MPWLYP1W = libxc_t("XC_GGA_XC_MPWLYP1W", 174 , EXCH_CORR),  &
+      XC_GGA_XC_PBELYP1W = libxc_t("XC_GGA_XC_PBELYP1W", 175 , EXCH_CORR),  &
+      XC_GGA_XC_SB98_1a = libxc_t("XC_GGA_XC_SB98_1a", 176 , EXCH_CORR),  &
+      XC_GGA_XC_SB98_1b = libxc_t("XC_GGA_XC_SB98_1b", 177 , EXCH_CORR),  &
+      XC_GGA_XC_SB98_1c = libxc_t("XC_GGA_XC_SB98_1c", 178 , EXCH_CORR),  &
+      XC_GGA_XC_SB98_2a = libxc_t("XC_GGA_XC_SB98_2a", 179 , EXCH_CORR),  &
+      XC_GGA_XC_SB98_2b = libxc_t("XC_GGA_XC_SB98_2b", 180 , EXCH_CORR),  &
+      XC_GGA_XC_SB98_2c = libxc_t("XC_GGA_XC_SB98_2c", 181 , EXCH_CORR),  &
+      XC_GGA_XC_MOHLYP = libxc_t("XC_GGA_XC_MOHLYP", 194 , EXCH_CORR),  &
+      XC_GGA_XC_MOHLYP2 = libxc_t("XC_GGA_XC_MOHLYP2", 195 , EXCH_CORR),  &
+      XC_GGA_XC_TH_FL = libxc_t("XC_GGA_XC_TH_FL", 196 , EXCH_CORR),  &
+      XC_GGA_XC_TH_FC = libxc_t("XC_GGA_XC_TH_FC", 197 , EXCH_CORR),  &
+      XC_GGA_XC_TH_FCFO = libxc_t("XC_GGA_XC_TH_FCFO", 198 , EXCH_CORR),  &
+      XC_GGA_XC_TH_FCO = libxc_t("XC_GGA_XC_TH_FCO", 199 , EXCH_CORR)
 
 end module m_libxc_list

--- a/src/m_psmlout.f90
+++ b/src/m_psmlout.f90
@@ -4,17 +4,17 @@
 ! Copyright (c) 2015 by Alberto Garcia, ICMAB-CSIC for xmlf90-wxml calls
 ! in support of the PSML format
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
@@ -22,15 +22,15 @@
 !
 module m_psmlout
 
-  public :: psmlout, psmlout_r
-  private
+   public :: psmlout, psmlout_r
+   private
 
-  integer, parameter :: dp = selected_real_kind(10,100)
-  character(len=1), dimension(0:4) :: lsymb = (/'s','p','d','f','g'/)
+   integer, parameter :: dp = selected_real_kind(10,100)
+   character(len=1), dimension(0:4) :: lsymb = ['s','p','d','f','g']
 
-  CONTAINS
+CONTAINS
 
- subroutine psmlout(lmax,lloc,rc,vkb,evkb,nproj,rr,vpuns,rho,rhomod, &
+subroutine psmlout(lmax,lloc,rc,vkb,evkb,nproj,rr,vpuns,rho,rhomod, &
 &                  irct, srel, &
 &                  zz,zion,mmax,iexc,icmod,nrl,drl,atsym,epstot, &
 &                  na,la,ncon,nbas,nvcnf,nacnf,lacnf,nc,nv,lpopt,ncnf, &
@@ -44,7 +44,7 @@ module m_psmlout
 !evkb  coefficients of VKB projectors
 !nproj  number of vkb projectors for each l
 !rr  log radial grid
-!vpuns  unscreened semi-local pseudopotentials (vp(:,5) is local potential 
+!vpuns  unscreened semi-local pseudopotentials (vp(:,5) is local potential
 !  if linear combination is used)
 !rho  valence pseudocharge
 !rhomod  model core charge
@@ -59,293 +59,293 @@ module m_psmlout
 !epstot  pseudoatom total energy
 !psfile  should be 'upf'
 
-  ! Alberto Garcia, February 1, 2015
+   ! Alberto Garcia, February 1, 2015
 
-  use xmlf90_wxml     ! To write XML files
-  use m_libxc_list  ! For ease of libxc handling
+   use xmlf90_wxml     ! To write XML files
+   use m_libxc_list  ! For ease of libxc handling
 
- implicit none
+   implicit none
 
- real(dp), parameter :: pi=3.141592653589793238462643383279502884197_dp
+   real(dp), parameter :: pi=3.141592653589793238462643383279502884197_dp
 
 !Input variables
- integer :: lmax,lloc,iexc,mmax,nrl,icmod
- integer :: nproj(6)
- integer :: irct ! index of point at which rho_core is matched
- logical :: srel ! whether it is scalar-relativistic or not
- real(dp) :: drl,fcfact,zz,zion,epstot
- real(dp), target :: rr(mmax),vpuns(mmax,5),rho(mmax),vkb(mmax,2,4)
- real(dp), target :: rhomod(mmax,5)
- real(dp):: rc(6),evkb(2,4)
- character*2 :: atsym
+   integer :: lmax,lloc,iexc,mmax,nrl,icmod
+   integer :: nproj(6)
+   integer :: irct  ! index of point at which rho_core is matched
+   logical :: srel  ! whether it is scalar-relativistic or not
+   real(dp) :: drl,fcfact,zz,zion,epstot
+   real(dp), target :: rr(mmax),vpuns(mmax,5),rho(mmax),vkb(mmax,2,4)
+   real(dp), target :: rhomod(mmax,5)
+   real(dp):: rc(6),evkb(2,4)
+   character(len=2) :: atsym
 
 !additional input for upf output to echo input file, all as defined
 ! in the main progam
- integer :: na(30),la(30),ncon(6),nbas(6)
- integer :: nvcnf(5),nacnf(30,5),lacnf(30,5)
- integer :: nc,nv,lpopt,ncnf
- real(dp) :: fa(30),rc0(6),ep(6),qcut(6),debl(6),facnf(30,5)
- real(dp) :: dvloc0,epsh1,epsh2,depsh,rlmax
- character*4 :: psfile
+   integer :: na(30),la(30),ncon(6),nbas(6)
+   integer :: nvcnf(5),nacnf(30,5),lacnf(30,5)
+   integer :: nc,nv,lpopt,ncnf
+   real(dp) :: fa(30),rc0(6),ep(6),qcut(6),debl(6),facnf(30,5)
+   real(dp) :: dvloc0,epsh1,epsh2,depsh,rlmax
+   character(len=4) :: psfile
 
 !Local variables
- integer :: dtime(8)
+   integer :: dtime(8)
 
 !-------
 !psml stuff
 
-  type(xmlf_t) :: xf
-  type(libxc_t) :: libxc_id(2)
+   type(xmlf_t) :: xf
+   type(libxc_t) :: libxc_id(2)
 
-  integer   :: i, j, npts
-  integer   :: ii, jj, l1
-  real(dp)  :: rcore
-  real(dp)  :: total_valence_charge
-  real(dp), pointer :: r(:), chval(:), chcore(:)
-  real(dp), pointer :: vps(:), vlocal(:)
-  real(dp), allocatable :: r0(:), f0(:)
+   integer   :: i, j, npts
+   integer   :: ii, jj, l1
+   real(dp)  :: rcore
+   real(dp)  :: total_valence_charge
+   real(dp), pointer :: r(:), chval(:), chcore(:)
+   real(dp), pointer :: vps(:), vlocal(:)
+   real(dp), allocatable :: r0(:), f0(:)
 
-  character(len=100)    :: line
-  character*4      :: polattrib, coreattrib
-  character*1      :: pscode, char_dummy
-  character(len=2) :: nameat
-  character(len=40):: psflavor
+   character(len=100)    :: line
+   character(len=4)      :: polattrib, coreattrib
+   character(len=1)      :: pscode, char_dummy
+   character(len=2) :: nameat
+   character(len=40):: psflavor
 
-  character(len=1), dimension(0:4) :: lsymb = (/'s','p','d','f','g'/)
+   character(len=1), dimension(0:4) :: lsymb = ['s','p','d','f','g']
 
-  character*30 xcfuntype, xcfunparam
-  integer          :: ncore, nval, ncp, norbs, npots
+   character(len=30) :: xcfuntype, xcfunparam
+   integer          :: ncore, nval, ncp, norbs, npots
 
-  integer, allocatable  :: n(:), l(:)
-  integer, allocatable  :: nn(:), ll(:)
-  real(dp), allocatable :: f(:), ff(:)
-  real(dp), allocatable :: fdown(:), fup(:)
-  integer :: nr
-  character(len=10)     :: datestr
+   integer, allocatable  :: n(:), l(:)
+   integer, allocatable  :: nn(:), ll(:)
+   real(dp), allocatable :: f(:), ff(:)
+   real(dp), allocatable :: fdown(:), fup(:)
+   integer :: nr
+   character(len=10)     :: datestr
 
-  logical :: tdopsp, nonrel, polarized, there_is_core, found
-  integer :: lun, stat
+   logical :: tdopsp, nonrel, polarized, there_is_core, found
+   integer :: lun, stat
 
 !---
 
- call date_and_time(VALUES=dtime)
- write(datestr,"(i4,'-',i2.2,'-',i2.2)") dtime(1:3)
+   call date_and_time(VALUES=dtime)
+   write(datestr,"(i4,'-',i2.2,'-',i2.2)") dtime(1:3)
 
- !-------------- beginning of file echoing
-  call get_unit(lun)
-  open(unit=lun,file="_tmp_input",form="formatted",&
-       status="unknown",position="rewind",action="write")
+   !-------------- beginning of file echoing
+   call get_unit(lun)
+   open(unit=lun,file="_tmp_input",form="formatted",&
+        status="unknown",position="rewind",action="write")
 
- write(lun,'(a)') '# ATOM AND REFERENCE CONFIGURATION'
- write(lun,'(a)') '# atsym  z    nc    nv    iexc   psfile'
- write(lun,'(a,a,f6.2,3i6,2a)') '  ',trim(atsym),zz,nc,nv,iexc, &
-&      '      ',trim(psfile)
- write(lun,'(a/a)') '#','#   n    l    f        energy (Ha)'
- do ii=1,nc+nv
-   write(lun,'(2i5,f8.2)') na(ii),la(ii),fa(ii)
- end do
-
- write(lun,'(a/a/a)') '#','# PSEUDOPOTENTIAL AND OPTIMIZATION','# lmax'
- write(lun,'(i5)')  lmax
- write(lun,'(a/a)') '#','#   l,   rc,     ep,   ncon, nbas, qcut'
- do l1=1,lmax+1
-   write(lun,'(i5,2f8.2,2i5,f8.2)') l1-1,rc(l1),ep(l1),ncon(l1),nbas(l1),qcut(l1)
- end do
-
- write(lun,'(a/a/a,a)') '#','# LOCAL POTENTIAL','# lloc, lpopt,  rc(5),', &
-&      '   dvloc0'
- write(lun,'(2i5,f10.2,a,f8.2)') lloc,lpopt,rc(5),'   ',dvloc0
-
- write(lun,'(a/a/a)') '#','# VANDERBILT-KLEINMAN-BYLANDER PROJECTORs', &
-&      '# l, nproj, debl'
- do l1=1,lmax+1
-   write(lun,'(2i5,f10.4)') l1-1,nproj(l1),debl(l1)
- end do
-
- write(lun,'(a/a/a)') '#','# MODEL CORE CHARGE', &
-&      '# icmod, fcfact'
- write(lun,'(i5,f8.2,2i5,f8.2)') icmod,fcfact
-
- write(lun,'(a/a/a)') '#','# LOG DERIVATIVE ANALYSIS', &
-&      '# epsh1, epsh2, depsh'
- write(lun,'(3f8.2)') epsh1,epsh2,depsh
-
- write(lun,'(a/a/a)') '#','# OUTPUT GRID','# rlmax, drl'
- write(lun,'(2f8.2)') rlmax,drl
-
- write(lun,'(a/a/a)') '#','# TEST CONFIGURATIONS','# ncnf'
- write(lun,'(i5)') ncnf
- write(lun,'(a/a)') '# nvcnf','#   n    l    f'
- do jj=2,ncnf+1
-   write(lun,'(i5)') nvcnf(jj)
-   do ii=nc+1,nc+nvcnf(jj)
-     write(lun,'(2i5,f8.2)') nacnf(ii,jj),lacnf(ii,jj),facnf(ii,jj)
+   write(lun,'(a)') '# ATOM AND REFERENCE CONFIGURATION'
+   write(lun,'(a)') '# atsym  z    nc    nv    iexc   psfile'
+   write(lun,'(a,a,f6.2,3i6,2a)') '  ',trim(atsym),zz,nc,nv,iexc, &
+   &      '      ',trim(psfile)
+   write(lun,'(a/a)') '#','#   n    l    f        energy (Ha)'
+   do ii=1,nc+nv
+      write(lun,'(2i5,f8.2)') na(ii),la(ii),fa(ii)
    end do
-   write(lun,'(a)') '#'
- end do
- close(lun)
 
-  call xml_OpenFile("ONCVPSP.psml",xf, indent=.false.)
+   write(lun,'(a/a/a)') '#','# PSEUDOPOTENTIAL AND OPTIMIZATION','# lmax'
+   write(lun,'(i5)')  lmax
+   write(lun,'(a/a)') '#','#   l,   rc,     ep,   ncon, nbas, qcut'
+   do l1=1,lmax+1
+      write(lun,'(i5,2f8.2,2i5,f8.2)') l1-1,rc(l1),ep(l1),ncon(l1),nbas(l1),qcut(l1)
+   end do
 
-  call xml_AddXMLDeclaration(xf,"UTF-8")
+   write(lun,'(a/a/a,a)') '#','# LOCAL POTENTIAL','# lloc, lpopt,  rc(5),', &
+   &      '   dvloc0'
+   write(lun,'(2i5,f10.2,a,f8.2)') lloc,lpopt,rc(5),'   ',dvloc0
 
-  call xml_NewElement(xf,"psml")
-  call my_add_attribute(xf,"version","0.8")
-  call my_add_attribute(xf,"energy_unit","hartree")
-  call my_add_attribute(xf,"length_unit","bohr")
+   write(lun,'(a/a/a)') '#','# VANDERBILT-KLEINMAN-BYLANDER PROJECTORs', &
+   &      '# l, nproj, debl'
+   do l1=1,lmax+1
+      write(lun,'(2i5,f10.4)') l1-1,nproj(l1),debl(l1)
+   end do
 
-  call xml_NewElement(xf,"provenance")
-  call my_add_attribute(xf,"creator","ONCVPSP-2.1.2+psml")
-  call my_add_attribute(xf,"date",datestr)
-  call xml_NewElement(xf,"input-file")
-  call my_add_attribute(xf,"name","oncvpsp-input")
+   write(lun,'(a/a/a)') '#','# MODEL CORE CHARGE', &
+   &      '# icmod, fcfact'
+   write(lun,'(i5,f8.2,2i5,f8.2)') icmod,fcfact
+
+   write(lun,'(a/a/a)') '#','# LOG DERIVATIVE ANALYSIS', &
+   &      '# epsh1, epsh2, depsh'
+   write(lun,'(3f8.2)') epsh1,epsh2,depsh
+
+   write(lun,'(a/a/a)') '#','# OUTPUT GRID','# rlmax, drl'
+   write(lun,'(2f8.2)') rlmax,drl
+
+   write(lun,'(a/a/a)') '#','# TEST CONFIGURATIONS','# ncnf'
+   write(lun,'(i5)') ncnf
+   write(lun,'(a/a)') '# nvcnf','#   n    l    f'
+   do jj=2,ncnf+1
+      write(lun,'(i5)') nvcnf(jj)
+      do ii=nc+1,nc+nvcnf(jj)
+         write(lun,'(2i5,f8.2)') nacnf(ii,jj),lacnf(ii,jj),facnf(ii,jj)
+      end do
+      write(lun,'(a)') '#'
+   end do
+   close(lun)
+
+   call xml_OpenFile("ONCVPSP.psml",xf, indent=.false.)
+
+   call xml_AddXMLDeclaration(xf,"UTF-8")
+
+   call xml_NewElement(xf,"psml")
+   call my_add_attribute(xf,"version","0.8")
+   call my_add_attribute(xf,"energy_unit","hartree")
+   call my_add_attribute(xf,"length_unit","bohr")
+
+   call xml_NewElement(xf,"provenance")
+   call my_add_attribute(xf,"creator","ONCVPSP-2.1.2+psml")
+   call my_add_attribute(xf,"date",datestr)
+   call xml_NewElement(xf,"input-file")
+   call my_add_attribute(xf,"name","oncvpsp-input")
 !
-  call get_unit(lun)
-  open(unit=lun,file="_tmp_input",form="formatted",&
-       status="old",position="rewind",action="read")
+   call get_unit(lun)
+   open(unit=lun,file="_tmp_input",form="formatted",&
+        status="old",position="rewind",action="read")
 
-  rewind(lun)
-  do
-     read(lun,fmt="(a)",iostat=stat) line
-     if (stat .ne. 0) exit
-     call xml_AddPcData(xf,trim(line),line_feed=.true.)
-  enddo
-  close(lun)
+   rewind(lun)
+   do
+      read(lun,fmt="(a)",iostat=stat) line
+      if (stat /= 0) exit
+      call xml_AddPcData(xf,trim(line),line_feed=.true.)
+   enddo
+   close(lun)
 
-  call xml_EndElement(xf,"input-file")
-  !
-  call xml_EndElement(xf,"provenance")
+   call xml_EndElement(xf,"input-file")
+   !
+   call xml_EndElement(xf,"provenance")
 
 !  nameat = symbol(nint(zz))
-  nameat = atsym
-  ncore  = nc
-  nval   = nv
+   nameat = atsym
+   ncore  = nc
+   nval   = nv
 
-  norbs = ncore + nval
-  allocate (n(norbs), l(norbs), f(norbs))
+   norbs = ncore + nval
+   allocate (n(norbs), l(norbs), f(norbs))
 
-  total_valence_charge = 0.0_dp
-  ncp = ncore + 1
-  do i = 1, norbs
-     n(i) = na(i)
-     l(i) = la(i)
-     f(i) = fa(i)
-     if (i > ncore) then
-        total_valence_charge =   total_valence_charge + f(i)
-     endif
-  enddo
-  lmax = lmax
+   total_valence_charge = 0.0_dp
+   ncp = ncore + 1
+   do i = 1, norbs
+      n(i) = na(i)
+      l(i) = la(i)
+      f(i) = fa(i)
+      if (i > ncore) then
+         total_valence_charge =   total_valence_charge + f(i)
+      endif
+   enddo
+   lmax = lmax
 
-  npots = lmax + 1
-  allocate (ll(npots), nn(npots), ff(npots))
-  do i = 1, npots
-     ll(i) = i - 1
-     found = .false.
-     ! look for the appropriate shell in the valence
-     do j = ncp, norbs
-        if (l(j) == ll(i)) then
-           found = .true.
-           nn(i) = n(j)
-           ff(i) = f(j)
-           exit
-        endif
-     enddo
-     if (.not. found) then
-        ! generate the appropriate effective n
-        nn(i) = ll(i) + 1
-        do j = 1, ncore
-           if (l(j) == ll(i)) then
-              nn(i) = nn(i) + 1
-           endif
-           ff(i) = 0.0_dp
-        enddo
-     endif
-  enddo
+   npots = lmax + 1
+   allocate (ll(npots), nn(npots), ff(npots))
+   do i = 1, npots
+      ll(i) = i - 1
+      found = .false.
+      ! look for the appropriate shell in the valence
+      do j = ncp, norbs
+         if (l(j) == ll(i)) then
+            found = .true.
+            nn(i) = n(j)
+            ff(i) = f(j)
+            exit
+         endif
+      enddo
+      if (.not. found) then
+         ! generate the appropriate effective n
+         nn(i) = ll(i) + 1
+         do j = 1, ncore
+            if (l(j) == ll(i)) then
+               nn(i) = nn(i) + 1
+            endif
+            ff(i) = 0.0_dp
+         enddo
+      endif
+   enddo
 
-  psflavor ="Hamann's oncvpsp"
+   psflavor ="Hamann's oncvpsp"
 
-  polarized = .false.
-  polattrib = "no"
-  there_is_core = (icmod >= 1)
-  if (there_is_core) then
-     coreattrib = "yes"
-  else
-     coreattrib = "no"
-  endif
+   polarized = .false.
+   polattrib = "no"
+   there_is_core = (icmod >= 1)
+   if (there_is_core) then
+      coreattrib = "yes"
+   else
+      coreattrib = "no"
+   endif
 
-  ! XC name handling
+   ! XC name handling
 
-  select case(iexc)
+   select case(iexc)
 
-  case(1) 
-     xcfuntype    = 'LDA'
-     xcfunparam   = 'Wigner'
-     libxc_id = (/ XC_LDA_X, XC_LDA_C_WIGNER /)
-  case(2) 
-     xcfuntype    = 'LDA'
-     xcfunparam   = 'Hedin-Lundqvist'
-     libxc_id = (/ XC_LDA_X, XC_LDA_C_HL /)
-  case(3) 
-     xcfuntype    = 'LDA'
-     xcfunparam   = 'Ceperley-Alder PZ'
-     libxc_id = (/ XC_LDA_X, XC_LDA_C_PZ /)
+    case(1)
+      xcfuntype    = 'LDA'
+      xcfunparam   = 'Wigner'
+      libxc_id = [ XC_LDA_X, XC_LDA_C_WIGNER ]
+    case(2)
+      xcfuntype    = 'LDA'
+      xcfunparam   = 'Hedin-Lundqvist'
+      libxc_id = [ XC_LDA_X, XC_LDA_C_HL ]
+    case(3)
+      xcfuntype    = 'LDA'
+      xcfunparam   = 'Ceperley-Alder PZ'
+      libxc_id = [ XC_LDA_X, XC_LDA_C_PZ ]
 
-  case(4) 
-     xcfuntype    = 'GGA'
-     xcfunparam   = 'Perdew-Burke-Ernzerhof'
-     libxc_id = (/ XC_GGA_X_PBE, XC_GGA_C_PBE /) 
+    case(4)
+      xcfuntype    = 'GGA'
+      xcfunparam   = 'Perdew-Burke-Ernzerhof'
+      libxc_id = [ XC_GGA_X_PBE, XC_GGA_C_PBE ]
 
-  case  default
+    case  default
 
-     xcfuntype    = '-----'
-     xcfunparam   = '-----'
-     libxc_id = (/  XC_NOT_IMPL, XC_NOT_IMPL /)   ! ???
+      xcfuntype    = '-----'
+      xcfunparam   = '-----'
+      libxc_id = [  XC_NOT_IMPL, XC_NOT_IMPL ]   ! ???
 
-  end select
-  !
-  !
-  call xml_NewElement(xf,"header")
-  call my_add_attribute(xf,"atomic-label",nameat)
-  call my_add_attribute(xf,"atomic-number",str(zz))
-  call my_add_attribute(xf,"z-pseudo",str(zion))
-  call my_add_attribute(xf,"flavor",psflavor)
-  if (srel) then
-     call my_add_attribute(xf,"relativity","scalar")
-  else
-     call my_add_attribute(xf,"relativity","no")
-  endif
-  call my_add_attribute(xf,"polarized",polattrib)
-  call my_add_attribute(xf,"core-corrections",coreattrib)
+   end select
+   !
+   !
+   call xml_NewElement(xf,"header")
+   call my_add_attribute(xf,"atomic-label",nameat)
+   call my_add_attribute(xf,"atomic-number",str(zz))
+   call my_add_attribute(xf,"z-pseudo",str(zion))
+   call my_add_attribute(xf,"flavor",psflavor)
+   if (srel) then
+      call my_add_attribute(xf,"relativity","scalar")
+   else
+      call my_add_attribute(xf,"relativity","no")
+   endif
+   call my_add_attribute(xf,"polarized",polattrib)
+   call my_add_attribute(xf,"core-corrections",coreattrib)
 
-          call xml_NewElement(xf,"exchange-correlation")
-          call xml_NewElement(xf,"annotation")
-          call my_add_attribute(xf,"oncvpsp-xc-code",str(iexc))
-          call my_add_attribute(xf,"oncvpsp-xc-type",trim(xcfuntype))
-          call my_add_attribute(xf,"oncvpsp-xc-authors",trim(xcfunparam))
-          call xml_EndElement(xf,"annotation")
+   call xml_NewElement(xf,"exchange-correlation")
+   call xml_NewElement(xf,"annotation")
+   call my_add_attribute(xf,"oncvpsp-xc-code",str(iexc))
+   call my_add_attribute(xf,"oncvpsp-xc-type",trim(xcfuntype))
+   call my_add_attribute(xf,"oncvpsp-xc-authors",trim(xcfunparam))
+   call xml_EndElement(xf,"annotation")
 
-          call xml_NewElement(xf,"libxc-info")
-          call my_add_attribute(xf,"number-of-functionals","2")
-           do i = 1, 2
-              call xml_NewElement(xf,"functional")
-               call my_add_attribute(xf,"name",trim(libxc_id(i)%name))
-               call my_add_attribute(xf,"type",trim(libxc_id(i)%xc_kind%str))
-               call my_add_attribute(xf,"id",str(libxc_id(i)%code))
-              call xml_EndElement(xf,"functional")
-           enddo
-          call xml_EndElement(xf,"libxc-info")
-          call xml_EndElement(xf,"exchange-correlation")
-          !
+   call xml_NewElement(xf,"libxc-info")
+   call my_add_attribute(xf,"number-of-functionals","2")
+   do i = 1, 2
+      call xml_NewElement(xf,"functional")
+      call my_add_attribute(xf,"name",trim(libxc_id(i)%name))
+      call my_add_attribute(xf,"type",trim(libxc_id(i)%xc_kind%str))
+      call my_add_attribute(xf,"id",str(libxc_id(i)%code))
+      call xml_EndElement(xf,"functional")
+   enddo
+   call xml_EndElement(xf,"libxc-info")
+   call xml_EndElement(xf,"exchange-correlation")
+   !
 
-  !
-  call do_configuration()
-  call xml_EndElement(xf,"header")
+   !
+   call do_configuration()
+   call xml_EndElement(xf,"header")
 
 !AG: save
    if(lloc==4) then
-       ! fitted local potential
+      ! fitted local potential
    else
-       ! 'l_local="',lloc,'"'
+      ! 'l_local="',lloc,'"'
    end if
 !AG -- decide how to handle the case of Vlocal as one of the sl pots.
 
@@ -353,156 +353,156 @@ module m_psmlout
 !AG: decide whether to use a single mesh (Hamann's own) or have the
 ! projectors use another one (linear, shorter)
 
- npts = mmax
+   npts = mmax
 
- r => rr(:)
- chval => rho(:)
- chcore => rhomod(:,1)
+   r => rr(:)
+   chval => rho(:)
+   chcore => rhomod(:,1)
 
-  nr = npts + 1
-  allocate(r0(nr))
-  call add_zero_r(r,r,r0)
-  r0(1) = 0.0_dp
+   nr = npts + 1
+   allocate(r0(nr))
+   call add_zero_r(r,r,r0)
+   r0(1) = 0.0_dp
 
-  call xml_NewElement(xf,"grid")
-  call my_add_attribute(xf,"npts",str(nr))
+   call xml_NewElement(xf,"grid")
+   call my_add_attribute(xf,"npts",str(nr))
 
-  call xml_NewElement(xf,"annotation")
-  call my_add_attribute(xf,"type","oncvpsp plus r=0")
-  call my_add_attribute(xf,"oncvpsp-npts",str(npts))
-  call my_add_attribute(xf,"oncvpsp-r1",trim(str(r(1))))
-  call my_add_attribute(xf,"oncvpsp-factor",trim(str(r(2)/r(1))))
-  call xml_EndElement(xf,"annotation")
+   call xml_NewElement(xf,"annotation")
+   call my_add_attribute(xf,"type","oncvpsp plus r=0")
+   call my_add_attribute(xf,"oncvpsp-npts",str(npts))
+   call my_add_attribute(xf,"oncvpsp-r1",trim(str(r(1))))
+   call my_add_attribute(xf,"oncvpsp-factor",trim(str(r(2)/r(1))))
+   call xml_EndElement(xf,"annotation")
 
-  call xml_NewElement(xf,"grid-data")
-  call xml_AddArray(xf,r0(1:nr))
-  call xml_EndElement(xf,"grid-data")
+   call xml_NewElement(xf,"grid-data")
+   call xml_AddArray(xf,r0(1:nr))
+   call xml_EndElement(xf,"grid-data")
 
-  call xml_EndElement(xf,"grid")
+   call xml_EndElement(xf,"grid")
 
-  call xml_NewElement(xf,"semilocal-potentials")
-  if (srel) then
-     call my_add_attribute(xf,"set","scalar_relativistic")
-  else
-     call my_add_attribute(xf,"set","non_relativistic")
-  endif
-  !  
-  allocate(f0(nr))
-  vpsd: do i = 1, npots
-     vps => vpuns(:,i)
-     call add_zero_r(vps(1:npts),r,f0)
-     call write_psml_item(xf, class="slps", &
-                          n=nn(i), l=ll(i), &
-                          rc=rc(i),flavor=psflavor,&
-                          f=f0)
-  enddo vpsd
-  call xml_EndElement(xf,"semilocal-potentials")
+   call xml_NewElement(xf,"semilocal-potentials")
+   if (srel) then
+      call my_add_attribute(xf,"set","scalar_relativistic")
+   else
+      call my_add_attribute(xf,"set","non_relativistic")
+   endif
+   !
+   allocate(f0(nr))
+   vpsd: do i = 1, npots
+      vps => vpuns(:,i)
+      call add_zero_r(vps(1:npts),r,f0)
+      call write_psml_item(xf, class="slps", &
+                           n=nn(i), l=ll(i), &
+                           rc=rc(i),flavor=psflavor,&
+                           f=f0)
+   enddo vpsd
+   call xml_EndElement(xf,"semilocal-potentials")
 !
 !--------
-  call xml_NewElement(xf,"valence-charge")
-  call my_add_attribute(xf,"total-charge",  &
-                      str(total_valence_charge))
-  call xml_NewElement(xf,"radfunc")
+   call xml_NewElement(xf,"valence-charge")
+   call my_add_attribute(xf,"total-charge",  &
+                         str(total_valence_charge))
+   call xml_NewElement(xf,"radfunc")
 
-  call xml_NewElement(xf,"data")
-  call add_zero_r(chval(1:npts),r,f0)
+   call xml_NewElement(xf,"data")
+   call add_zero_r(chval(1:npts),r,f0)
 !  call xml_AddArray(xf,chval(1:npts))
-  call xml_AddArray(xf,f0(1:nr))
-  call xml_EndElement(xf,"data")
-  call xml_EndElement(xf,"radfunc")
-  call xml_EndElement(xf,"valence-charge")
+   call xml_AddArray(xf,f0(1:nr))
+   call xml_EndElement(xf,"data")
+   call xml_EndElement(xf,"radfunc")
+   call xml_EndElement(xf,"valence-charge")
 
 
-  if (there_is_core) then
-     rcore = rr(irct)
-     call xml_NewElement(xf,"pseudocore-charge")
-     call my_add_attribute(xf,"matching-radius",str(rcore))
-     call my_add_attribute(xf,"number-of-continuous-derivatives", &
-                                    str(4))
-     call my_add_attribute(xf,"annotation",  &
-                  "Monotonic 8th-order polynomial with no linear term")
-     call xml_NewElement(xf,"radfunc")
+   if (there_is_core) then
+      rcore = rr(irct)
+      call xml_NewElement(xf,"pseudocore-charge")
+      call my_add_attribute(xf,"matching-radius",str(rcore))
+      call my_add_attribute(xf,"number-of-continuous-derivatives", &
+                            str(4))
+      call my_add_attribute(xf,"annotation",  &
+                            "Monotonic 8th-order polynomial with no linear term")
+      call xml_NewElement(xf,"radfunc")
 
-     call xml_NewElement(xf,"data")
-     call add_zero_r(chcore(1:npts),r,f0)
-     call xml_AddArray(xf,f0(1:nr))
-     call xml_EndElement(xf,"data")
-     call xml_EndElement(xf,"radfunc")
-     call xml_EndElement(xf,"pseudocore-charge")
-     deallocate(chcore)
-  endif
+      call xml_NewElement(xf,"data")
+      call add_zero_r(chcore(1:npts),r,f0)
+      call xml_AddArray(xf,f0(1:nr))
+      call xml_EndElement(xf,"data")
+      call xml_EndElement(xf,"radfunc")
+      call xml_EndElement(xf,"pseudocore-charge")
+      deallocate(chcore)
+   endif
 
-      call xml_NewElement(xf,"pseudopotential-operator")
-      call my_add_attribute(xf,"version","0.1")
-      call my_add_attribute(xf,"energy_unit","hartree")
-      call my_add_attribute(xf,"length_unit","bohr")
+   call xml_NewElement(xf,"pseudopotential-operator")
+   call my_add_attribute(xf,"version","0.1")
+   call my_add_attribute(xf,"energy_unit","hartree")
+   call my_add_attribute(xf,"length_unit","bohr")
 
-        call xml_NewElement(xf,"provenance")
-          call my_add_attribute(xf,"creator","oncvpsp 2.1.2+psml")
-        call xml_EndElement(xf,"provenance")
+   call xml_NewElement(xf,"provenance")
+   call my_add_attribute(xf,"creator","oncvpsp 2.1.2+psml")
+   call xml_EndElement(xf,"provenance")
 
-        vlocal => vpuns(:,lloc+1)
-        call xml_NewElement(xf,"local-potential")
-            if (lloc > lmax) then
-               call my_add_attribute(xf,"type","oncv-fit")
-            else
-               call my_add_attribute(xf,"type","l="//str(lloc))
-            endif
-            call xml_NewElement(xf,"radfunc")
-               call xml_NewElement(xf,"data")
-                call add_zero_r(vlocal(1:npts),r,f0)
-                call xml_AddArray(xf,f0(1:nr))
-               call xml_EndElement(xf,"data")
-            call xml_EndElement(xf,"radfunc")
-        call xml_EndElement(xf,"local-potential")
+   vlocal => vpuns(:,lloc+1)
+   call xml_NewElement(xf,"local-potential")
+   if (lloc > lmax) then
+      call my_add_attribute(xf,"type","oncv-fit")
+   else
+      call my_add_attribute(xf,"type","l="//str(lloc))
+   endif
+   call xml_NewElement(xf,"radfunc")
+   call xml_NewElement(xf,"data")
+   call add_zero_r(vlocal(1:npts),r,f0)
+   call xml_AddArray(xf,f0(1:nr))
+   call xml_EndElement(xf,"data")
+   call xml_EndElement(xf,"radfunc")
+   call xml_EndElement(xf,"local-potential")
 
-      call xml_NewElement(xf,"projectors")
-      if (srel) then
-         call my_add_attribute(xf,"set","scalar_relativistic")
-      else
-         call my_add_attribute(xf,"set","non_relativistic")
-      endif
+   call xml_NewElement(xf,"projectors")
+   if (srel) then
+      call my_add_attribute(xf,"set","scalar_relativistic")
+   else
+      call my_add_attribute(xf,"set","non_relativistic")
+   endif
 
-      do l1=1,lmax+1
-         if(l1==lloc+1) cycle
-         do jj=1,nproj(l1)
-            call add_zero_r(vkb(:,jj,l1),r,f0)
-            call write_psml_item(xf, class="proj", &
-                                 seq=jj, l=l1-1, &
-                                 ekb=evkb(jj,l1), &
-                                 type="oncv", f=f0)
-         enddo
+   do l1=1,lmax+1
+      if(l1==lloc+1) cycle
+      do jj=1,nproj(l1)
+         call add_zero_r(vkb(:,jj,l1),r,f0)
+         call write_psml_item(xf, class="proj", &
+                              seq=jj, l=l1-1, &
+                              ekb=evkb(jj,l1), &
+                              type="oncv", f=f0)
       enddo
+   enddo
 
-      call xml_EndElement(xf,"projectors")
+   call xml_EndElement(xf,"projectors")
 
-    call xml_EndElement(xf,"pseudopotential-operator")
+   call xml_EndElement(xf,"pseudopotential-operator")
 
-  call xml_EndElement(xf,"psml")
+   call xml_EndElement(xf,"psml")
 
 
-  call xml_Close(xf)
+   call xml_Close(xf)
 
-  deallocate(f0,r0)
+   deallocate(f0,r0)
 
 CONTAINS
-  subroutine do_configuration()
+subroutine do_configuration()
 
-  call xml_NewElement(xf,"valence-configuration")
-  call my_add_attribute(xf,"total-valence-charge", str(total_valence_charge))
-  do i = ncp, norbs
-     if (f(i) .lt. 1.0e-10_dp) cycle
-     call xml_NewElement(xf,"shell")
-     call my_add_attribute(xf,"n",str(n(i)))
-     call my_add_attribute(xf,"l",lsymb(l(i)))
-     call my_add_attribute(xf,"occupation",str(f(i)))
-     if (polarized) then
-        call my_add_attribute(xf,"occupation-down",str(fdown(i)))
-        call my_add_attribute(xf,"occupation-up",str(fup(i)))
-     endif
-     call xml_EndElement(xf,"shell")
-  enddo
-  call xml_EndElement(xf,"valence-configuration")
+   call xml_NewElement(xf,"valence-configuration")
+   call my_add_attribute(xf,"total-valence-charge", str(total_valence_charge))
+   do i = ncp, norbs
+      if (f(i) < 1.0e-10_dp) cycle
+      call xml_NewElement(xf,"shell")
+      call my_add_attribute(xf,"n",str(n(i)))
+      call my_add_attribute(xf,"l",lsymb(l(i)))
+      call my_add_attribute(xf,"occupation",str(f(i)))
+      if (polarized) then
+         call my_add_attribute(xf,"occupation-down",str(fdown(i)))
+         call my_add_attribute(xf,"occupation-up",str(fup(i)))
+      endif
+      call xml_EndElement(xf,"shell")
+   enddo
+   call xml_EndElement(xf,"valence-configuration")
 end subroutine do_configuration
 
 end subroutine psmlout
@@ -510,7 +510,7 @@ end subroutine psmlout
 !=================================================
 ! Fully relativistic version
 !
- subroutine psmlout_r(lmax,lloc,rc,vkb,evkb,nproj,rr,vpuns,rho,rhomod, &
+subroutine psmlout_r(lmax,lloc,rc,vkb,evkb,nproj,rr,vpuns,rho,rhomod, &
 &                  irct, &
 &                  vsr,esr,vso,eso, &
 &                  zz,zion,mmax,iexc,icmod,nrl,drl,atsym,epstot, &
@@ -525,7 +525,7 @@ end subroutine psmlout
 !evkb  coefficients of VKB projectors
 !nproj  number of vkb projectors for each l
 !rr  log radial grid
-!vpuns  unscreened semi-local pseudopotentials (vp(:,5) is local potential 
+!vpuns  unscreened semi-local pseudopotentials (vp(:,5) is local potential
 !  if linear combination is used)
 !rho  valence pseudocharge
 !rhomod  model core charge
@@ -540,290 +540,290 @@ end subroutine psmlout
 !epstot  pseudoatom total energy
 !psfile  'upf' or 'psp8'
 
-  ! Alberto Garcia, February 1, 2015
+   ! Alberto Garcia, February 1, 2015
 
-  use xmlf90_wxml     ! To write XML files
-  use m_libxc_list  ! For ease of libxc handling
+   use xmlf90_wxml     ! To write XML files
+   use m_libxc_list  ! For ease of libxc handling
 
- implicit none
+   implicit none
 
- real(dp), parameter :: pi=3.141592653589793238462643383279502884197_dp
+   real(dp), parameter :: pi=3.141592653589793238462643383279502884197_dp
 
 !Input variables
- integer :: lmax,lloc,iexc,mmax,nrl,icmod
- integer :: nproj(6)
- integer :: irct ! index of point at which rho_core is matched
- real(dp) :: drl,fcfact,zz,zion,epstot
- real(dp), target :: rr(mmax),vpuns(mmax,5,2),rho(mmax),vkb(mmax,2,4,2)
- real(dp), target :: rhomod(mmax,5)
- real(dp):: rc(6),evkb(2,4,2)
- real(dp), target :: vsr(mmax,4,4),vso(mmax,4,4)
- real(dp) :: esr(4,4),eso(4,4)
- character*2 :: atsym
+   integer :: lmax,lloc,iexc,mmax,nrl,icmod
+   integer :: nproj(6)
+   integer :: irct  ! index of point at which rho_core is matched
+   real(dp) :: drl,fcfact,zz,zion,epstot
+   real(dp), target :: rr(mmax),vpuns(mmax,5,2),rho(mmax),vkb(mmax,2,4,2)
+   real(dp), target :: rhomod(mmax,5)
+   real(dp):: rc(6),evkb(2,4,2)
+   real(dp), target :: vsr(mmax,4,4),vso(mmax,4,4)
+   real(dp) :: esr(4,4),eso(4,4)
+   character(len=2) :: atsym
 
 !additional input for upf output to echo input file, all as defined
 ! in the main progam
- integer :: na(30),la(30),ncon(6),nbas(6)
- integer :: nvcnf(5),nacnf(30,5),lacnf(30,5)
- integer :: nc,nv,lpopt,ncnf
- real(dp) :: fa(30),rc0(6),ep(6),qcut(6),debl(6),facnf(30,5)
- real(dp) :: dvloc0,epsh1,epsh2,depsh,rlmax
- character*4 :: psfile
+   integer :: na(30),la(30),ncon(6),nbas(6)
+   integer :: nvcnf(5),nacnf(30,5),lacnf(30,5)
+   integer :: nc,nv,lpopt,ncnf
+   real(dp) :: fa(30),rc0(6),ep(6),qcut(6),debl(6),facnf(30,5)
+   real(dp) :: dvloc0,epsh1,epsh2,depsh,rlmax
+   character(len=4) :: psfile
 
 
 !Local variables
- integer :: dtime(8)
- integer :: npr_so(4), npr_sr(4)
+   integer :: dtime(8)
+   integer :: npr_so(4), npr_sr(4)
 
-  type(xmlf_t) :: xf
-  type(libxc_t) :: libxc_id(2)
+   type(xmlf_t) :: xf
+   type(libxc_t) :: libxc_id(2)
 
-  integer   :: i, j, npts
-  integer   :: ii, jj, l1, jk
-  real(dp)  :: rcore, jval
-  real(dp)  :: total_valence_charge
-  real(dp), pointer :: r(:), chval(:), chcore(:)
-  real(dp), pointer :: vlocal(:)
-  real(dp), allocatable :: r0(:), f0(:), vps(:)
+   integer   :: i, j, npts
+   integer   :: ii, jj, l1, jk
+   real(dp)  :: rcore, jval
+   real(dp)  :: total_valence_charge
+   real(dp), pointer :: r(:), chval(:), chcore(:)
+   real(dp), pointer :: vlocal(:)
+   real(dp), allocatable :: r0(:), f0(:), vps(:)
 
-  character(len=100)    :: line
-  character*4      :: polattrib, coreattrib
-  character*1      :: pscode, char_dummy
-  character(len=2) :: nameat
-  character(len=40):: psflavor
+   character(len=100)    :: line
+   character(len=4)      :: polattrib, coreattrib
+   character(len=1)      :: pscode, char_dummy
+   character(len=2) :: nameat
+   character(len=40):: psflavor
 
-  character(len=1), dimension(0:4) :: lsymb = (/'s','p','d','f','g'/)
+   character(len=1), dimension(0:4) :: lsymb = ['s','p','d','f','g']
 
-  character*30 xcfuntype, xcfunparam
-  integer          :: ncore, nval, ncp, norbs, npots
+   character(len=30) :: xcfuntype, xcfunparam
+   integer          :: ncore, nval, ncp, norbs, npots
 
-  integer, allocatable  :: n(:), l(:)
-  integer, allocatable  :: nn(:), ll(:)
-  real(dp), allocatable :: f(:), ff(:)
-  real(dp), allocatable :: fdown(:), fup(:)
-  integer :: nr
-  character(len=10)     :: datestr
+   integer, allocatable  :: n(:), l(:)
+   integer, allocatable  :: nn(:), ll(:)
+   real(dp), allocatable :: f(:), ff(:)
+   real(dp), allocatable :: fdown(:), fup(:)
+   integer :: nr
+   character(len=10)     :: datestr
 
-  logical :: tdopsp, nonrel, polarized, there_is_core, found
-  integer :: lun, stat
+   logical :: tdopsp, nonrel, polarized, there_is_core, found
+   integer :: lun, stat
 
 !---
 
- call date_and_time(VALUES=dtime)
- write(datestr,"(i4,'-',i2.2,'-',i2.2)") dtime(1:3)
+   call date_and_time(VALUES=dtime)
+   write(datestr,"(i4,'-',i2.2,'-',i2.2)") dtime(1:3)
 
- !-------------- beginning of file echoing
-  call get_unit(lun)
-  open(unit=lun,file="_tmp_input",form="formatted",&
-       status="unknown",position="rewind",action="write")
+   !-------------- beginning of file echoing
+   call get_unit(lun)
+   open(unit=lun,file="_tmp_input",form="formatted",&
+        status="unknown",position="rewind",action="write")
 
- write(lun,'(a)') '# ATOM AND REFERENCE CONFIGURATION'
- write(lun,'(a)') '# atsym  z    nc    nv    iexc   psfile'
- write(lun,'(a,a,f6.2,3i6,2a)') '  ',trim(atsym),zz,nc,nv,iexc, &
-&      '      ',trim(psfile)
- write(lun,'(a/a)') '#','#   n    l    f        energy (Ha)'
- do ii=1,nc+nv
-   write(lun,'(2i5,f8.2)') na(ii),la(ii),fa(ii)
- end do
-
- write(lun,'(a/a/a)') '#','# PSEUDOPOTENTIAL AND OPTIMIZATION','# lmax'
- write(lun,'(i5)')  lmax
- write(lun,'(a/a)') '#','#   l,   rc,     ep,   ncon, nbas, qcut'
- do l1=1,lmax+1
-   write(lun,'(i5,2f8.2,2i5,f8.2)') l1-1,rc(l1),ep(l1),ncon(l1),nbas(l1),qcut(l1)
- end do
-
- write(lun,'(a/a/a,a)') '#','# LOCAL POTENTIAL','# lloc, lpopt,  rc(5),', &
-&      '   dvloc0'
- write(lun,'(2i5,f10.2,a,f8.2)') lloc,lpopt,rc(5),'   ',dvloc0
-
- write(lun,'(a/a/a)') '#','# VANDERBILT-KLEINMAN-BYLANDER PROJECTORs', &
-&      '# l, nproj, debl'
- do l1=1,lmax+1
-   write(lun,'(2i5,f10.4)') l1-1,nproj(l1),debl(l1)
- end do
-
- write(lun,'(a/a/a)') '#','# MODEL CORE CHARGE', &
-&      '# icmod, fcfact'
- write(lun,'(i5,f8.2,2i5,f8.2)') icmod,fcfact
-
- write(lun,'(a/a/a)') '#','# LOG DERIVATIVE ANALYSIS', &
-&      '# epsh1, epsh2, depsh'
- write(lun,'(3f8.2)') epsh1,epsh2,depsh
-
- write(lun,'(a/a/a)') '#','# OUTPUT GRID','# rlmax, drl'
- write(lun,'(2f8.2)') rlmax,drl
-
- write(lun,'(a/a/a)') '#','# TEST CONFIGURATIONS','# ncnf'
- write(lun,'(i5)') ncnf
- write(lun,'(a/a)') '# nvcnf','#   n    l    f'
- do jj=2,ncnf+1
-   write(lun,'(i5)') nvcnf(jj)
-   do ii=nc+1,nc+nvcnf(jj)
-     write(lun,'(2i5,f8.2)') nacnf(ii,jj),lacnf(ii,jj),facnf(ii,jj)
+   write(lun,'(a)') '# ATOM AND REFERENCE CONFIGURATION'
+   write(lun,'(a)') '# atsym  z    nc    nv    iexc   psfile'
+   write(lun,'(a,a,f6.2,3i6,2a)') '  ',trim(atsym),zz,nc,nv,iexc, &
+   &      '      ',trim(psfile)
+   write(lun,'(a/a)') '#','#   n    l    f        energy (Ha)'
+   do ii=1,nc+nv
+      write(lun,'(2i5,f8.2)') na(ii),la(ii),fa(ii)
    end do
-   write(lun,'(a)') '#'
- end do
- close(lun)
+
+   write(lun,'(a/a/a)') '#','# PSEUDOPOTENTIAL AND OPTIMIZATION','# lmax'
+   write(lun,'(i5)')  lmax
+   write(lun,'(a/a)') '#','#   l,   rc,     ep,   ncon, nbas, qcut'
+   do l1=1,lmax+1
+      write(lun,'(i5,2f8.2,2i5,f8.2)') l1-1,rc(l1),ep(l1),ncon(l1),nbas(l1),qcut(l1)
+   end do
+
+   write(lun,'(a/a/a,a)') '#','# LOCAL POTENTIAL','# lloc, lpopt,  rc(5),', &
+   &      '   dvloc0'
+   write(lun,'(2i5,f10.2,a,f8.2)') lloc,lpopt,rc(5),'   ',dvloc0
+
+   write(lun,'(a/a/a)') '#','# VANDERBILT-KLEINMAN-BYLANDER PROJECTORs', &
+   &      '# l, nproj, debl'
+   do l1=1,lmax+1
+      write(lun,'(2i5,f10.4)') l1-1,nproj(l1),debl(l1)
+   end do
+
+   write(lun,'(a/a/a)') '#','# MODEL CORE CHARGE', &
+   &      '# icmod, fcfact'
+   write(lun,'(i5,f8.2,2i5,f8.2)') icmod,fcfact
+
+   write(lun,'(a/a/a)') '#','# LOG DERIVATIVE ANALYSIS', &
+   &      '# epsh1, epsh2, depsh'
+   write(lun,'(3f8.2)') epsh1,epsh2,depsh
+
+   write(lun,'(a/a/a)') '#','# OUTPUT GRID','# rlmax, drl'
+   write(lun,'(2f8.2)') rlmax,drl
+
+   write(lun,'(a/a/a)') '#','# TEST CONFIGURATIONS','# ncnf'
+   write(lun,'(i5)') ncnf
+   write(lun,'(a/a)') '# nvcnf','#   n    l    f'
+   do jj=2,ncnf+1
+      write(lun,'(i5)') nvcnf(jj)
+      do ii=nc+1,nc+nvcnf(jj)
+         write(lun,'(2i5,f8.2)') nacnf(ii,jj),lacnf(ii,jj),facnf(ii,jj)
+      end do
+      write(lun,'(a)') '#'
+   end do
+   close(lun)
 
 
-  call xml_OpenFile("ONCVPSP.psml",xf, indent=.false.)
+   call xml_OpenFile("ONCVPSP.psml",xf, indent=.false.)
 
-  call xml_AddXMLDeclaration(xf,"UTF-8")
+   call xml_AddXMLDeclaration(xf,"UTF-8")
 
-  call xml_NewElement(xf,"psml")
-  call my_add_attribute(xf,"version","0.8")
-  call my_add_attribute(xf,"energy_unit","hartree")
-  call my_add_attribute(xf,"length_unit","bohr")
+   call xml_NewElement(xf,"psml")
+   call my_add_attribute(xf,"version","0.8")
+   call my_add_attribute(xf,"energy_unit","hartree")
+   call my_add_attribute(xf,"length_unit","bohr")
 
-  call xml_NewElement(xf,"provenance")
-  call my_add_attribute(xf,"creator","ONCVPSP-2.1.2+psml")
-  call my_add_attribute(xf,"date",datestr)
-  call xml_NewElement(xf,"input-file")
-  call my_add_attribute(xf,"name","oncvpsp-input")
+   call xml_NewElement(xf,"provenance")
+   call my_add_attribute(xf,"creator","ONCVPSP-2.1.2+psml")
+   call my_add_attribute(xf,"date",datestr)
+   call xml_NewElement(xf,"input-file")
+   call my_add_attribute(xf,"name","oncvpsp-input")
 !
-  call get_unit(lun)
-  open(unit=lun,file="_tmp_input",form="formatted",&
-       status="old",position="rewind",action="read")
+   call get_unit(lun)
+   open(unit=lun,file="_tmp_input",form="formatted",&
+        status="old",position="rewind",action="read")
 
-  rewind(lun)
-  do
-     read(lun,fmt="(a)",iostat=stat) line
-     if (stat .ne. 0) exit
-     call xml_AddPcData(xf,trim(line),line_feed=.true.)
-  enddo
-  close(lun)
+   rewind(lun)
+   do
+      read(lun,fmt="(a)",iostat=stat) line
+      if (stat /= 0) exit
+      call xml_AddPcData(xf,trim(line),line_feed=.true.)
+   enddo
+   close(lun)
 
-  call xml_EndElement(xf,"input-file")
-  !
-  call xml_EndElement(xf,"provenance")
+   call xml_EndElement(xf,"input-file")
+   !
+   call xml_EndElement(xf,"provenance")
 
 !  nameat = symbol(nint(zz))
-  nameat = atsym
-  ncore  = nc
-  nval   = nv
+   nameat = atsym
+   ncore  = nc
+   nval   = nv
 
-  norbs = ncore + nval
-  allocate (n(norbs), l(norbs), f(norbs))
+   norbs = ncore + nval
+   allocate (n(norbs), l(norbs), f(norbs))
 
-  total_valence_charge = 0.0_dp
-  ncp = ncore + 1
-  do i = 1, norbs
-     n(i) = na(i)
-     l(i) = la(i)
-     f(i) = fa(i)
-     if (i > ncore) then
-        total_valence_charge =   total_valence_charge + f(i)
-     endif
-  enddo
-  lmax = lmax
+   total_valence_charge = 0.0_dp
+   ncp = ncore + 1
+   do i = 1, norbs
+      n(i) = na(i)
+      l(i) = la(i)
+      f(i) = fa(i)
+      if (i > ncore) then
+         total_valence_charge =   total_valence_charge + f(i)
+      endif
+   enddo
+   lmax = lmax
 
-  npots = lmax + 1
-  allocate (ll(npots), nn(npots), ff(npots))
-  do i = 1, npots
-     ll(i) = i - 1
-     found = .false.
-     ! look for the appropriate shell in the valence
-     do j = ncp, norbs
-        if (l(j) == ll(i)) then
-           found = .true.
-           nn(i) = n(j)
-           ff(i) = f(j)
-           exit
-        endif
-     enddo
-     if (.not. found) then
-        ! generate the appropriate effective n
-        nn(i) = ll(i) + 1
-        do j = 1, ncore
-           if (l(j) == ll(i)) then
-              nn(i) = nn(i) + 1
-           endif
-           ff(i) = 0.0_dp
-        enddo
-     endif
-  enddo
+   npots = lmax + 1
+   allocate (ll(npots), nn(npots), ff(npots))
+   do i = 1, npots
+      ll(i) = i - 1
+      found = .false.
+      ! look for the appropriate shell in the valence
+      do j = ncp, norbs
+         if (l(j) == ll(i)) then
+            found = .true.
+            nn(i) = n(j)
+            ff(i) = f(j)
+            exit
+         endif
+      enddo
+      if (.not. found) then
+         ! generate the appropriate effective n
+         nn(i) = ll(i) + 1
+         do j = 1, ncore
+            if (l(j) == ll(i)) then
+               nn(i) = nn(i) + 1
+            endif
+            ff(i) = 0.0_dp
+         enddo
+      endif
+   enddo
 
-  psflavor ="Hamann's oncvpsp"
+   psflavor ="Hamann's oncvpsp"
 
-  polarized = .false.
-  polattrib = "no"
-  there_is_core = (icmod >= 1)
-  if (there_is_core) then
-     coreattrib = "yes"
-  else
-     coreattrib = "no"
-  endif
+   polarized = .false.
+   polattrib = "no"
+   there_is_core = (icmod >= 1)
+   if (there_is_core) then
+      coreattrib = "yes"
+   else
+      coreattrib = "no"
+   endif
 
-  ! XC name handling
+   ! XC name handling
 
-  select case(iexc)
+   select case(iexc)
 
-  case(1) 
-     xcfuntype    = 'LDA'
-     xcfunparam   = 'Wigner'
-     libxc_id = (/ XC_LDA_X, XC_LDA_C_WIGNER /)
-  case(2) 
-     xcfuntype    = 'LDA'
-     xcfunparam   = 'Hedin-Lundqvist'
-     libxc_id = (/ XC_LDA_X, XC_LDA_C_HL /)
-  case(3) 
-     xcfuntype    = 'LDA'
-     xcfunparam   = 'Ceperley-Alder PZ'
-     libxc_id = (/ XC_LDA_X, XC_LDA_C_PZ /)
+    case(1)
+      xcfuntype    = 'LDA'
+      xcfunparam   = 'Wigner'
+      libxc_id = [ XC_LDA_X, XC_LDA_C_WIGNER ]
+    case(2)
+      xcfuntype    = 'LDA'
+      xcfunparam   = 'Hedin-Lundqvist'
+      libxc_id = [ XC_LDA_X, XC_LDA_C_HL ]
+    case(3)
+      xcfuntype    = 'LDA'
+      xcfunparam   = 'Ceperley-Alder PZ'
+      libxc_id = [ XC_LDA_X, XC_LDA_C_PZ ]
 
-  case(4) 
-     xcfuntype    = 'GGA'
-     xcfunparam   = 'Perdew-Burke-Ernzerhof'
-     libxc_id = (/ XC_GGA_X_PBE, XC_GGA_C_PBE /) 
+    case(4)
+      xcfuntype    = 'GGA'
+      xcfunparam   = 'Perdew-Burke-Ernzerhof'
+      libxc_id = [ XC_GGA_X_PBE, XC_GGA_C_PBE ]
 
-  case  default
+    case  default
 
-     xcfuntype    = '-----'
-     xcfunparam   = '-----'
-     libxc_id = (/  XC_NOT_IMPL, XC_NOT_IMPL /)   ! ???
+      xcfuntype    = '-----'
+      xcfunparam   = '-----'
+      libxc_id = [  XC_NOT_IMPL, XC_NOT_IMPL ]   ! ???
 
-  end select
-  !
-  !
-  call xml_NewElement(xf,"header")
-  call my_add_attribute(xf,"atomic-label",nameat)
-  call my_add_attribute(xf,"atomic-number",str(zz))
-  call my_add_attribute(xf,"z-pseudo",str(zion))
-  call my_add_attribute(xf,"flavor",psflavor)
-  call my_add_attribute(xf,"relativity","dirac")
-  call my_add_attribute(xf,"polarized",polattrib)
-  call my_add_attribute(xf,"core-corrections",coreattrib)
+   end select
+   !
+   !
+   call xml_NewElement(xf,"header")
+   call my_add_attribute(xf,"atomic-label",nameat)
+   call my_add_attribute(xf,"atomic-number",str(zz))
+   call my_add_attribute(xf,"z-pseudo",str(zion))
+   call my_add_attribute(xf,"flavor",psflavor)
+   call my_add_attribute(xf,"relativity","dirac")
+   call my_add_attribute(xf,"polarized",polattrib)
+   call my_add_attribute(xf,"core-corrections",coreattrib)
 
-          call xml_NewElement(xf,"exchange-correlation")
-          call xml_NewElement(xf,"annotation")
-          call my_add_attribute(xf,"oncvpsp-xc-code",str(iexc))
-          call my_add_attribute(xf,"oncvpsp-xc-type",trim(xcfuntype))
-          call my_add_attribute(xf,"oncvpsp-xc-authors",trim(xcfunparam))
-          call xml_EndElement(xf,"annotation")
+   call xml_NewElement(xf,"exchange-correlation")
+   call xml_NewElement(xf,"annotation")
+   call my_add_attribute(xf,"oncvpsp-xc-code",str(iexc))
+   call my_add_attribute(xf,"oncvpsp-xc-type",trim(xcfuntype))
+   call my_add_attribute(xf,"oncvpsp-xc-authors",trim(xcfunparam))
+   call xml_EndElement(xf,"annotation")
 
-          call xml_NewElement(xf,"libxc-info")
-          call my_add_attribute(xf,"number-of-functionals","2")
-           do i = 1, 2
-              call xml_NewElement(xf,"functional")
-               call my_add_attribute(xf,"name",trim(libxc_id(i)%name))
-               call my_add_attribute(xf,"type",trim(libxc_id(i)%xc_kind%str))
-               call my_add_attribute(xf,"id",str(libxc_id(i)%code))
-              call xml_EndElement(xf,"functional")
-           enddo
-          call xml_EndElement(xf,"libxc-info")
-          call xml_EndElement(xf,"exchange-correlation")
-          !
+   call xml_NewElement(xf,"libxc-info")
+   call my_add_attribute(xf,"number-of-functionals","2")
+   do i = 1, 2
+      call xml_NewElement(xf,"functional")
+      call my_add_attribute(xf,"name",trim(libxc_id(i)%name))
+      call my_add_attribute(xf,"type",trim(libxc_id(i)%xc_kind%str))
+      call my_add_attribute(xf,"id",str(libxc_id(i)%code))
+      call xml_EndElement(xf,"functional")
+   enddo
+   call xml_EndElement(xf,"libxc-info")
+   call xml_EndElement(xf,"exchange-correlation")
+   !
 
-  !
-  call do_configuration()
-  call xml_EndElement(xf,"header")
+   !
+   call do_configuration()
+   call xml_EndElement(xf,"header")
 
 !AG: save
    if(lloc==4) then
-       ! fitted local potential
+      ! fitted local potential
    else
-       ! 'l_local="',lloc,'"'
+      ! 'l_local="',lloc,'"'
    end if
 !AG -- decide how to handle the case of Vlocal as one of the sl pots.
 
@@ -831,183 +831,183 @@ end subroutine psmlout
 !AG: decide whether to use a single mesh (Hamann's own) or have the
 ! projectors use another one (linear, shorter)
 
- npts = mmax
+   npts = mmax
 
- r => rr(:)
- chval => rho(:)
- chcore => rhomod(:,1)
- allocate(vps(npts))
+   r => rr(:)
+   chval => rho(:)
+   chcore => rhomod(:,1)
+   allocate(vps(npts))
 
-  nr = npts + 1
-  allocate(r0(nr))
-  call add_zero_r(r,r,r0)
-  r0(1) = 0.0_dp
+   nr = npts + 1
+   allocate(r0(nr))
+   call add_zero_r(r,r,r0)
+   r0(1) = 0.0_dp
 
-  call xml_NewElement(xf,"grid")
-  call my_add_attribute(xf,"npts",str(nr))
+   call xml_NewElement(xf,"grid")
+   call my_add_attribute(xf,"npts",str(nr))
 
-  call xml_NewElement(xf,"annotation")
-  call my_add_attribute(xf,"type","oncvpsp plus r=0")
-  call my_add_attribute(xf,"oncvpsp-npts",str(npts))
-  call my_add_attribute(xf,"oncvpsp-r1",trim(str(r(1))))
-  call my_add_attribute(xf,"oncvpsp-factor",trim(str(r(2)/r(1))))
-  call xml_EndElement(xf,"annotation")
+   call xml_NewElement(xf,"annotation")
+   call my_add_attribute(xf,"type","oncvpsp plus r=0")
+   call my_add_attribute(xf,"oncvpsp-npts",str(npts))
+   call my_add_attribute(xf,"oncvpsp-r1",trim(str(r(1))))
+   call my_add_attribute(xf,"oncvpsp-factor",trim(str(r(2)/r(1))))
+   call xml_EndElement(xf,"annotation")
 
-  call xml_NewElement(xf,"grid-data")
-  call xml_AddArray(xf,r0(1:nr))
-  call xml_EndElement(xf,"grid-data")
+   call xml_NewElement(xf,"grid-data")
+   call xml_AddArray(xf,r0(1:nr))
+   call xml_EndElement(xf,"grid-data")
 
-  call xml_EndElement(xf,"grid")
+   call xml_EndElement(xf,"grid")
 
-  !  
-  ! Semilocal potentials
-  !
-  allocate(f0(nr))
+   !
+   ! Semilocal potentials
+   !
+   allocate(f0(nr))
 
-  if (trim(psfile)=="psp8") then
+   if (trim(psfile)=="psp8") then
 
-     call xml_NewElement(xf,"semilocal-potentials")
-     call my_add_attribute(xf,"set","scalar_relativistic")
+      call xml_NewElement(xf,"semilocal-potentials")
+      call my_add_attribute(xf,"set","scalar_relativistic")
 ! sr components
-    do i = 1, npots
-     l1 = i
-     ! last index:  1: j=l+1/2; 2: j=l-1/2; l=0,j=0 stored in index 1
-     vps(:) = ((ll(i)+1)*vpuns(:,l1,1)+ ll(i)*vpuns(:,l1,2)) / dble(2*ll(i)+1)
-     call add_zero_r(vps(1:npts),r,f0)
-     call write_psml_item(xf, class="slps", &
-                          n=nn(i), l=ll(i), &
-                          rc=rc(i),flavor=psflavor,&
-                          f=f0)
-  enddo
-  call xml_EndElement(xf,"semilocal-potentials")
+      do i = 1, npots
+         l1 = i
+         ! last index:  1: j=l+1/2; 2: j=l-1/2; l=0,j=0 stored in index 1
+         vps(:) = ((ll(i)+1)*vpuns(:,l1,1)+ ll(i)*vpuns(:,l1,2)) / dble(2*ll(i)+1)
+         call add_zero_r(vps(1:npts),r,f0)
+         call write_psml_item(xf, class="slps", &
+                              n=nn(i), l=ll(i), &
+                              rc=rc(i),flavor=psflavor,&
+                              f=f0)
+      enddo
+      call xml_EndElement(xf,"semilocal-potentials")
 !
 ! so components
 !
-  call xml_NewElement(xf,"semilocal-potentials")
-   call my_add_attribute(xf,"set","spin_orbit")
+      call xml_NewElement(xf,"semilocal-potentials")
+      call my_add_attribute(xf,"set","spin_orbit")
 
- do i = 2, npots
-     l1 = i
-     vps(:) = 2*(vpuns(:,l1,1) - vpuns(:,l1,2)) / dble(2*ll(i)+1)
-     call add_zero_r(vps(1:npts),r,f0)
-     call write_psml_item(xf, class="slps", &
-                          n=nn(i), l=ll(i), &
-                          rc=rc(i),flavor=psflavor,&
-                          f=f0)
-  enddo
+      do i = 2, npots
+         l1 = i
+         vps(:) = 2*(vpuns(:,l1,1) - vpuns(:,l1,2)) / dble(2*ll(i)+1)
+         call add_zero_r(vps(1:npts),r,f0)
+         call write_psml_item(xf, class="slps", &
+                              n=nn(i), l=ll(i), &
+                              rc=rc(i),flavor=psflavor,&
+                              f=f0)
+      enddo
 
-  call xml_EndElement(xf,"semilocal-potentials")
+      call xml_EndElement(xf,"semilocal-potentials")
 
-  else   ! upf
+   else   ! upf
 
-     call xml_NewElement(xf,"semilocal-potentials")
-     call my_add_attribute(xf,"set","lj")
+      call xml_NewElement(xf,"semilocal-potentials")
+      call my_add_attribute(xf,"set","lj")
 
-     do i = 1, npots
-        l1 = i
-        if (i == 1) then
-           jval = 0.0
-           ! last index:  1: j=l+1/2; 2: j=l-1/2; l=0,j=0 stored in index 1
-           vps(:) = vpuns(:,l1,1)
-           call add_zero_r(vps(1:npts),r,f0)
-           call write_psml_item(xf, class="slps", &
-                          n=nn(i), l=ll(i), j=jval, &
-                          rc=rc(i),flavor=psflavor,&
-                          f=f0)
-        else
-           do jj=1,2
-              jval = ll(i) + (3-2*jj)*0.5  ! convert (1,2) to (1,-1)*1/2
-              ! last index:  1: j=l+1/2; 2: j=l-1/2; l=0,j=0 stored in index 1
-              vps(:) = vpuns(:,l1,jj)
-              call add_zero_r(vps(1:npts),r,f0)
-              call write_psml_item(xf, class="slps", &
-                          n=nn(i), l=ll(i), j=jval, &
-                          rc=rc(i),flavor=psflavor,&
-                          f=f0)
-           enddo
-        endif
-     enddo
-     call xml_EndElement(xf,"semilocal-potentials")
+      do i = 1, npots
+         l1 = i
+         if (i == 1) then
+            jval = 0.0
+            ! last index:  1: j=l+1/2; 2: j=l-1/2; l=0,j=0 stored in index 1
+            vps(:) = vpuns(:,l1,1)
+            call add_zero_r(vps(1:npts),r,f0)
+            call write_psml_item(xf, class="slps", &
+                                 n=nn(i), l=ll(i), j=jval, &
+                                 rc=rc(i),flavor=psflavor,&
+                                 f=f0)
+         else
+            do jj=1,2
+               jval = ll(i) + (3-2*jj)*0.5  ! convert (1,2) to (1,-1)*1/2
+               ! last index:  1: j=l+1/2; 2: j=l-1/2; l=0,j=0 stored in index 1
+               vps(:) = vpuns(:,l1,jj)
+               call add_zero_r(vps(1:npts),r,f0)
+               call write_psml_item(xf, class="slps", &
+                                    n=nn(i), l=ll(i), j=jval, &
+                                    rc=rc(i),flavor=psflavor,&
+                                    f=f0)
+            enddo
+         endif
+      enddo
+      call xml_EndElement(xf,"semilocal-potentials")
 
-  endif ! upf vs psp8
+   endif  ! upf vs psp8
 !
 !--------
-  call xml_NewElement(xf,"valence-charge")
-  call my_add_attribute(xf,"total-charge",  &
-                      str(total_valence_charge))
-  call xml_NewElement(xf,"radfunc")
+   call xml_NewElement(xf,"valence-charge")
+   call my_add_attribute(xf,"total-charge",  &
+                         str(total_valence_charge))
+   call xml_NewElement(xf,"radfunc")
 
-  call xml_NewElement(xf,"data")
-  call add_zero_r(chval(1:npts),r,f0)
+   call xml_NewElement(xf,"data")
+   call add_zero_r(chval(1:npts),r,f0)
 !  call xml_AddArray(xf,chval(1:npts))
-  call xml_AddArray(xf,f0(1:nr))
-  call xml_EndElement(xf,"data")
-  call xml_EndElement(xf,"radfunc")
-  call xml_EndElement(xf,"valence-charge")
+   call xml_AddArray(xf,f0(1:nr))
+   call xml_EndElement(xf,"data")
+   call xml_EndElement(xf,"radfunc")
+   call xml_EndElement(xf,"valence-charge")
 
 
-  if (there_is_core) then
-     rcore = rr(irct)
-     call xml_NewElement(xf,"pseudocore-charge")
-     call my_add_attribute(xf,"matching-radius",str(rcore))
-     call my_add_attribute(xf,"number-of-continuous-derivatives", &
-                                    str(4))
-     call my_add_attribute(xf,"annotation",  &
-                  "Monotonic 8th-order polynomial with no linear term")
-     call xml_NewElement(xf,"radfunc")
+   if (there_is_core) then
+      rcore = rr(irct)
+      call xml_NewElement(xf,"pseudocore-charge")
+      call my_add_attribute(xf,"matching-radius",str(rcore))
+      call my_add_attribute(xf,"number-of-continuous-derivatives", &
+                            str(4))
+      call my_add_attribute(xf,"annotation",  &
+                            "Monotonic 8th-order polynomial with no linear term")
+      call xml_NewElement(xf,"radfunc")
 
-     call xml_NewElement(xf,"data")
-     call add_zero_r(chcore(1:npts),r,f0)
-     call xml_AddArray(xf,f0(1:nr))
-     call xml_EndElement(xf,"data")
-     call xml_EndElement(xf,"radfunc")
-     call xml_EndElement(xf,"pseudocore-charge")
-     deallocate(chcore)
-  endif
+      call xml_NewElement(xf,"data")
+      call add_zero_r(chcore(1:npts),r,f0)
+      call xml_AddArray(xf,f0(1:nr))
+      call xml_EndElement(xf,"data")
+      call xml_EndElement(xf,"radfunc")
+      call xml_EndElement(xf,"pseudocore-charge")
+      deallocate(chcore)
+   endif
 
 
-      call xml_NewElement(xf,"pseudopotential-operator")
-      call my_add_attribute(xf,"version","0.1")
-      call my_add_attribute(xf,"energy_unit","hartree")
-      call my_add_attribute(xf,"length_unit","bohr")
+   call xml_NewElement(xf,"pseudopotential-operator")
+   call my_add_attribute(xf,"version","0.1")
+   call my_add_attribute(xf,"energy_unit","hartree")
+   call my_add_attribute(xf,"length_unit","bohr")
 
-        call xml_NewElement(xf,"provenance")
-          call my_add_attribute(xf,"creator","oncvpsp 2.1.2+psml")
-        call xml_EndElement(xf,"provenance")
+   call xml_NewElement(xf,"provenance")
+   call my_add_attribute(xf,"creator","oncvpsp 2.1.2+psml")
+   call xml_EndElement(xf,"provenance")
 
-        vlocal => vpuns(:,lloc+1,1)
-        call xml_NewElement(xf,"local-potential")
-            if (lloc > lmax) then
-               call my_add_attribute(xf,"type","oncv-fit")
-            else
-               call my_add_attribute(xf,"type","l="//str(lloc))
-            endif
-            call xml_NewElement(xf,"radfunc")
-               call xml_NewElement(xf,"data")
-                call add_zero_r(vlocal(1:npts),r,f0)
-                call xml_AddArray(xf,f0(1:nr))
-               call xml_EndElement(xf,"data")
-            call xml_EndElement(xf,"radfunc")
-        call xml_EndElement(xf,"local-potential")
+   vlocal => vpuns(:,lloc+1,1)
+   call xml_NewElement(xf,"local-potential")
+   if (lloc > lmax) then
+      call my_add_attribute(xf,"type","oncv-fit")
+   else
+      call my_add_attribute(xf,"type","l="//str(lloc))
+   endif
+   call xml_NewElement(xf,"radfunc")
+   call xml_NewElement(xf,"data")
+   call add_zero_r(vlocal(1:npts),r,f0)
+   call xml_AddArray(xf,f0(1:nr))
+   call xml_EndElement(xf,"data")
+   call xml_EndElement(xf,"radfunc")
+   call xml_EndElement(xf,"local-potential")
 
 !
 !     Scalar-relativistic projectors
 !
-  if (trim(psfile)=="psp8") then
+   if (trim(psfile)=="psp8") then
 
 ! set up projector number for sr_so calculations based on non-zero coefficients
-  npr_sr(:)=0 
-  npr_so(:)=0
-  do l1=1,lmax+1
-   do ii=1,4
-    if(abs(esr(ii,l1))>0.0d0) npr_sr(l1)=npr_sr(l1)+1
-    if(abs(eso(ii,l1))>0.0d0) npr_so(l1)=npr_so(l1)+1
-   end do
-  end do
+      npr_sr(:)=0
+      npr_so(:)=0
+      do l1=1,lmax+1
+         do ii=1,4
+            if(abs(esr(ii,l1))>0.0d0) npr_sr(l1)=npr_sr(l1)+1
+            if(abs(eso(ii,l1))>0.0d0) npr_so(l1)=npr_so(l1)+1
+         end do
+      end do
 
       call xml_NewElement(xf,"projectors")
       call my_add_attribute(xf,"set","scalar_relativistic")
- 
+
       do l1=1,lmax+1
          if(l1==lloc+1) cycle
          do jj=1,npr_sr(l1)
@@ -1038,11 +1038,11 @@ end subroutine psmlout
 
       call xml_EndElement(xf,"projectors")
 
- else  ! upf
+   else  ! upf
 
       call xml_NewElement(xf,"projectors")
       call my_add_attribute(xf,"set","lj")
- 
+
       do l1=1,lmax+1
          if(l1==lloc+1) cycle
 
@@ -1053,168 +1053,168 @@ end subroutine psmlout
             do jj=1,nproj(l1)
                call add_zero_r(vkb(:,jj,l1,1),r,f0)
                call write_psml_item(xf, class="proj", &
-                                 seq=jj, l=l1-1, j=jval, &
-                                 ekb=evkb(jj,l1,1), &
-                                 type="oncv", f=f0)
+                                    seq=jj, l=l1-1, j=jval, &
+                                    ekb=evkb(jj,l1,1), &
+                                    type="oncv", f=f0)
             enddo
 
          else  ! l1 /=1  (l/=0)
 
-           ! two j values
-           do jk=1,2
-              jval = l1-1 + (3-2*jk)*0.5  ! convert (1,2) to (1,-1)*1/2
-              do jj=1,nproj(l1)
-                 call add_zero_r(vkb(:,jj,l1,jk),r,f0)
-                 call write_psml_item(xf, class="proj", &
-                                 seq=jj, l=l1-1, j=jval, &
-                                 ekb=evkb(jj,l1,jk), &
-                                 type="oncv", f=f0)
-              enddo
-           enddo
+            ! two j values
+            do jk=1,2
+               jval = l1-1 + (3-2*jk)*0.5  ! convert (1,2) to (1,-1)*1/2
+               do jj=1,nproj(l1)
+                  call add_zero_r(vkb(:,jj,l1,jk),r,f0)
+                  call write_psml_item(xf, class="proj", &
+                                       seq=jj, l=l1-1, j=jval, &
+                                       ekb=evkb(jj,l1,jk), &
+                                       type="oncv", f=f0)
+               enddo
+            enddo
 
-        endif  ! l1 == 1
+         endif  ! l1 == 1
 
-      enddo ! over l shells
+      enddo  ! over l shells
       call xml_EndElement(xf,"projectors")
 !
-   endif ! upf vs psp8
+   endif  ! upf vs psp8
 
-    call xml_EndElement(xf,"pseudopotential-operator")
+   call xml_EndElement(xf,"pseudopotential-operator")
 
-  call xml_EndElement(xf,"psml")
+   call xml_EndElement(xf,"psml")
 
 
-  call xml_Close(xf)
+   call xml_Close(xf)
 
-  deallocate(f0,r0)
+   deallocate(f0,r0)
 
 CONTAINS
-  subroutine do_configuration()
+subroutine do_configuration()
 
-  call xml_NewElement(xf,"valence-configuration")
-  call my_add_attribute(xf,"total-valence-charge", str(total_valence_charge))
-  do i = ncp, norbs
-     if (f(i) .lt. 1.0e-10_dp) cycle
-     call xml_NewElement(xf,"shell")
-     call my_add_attribute(xf,"n",str(n(i)))
-     call my_add_attribute(xf,"l",lsymb(l(i)))
-     call my_add_attribute(xf,"occupation",str(f(i)))
-     if (polarized) then
-        call my_add_attribute(xf,"occupation-down",str(fdown(i)))
-        call my_add_attribute(xf,"occupation-up",str(fup(i)))
-     endif
-     call xml_EndElement(xf,"shell")
-  enddo
-  call xml_EndElement(xf,"valence-configuration")
+   call xml_NewElement(xf,"valence-configuration")
+   call my_add_attribute(xf,"total-valence-charge", str(total_valence_charge))
+   do i = ncp, norbs
+      if (f(i) < 1.0e-10_dp) cycle
+      call xml_NewElement(xf,"shell")
+      call my_add_attribute(xf,"n",str(n(i)))
+      call my_add_attribute(xf,"l",lsymb(l(i)))
+      call my_add_attribute(xf,"occupation",str(f(i)))
+      if (polarized) then
+         call my_add_attribute(xf,"occupation-down",str(fdown(i)))
+         call my_add_attribute(xf,"occupation-up",str(fup(i)))
+      endif
+      call xml_EndElement(xf,"shell")
+   enddo
+   call xml_EndElement(xf,"valence-configuration")
 end subroutine do_configuration
 
 
 end subroutine psmlout_r
 
-     subroutine my_add_attribute(xf,name,value)
-       use xmlf90_wxml, only: xmlf_t, xml_AddAttribute
+subroutine my_add_attribute(xf,name,value)
+   use xmlf90_wxml, only: xmlf_t, xml_AddAttribute
 
-       type(xmlf_t), intent(inout)   :: xf
-       character(len=*), intent(in)  :: name
-       character(len=*), intent(in)  :: value
+   type(xmlf_t), intent(inout)   :: xf
+   character(len=*), intent(in)  :: name
+   character(len=*), intent(in)  :: value
 
-       call xml_AddAttribute(xf,name,trim(value))
-     end subroutine my_add_attribute
+   call xml_AddAttribute(xf,name,trim(value))
+end subroutine my_add_attribute
 
-      subroutine add_zero_r(f,r,f0)
-      ! Adds an r=0 element to a grid function f0, extrapolating
+subroutine add_zero_r(f,r,f0)
+   ! Adds an r=0 element to a grid function f0, extrapolating
 
-      double precision, intent(in)  :: f(:), r(:)
-      double precision, intent(out) :: f0(:)
-      
-      integer i, npts
-      double precision :: r2
+   double precision, intent(in)  :: f(:), r(:)
+   double precision, intent(out) :: f0(:)
 
-      npts = size(f)
-      if (size(f0) /= npts +1) stop "nr /= npts + 1 in add_zero_r"
-      do i = 1, npts
-         f0(i+1) = f(i)
-      enddo
-      r2 = r(1)/(r(2)-r(1))
-      f0(1) = f(2) - (f(3)-f(2))*r2
+   integer :: i, npts
+   double precision :: r2
 
-    end subroutine add_zero_r
+   npts = size(f)
+   if (size(f0) /= npts +1) stop "nr /= npts + 1 in add_zero_r"
+   do i = 1, npts
+      f0(i+1) = f(i)
+   enddo
+   r2 = r(1)/(r(2)-r(1))
+   f0(1) = f(2) - (f(3)-f(2))*r2
 
-    subroutine get_unit(lun)
+end subroutine add_zero_r
+
+subroutine get_unit(lun)
 
 !     Get an available Fortran unit number
 
-      integer, intent(out) ::  lun
+   integer, intent(out) ::  lun
 
-      integer i
-      logical unit_used
+   integer :: i
+   logical :: unit_used
 
-      do i = 10, 99
-         lun = i
-         inquire(lun,opened=unit_used)
-         if (.not. unit_used) return
-      enddo
-      stop 'NO LUNS'
-    end subroutine get_unit
+   do i = 10, 99
+      lun = i
+      inquire(lun,opened=unit_used)
+      if (.not. unit_used) return
+   enddo
+   stop 'NO LUNS'
+end subroutine get_unit
 
-    subroutine write_psml_item(xf,class, &
-                               n, l, j, s, &
-                               seq, &
-                               rc, ekb, &
-                               flavor, type, set, &
-                               f)
+subroutine write_psml_item(xf,class, &
+                           n, l, j, s, &
+                           seq, &
+                           rc, ekb, &
+                           flavor, type, set, &
+                           f)
 
-       use xmlf90_wxml
+   use xmlf90_wxml
 
 
-       type(xmlf_t), intent(inout)   :: xf
-       character(len=*), intent(in)  :: class
+   type(xmlf_t), intent(inout)   :: xf
+   character(len=*), intent(in)  :: class
 
-       integer, intent(in), optional  :: n
-       integer, intent(in), optional  :: l
-       real(dp), intent(in), optional  :: j
-       real(dp), intent(in), optional  :: s
+   integer, intent(in), optional  :: n
+   integer, intent(in), optional  :: l
+   real(dp), intent(in), optional  :: j
+   real(dp), intent(in), optional  :: s
 
-       ! for sl potentials
-       real(dp), intent(in), optional  :: rc
-       character(len=*), intent(in), optional  :: flavor
+   ! for sl potentials
+   real(dp), intent(in), optional  :: rc
+   character(len=*), intent(in), optional  :: flavor
 
-       ! for projectors
-       integer, intent(in), optional   :: seq
-       real(dp), intent(in), optional  :: ekb
-       character(len=*), intent(in), optional  :: type
+   ! for projectors
+   integer, intent(in), optional   :: seq
+   real(dp), intent(in), optional  :: ekb
+   character(len=*), intent(in), optional  :: type
 
-       character(len=*), intent(in), optional  :: set
-       real(dp), intent(in), optional  :: f(:)
-       
-       call xml_NewElement(xf,trim(class))
-         if (present(set))  call my_add_attribute(xf,"set",set)
+   character(len=*), intent(in), optional  :: set
+   real(dp), intent(in), optional  :: f(:)
 
-         ! we might want to check input values
-         if (present(n))  call my_add_attribute(xf,"n",str(n))
-         if (present(l))  call my_add_attribute(xf,"l",lsymb(l))
-         if (present(j))  call my_add_attribute(xf,"j", &
-                                                str(j,format="(f3.1)"))
-         ! spin: +0.5 or -0.5
-         if (present(s))  call my_add_attribute(xf,"s", &
-                                                str(s,format="(f4.1)"))
+   call xml_NewElement(xf,trim(class))
+   if (present(set))  call my_add_attribute(xf,"set",set)
 
-         if (present(seq)) call my_add_attribute(xf,"seq",str(seq))
+   ! we might want to check input values
+   if (present(n))  call my_add_attribute(xf,"n",str(n))
+   if (present(l))  call my_add_attribute(xf,"l",lsymb(l))
+   if (present(j))  call my_add_attribute(xf,"j", &
+                                          str(j,format="(f3.1)"))
+   ! spin: +0.5 or -0.5
+   if (present(s))  call my_add_attribute(xf,"s", &
+                                          str(s,format="(f4.1)"))
 
-         if (present(rc))  call my_add_attribute(xf,"rc",str(rc))
-         if (present(ekb))  call my_add_attribute(xf,"ekb",str(ekb))
+   if (present(seq)) call my_add_attribute(xf,"seq",str(seq))
 
-         if (present(flavor))  call my_add_attribute(xf,"flavor",flavor)
-         if (present(type))  call my_add_attribute(xf,"type",type)
+   if (present(rc))  call my_add_attribute(xf,"rc",str(rc))
+   if (present(ekb))  call my_add_attribute(xf,"ekb",str(ekb))
 
-         call xml_NewElement(xf,"radfunc")
-           call xml_NewElement(xf,"data")
-           call xml_AddArray(xf,f(:))
-           call xml_EndElement(xf,"data")
-         call xml_EndElement(xf,"radfunc")
+   if (present(flavor))  call my_add_attribute(xf,"flavor",flavor)
+   if (present(type))  call my_add_attribute(xf,"type",type)
 
-       call xml_EndElement(xf,trim(class))
+   call xml_NewElement(xf,"radfunc")
+   call xml_NewElement(xf,"data")
+   call xml_AddArray(xf,f(:))
+   call xml_EndElement(xf,"data")
+   call xml_EndElement(xf,"radfunc")
 
-     end subroutine write_psml_item
+   call xml_EndElement(xf,trim(class))
+
+end subroutine write_psml_item
 
 end module m_psmlout

--- a/src/modcore.f90
+++ b/src/modcore.f90
@@ -2,17 +2,17 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
@@ -20,10 +20,10 @@
 ! core charge and 4 derivatives at "crossover" radius.
 ! Polynomial is 8th-order with no linear term.
 
-! Performs analysis and based on "hardness" criterion described in 
-! Teter, Phys. Rev. B 48, 5031 (1993) , Appendix, as 
+! Performs analysis and based on "hardness" criterion described in
+! Teter, Phys. Rev. B 48, 5031 (1993) , Appendix, as
 
- subroutine modcore(icmod,rhops,rhotps,rhoc,rhoae,rhotae,rhomod, &
+subroutine modcore(icmod,rhops,rhotps,rhoc,rhoae,rhotae,rhomod, &
 &                   fcfact,rcfact,irps,mmax,rr,nc,nv,la,zion,iexc)
 
 !icmod  3 coefficient optimizaion, 4 for specivied fcfact and rfact
@@ -44,237 +44,237 @@
 !zion  ion charge
 !iexc  exchange-correlation function to be used
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !Input variables
- integer :: icmod,nv,nc,iexc,irps,mmax
- integer :: la(30)
- real(dp) :: rhoae(mmax,nv),rhops(mmax,nv),rhotae(mmax)
- real(dp) :: rhotps(mmax),rhoc(mmax),rr(mmax)
- real(dp) :: zion,fcfact,rcfact
- logical :: srel
+   integer :: icmod,nv,nc,iexc,irps,mmax
+   integer :: la(30)
+   real(dp) :: rhoae(mmax,nv),rhops(mmax,nv),rhotae(mmax)
+   real(dp) :: rhotps(mmax),rhoc(mmax),rr(mmax)
+   real(dp) :: zion,fcfact,rcfact
+   logical :: srel
 
 !Output variables
- real(dp) :: rhomod(mmax,5)
+   real(dp) :: rhomod(mmax,5)
 
 !convergence criterion
- real(dp), parameter :: eps=1.0d-7
+   real(dp), parameter :: eps=1.0d-7
 
 !Local variables
- real(dp) :: a0,al,et,yy,gg,a0min,a0max,dermax,psum,sf,eeel,eexc
- real(dp) :: d2mdiff,rmatch,rhocmatch
- real(dp) :: emin,emax,sls,ss,hh,rgg,xx
- real(dp) :: aco(5),polym(5,5),work(5,5),constm(5,5),xpow(9),fmatch(5)
- real(dp), allocatable :: vxcae(:),vxcpsp(:),vo(:),d2excae(:,:),d2excps(:,:)
- real(dp), allocatable :: dvxcae(:,:),dvxcps(:,:),vxct(:)
- integer :: ii,ierr,ircc,irmod,iter,jj,kk,ll,l1,mch
- integer :: ipvt(5),nodes(4)
+   real(dp) :: a0,al,et,yy,gg,a0min,a0max,dermax,psum,sf,eeel,eexc
+   real(dp) :: d2mdiff,rmatch,rhocmatch
+   real(dp) :: emin,emax,sls,ss,hh,rgg,xx
+   real(dp) :: aco(5),polym(5,5),work(5,5),constm(5,5),xpow(9),fmatch(5)
+   real(dp), allocatable :: vxcae(:),vxcpsp(:),vo(:),d2excae(:,:),d2excps(:,:)
+   real(dp), allocatable :: dvxcae(:,:),dvxcps(:,:),vxct(:)
+   integer :: ii,ierr,ircc,irmod,iter,jj,kk,ll,l1,mch
+   integer :: ipvt(5),nodes(4)
 
 
- allocate(vxcae(mmax),vxcpsp(mmax),vo(mmax))
- allocate(dvxcae(mmax,nv),dvxcps(mmax,nv),vxct(mmax))
- allocate(d2excae(nv,nv),d2excps(nv,nv))
+   allocate(vxcae(mmax),vxcpsp(mmax),vo(mmax))
+   allocate(dvxcae(mmax,nv),dvxcps(mmax,nv),vxct(mmax))
+   allocate(d2excae(nv,nv),d2excps(nv,nv))
 
- d2excae(:,:)=0.0d0
- d2excps(:,:)=0.0d0
- ircc = 0
- 
- do ii = mmax,1,-1
-   if(rhoc(ii) .gt. fcfact*rhotps(ii)) then
-     ircc=ii
-     exit
+   d2excae(:,:)=0.0d0
+   d2excps(:,:)=0.0d0
+   ircc = 0
+
+   do ii = mmax,1,-1
+      if(rhoc(ii) > fcfact*rhotps(ii)) then
+         ircc=ii
+         exit
+      end if
+   end do
+
+   if(ircc == 0) then
+      write(6,'(/a)') 'rhomod: ERROR ircc (core-valence charge crossover) &
+      &        not found'
+      stop
    end if
- end do
- 
- if(ircc .eq. 0) then
-   write(6,'(/a)') 'rhomod: ERROR ircc (core-valence charge crossover) &
-&        not found'
-   stop
- end if
 
 !set limit for d2Exc calculation to radius beyond which rhomod=rhoc
    irmod=max(irps,ircc)
 
- write(6,'(/a/a)') 'Model core correction analysis',&
-&                  '  based on d2Exc/dn_idn_j'
+   write(6,'(/a/a)') 'Model core correction analysis',&
+   &                  '  based on d2Exc/dn_idn_j'
 
 
 ! get derivatives of all-electron xc energy
 
- call der2exc(rhotae,rhoc,rhoae,rr,d2excae,d2excps,d2mdiff, &
-&                   zion,iexc,nc,nv,la,irmod,mmax)
+   call der2exc(rhotae,rhoc,rhoae,rr,d2excae,d2excps,d2mdiff, &
+   &                   zion,iexc,nc,nv,la,irmod,mmax)
 
- write(6,'(/a/)') 'd2excae - all-electron derivatives'
- do kk=1,nv
-   write(6,'(1p,4d16.6)') (d2excae(kk,jj),jj=1,nv)
- end do
+   write(6,'(/a/)') 'd2excae - all-electron derivatives'
+   do kk=1,nv
+      write(6,'(1p,4d16.6)') (d2excae(kk,jj),jj=1,nv)
+   end do
 
- 
+
 ! set model charge to zero
- rhomod(:,:)=0.0d0
+   rhomod(:,:)=0.0d0
 
 ! compute d2excps with no core correction
- rhomod(:,:)=0.0d0
+   rhomod(:,:)=0.0d0
 
- call der2exc(rhotps,rhomod(1,1),rhops,rr,d2excps,d2excae,d2mdiff, &
-&                   zion,iexc,nc,nv,la,irmod,mmax)
+   call der2exc(rhotps,rhomod(1,1),rhops,rr,d2excps,d2excae,d2mdiff, &
+   &                   zion,iexc,nc,nv,la,irmod,mmax)
 
- write(6,'(/a/)') 'd2excps - pseudofunction derivatives with no core correction'
- do kk=1,nv
-   write(6,'(1p,4d16.6)') (d2excps(kk,jj),jj=1,nv)
- end do
- write(6,'(/a,1p,e16.6)') 'rms 2nd derivative error',d2mdiff
+   write(6,'(/a/)') 'd2excps - pseudofunction derivatives with no core correction'
+   do kk=1,nv
+      write(6,'(1p,4d16.6)') (d2excps(kk,jj),jj=1,nv)
+   end do
+   write(6,'(/a,1p,e16.6)') 'rms 2nd derivative error',d2mdiff
 
- al = 0.01d0 * dlog(rr(101) / rr(1))
+   al = 0.01d0 * dlog(rr(101) / rr(1))
 
 ! core charge density for Louie-Froyen-Cohen correction
 
- rhomod(:,1)= rhoc(:)
+   rhomod(:,1)= rhoc(:)
 
- xx=rr(ircc)
- fmatch(1)=rhoc(ircc)
+   xx=rr(ircc)
+   fmatch(1)=rhoc(ircc)
 
 ! core charge derivatives
- do jj=2,5
+   do jj=2,5
 
 !7-point numerical first derivatives applied successively
-  do ii=ircc-25+3*jj,mmax-3
-     rhomod(ii,jj)=(-rhomod(ii-3,jj-1)+ 9.d0*rhomod(ii-2,jj-1)&
-&     -45.d0*rhomod(ii-1,jj-1)+45.d0*rhomod(ii+1,jj-1)&
-&     -9.d0*rhomod(ii+2,jj-1)+rhomod(ii+3,jj-1))&
-&     /(60.d0*al*rr(ii))
-  end do
-  fmatch(jj)=rhomod(ircc,jj)
- end do
+      do ii=ircc-25+3*jj,mmax-3
+         rhomod(ii,jj)=(-rhomod(ii-3,jj-1)+ 9.d0*rhomod(ii-2,jj-1)&
+         &     -45.d0*rhomod(ii-1,jj-1)+45.d0*rhomod(ii+1,jj-1)&
+         &     -9.d0*rhomod(ii+2,jj-1)+rhomod(ii+3,jj-1))&
+         &     /(60.d0*al*rr(ii))
+      end do
+      fmatch(jj)=rhomod(ircc,jj)
+   end do
 
 ! constants for polynomial matrix
- do jj=1,5
-   constm(1,jj)=1.0d0
- end do
- do jj=1,5
-   constm(2,jj)=jj+2
- end do
- do ii=3,5
    do jj=1,5
-     constm(ii,jj)=constm(ii-1,jj)*(constm(2,jj)-ii+2)
+      constm(1,jj)=1.0d0
    end do
- end do
+   do jj=1,5
+      constm(2,jj)=jj+2
+   end do
+   do ii=3,5
+      do jj=1,5
+         constm(ii,jj)=constm(ii-1,jj)*(constm(2,jj)-ii+2)
+      end do
+   end do
 
 ! powers of xx=rr(ircc)
 
- xpow(1)=0.0d0
- xpow(2)=1.0d0
- do ii=3,9
-   xpow(ii)=xx*xpow(ii-1)
- end do
+   xpow(1)=0.0d0
+   xpow(2)=1.0d0
+   do ii=3,9
+      xpow(ii)=xx*xpow(ii-1)
+   end do
 
 ! polynomial matrix
    do jj=1,5
-     do ii=1,5
-       polym(ii,jj)=constm(ii,jj)*xpow(jj-ii+5)
-     end do
+      do ii=1,5
+         polym(ii,jj)=constm(ii,jj)*xpow(jj-ii+5)
+      end do
    end do
 
 
 ! begin iteration for monotonic polynomial match
 
- a0=fmatch(1)
- a0min=a0
- a0max=0.0d0
+   a0=fmatch(1)
+   a0min=a0
+   a0max=0.0d0
 
- do iter=1,50
+   do iter=1,50
 
-  work(:,:)=polym(:,:)
+      work(:,:)=polym(:,:)
 
 ! fill target value vector
-   aco(1)=fmatch(1)-a0
-   do jj=2,5
-     aco(jj)=fmatch(jj)
-   end do
+      aco(1)=fmatch(1)-a0
+      do jj=2,5
+         aco(jj)=fmatch(jj)
+      end do
 
 ! solve linear equations for coefficients
 
-   call dgesv(5,1,work,5,ipvt,aco,5,kk)
-   if(kk/= 0) then
-     if(kk>0) write(6,'(a,i4)') &
-&      'modcore:ERROR stop - singular polym matrix',kk
-     if(kk<0) write(6,'(a,i4)') &
-&      'modcore:ERROR stop - dgesv input error',kk
-     stop
-   end if
+      call dgesv(5,1,work,5,ipvt,aco,5,kk)
+      if(kk/= 0) then
+         if(kk>0) write(6,'(a,i4)') &
+         &      'modcore:ERROR stop - singular polym matrix',kk
+         if(kk<0) write(6,'(a,i4)') &
+         &      'modcore:ERROR stop - dgesv input error',kk
+         stop
+      end if
 
 ! find maximum derivative
 ! note that xpow end up properly re-written for continued iteation
-   dermax=-1.0d20
-   do kk=1,ircc
-     do ii=3,9
-       xpow(ii)=rr(kk)*xpow(ii-1)
-     end do
-     ii=2
-     psum=0.0d0
-     do jj=1,5
-       psum=psum+constm(ii,jj)*xpow(jj-ii+5)*aco(jj)
-     end do
-     dermax=dmax1(dermax,psum)
-   end do
+      dermax=-1.0d20
+      do kk=1,ircc
+         do ii=3,9
+            xpow(ii)=rr(kk)*xpow(ii-1)
+         end do
+         ii=2
+         psum=0.0d0
+         do jj=1,5
+            psum=psum+constm(ii,jj)*xpow(jj-ii+5)*aco(jj)
+         end do
+         dermax=dmax1(dermax,psum)
+      end do
 
 ! test maximum derivative and adjust a0
 ! interval-halving search after achieving monotonicity to get
 ! barely monotonic model
-   if(dermax .gt. 0.0d0) then
-     a0min=a0
-   else
-     a0max=a0
-   end if
+      if(dermax > 0.0d0) then
+         a0min=a0
+      else
+         a0max=a0
+      end if
 
 ! success when maximum derivative bracketed just above zero
-   if(dermax>0.0d0 .and. dermax<eps*dabs(fmatch(2))) exit
+      if(dermax>0.0d0 .and. dermax<eps*dabs(fmatch(2))) exit
 
-   if(a0max==0.0d0) then
-     a0=2.5d0*a0
-   else
-     a0=0.5d0*(a0max+a0min)
-   end if
+      if(a0max==0.0d0) then
+         a0=2.5d0*a0
+      else
+         a0=0.5d0*(a0max+a0min)
+      end if
 
- end do !iterr
- if(iter>50) write(6,'(/a/)') 'WARNING - modcore not conveged'
+   end do  !iterr
+   if(iter>50) write(6,'(/a/)') 'WARNING - modcore not conveged'
 
 
 ! fill in model and derivatives with fitted polynomial
- do kk=1,ircc-1
-   do ii=3,9
-     xpow(ii)=rr(kk)*xpow(ii-1)
+   do kk=1,ircc-1
+      do ii=3,9
+         xpow(ii)=rr(kk)*xpow(ii-1)
+      end do
+      do ii=1,5
+         if(ii == 1) then
+            psum=a0
+         else
+            psum=0.0d0
+         end if
+         do jj=1,5
+            psum=psum+constm(ii,jj)*xpow(jj-ii+5)*aco(jj)
+         end do
+         rhomod(kk,ii)=psum
+      end do
    end do
-   do ii=1,5
-     if(ii .eq. 1) then
-       psum=a0
-     else
-       psum=0.0d0
-     end if
-     do jj=1,5
-       psum=psum+constm(ii,jj)*xpow(jj-ii+5)*aco(jj)
-     end do
-     rhomod(kk,ii)=psum
-   end do
- end do
 
 
 !test model
- call der2exc(rhotps,rhomod(1,1),rhops,rr,d2excps,d2excae,d2mdiff, &
-&                   zion,iexc,nc,nv,la,irmod,mmax)
- 
- write(6,'(/a/)') 'Polynomial model core charge'
- write(6,'(/a/)') 'd2excps - pseudofunction derivatives with core correction'
+   call der2exc(rhotps,rhomod(1,1),rhops,rr,d2excps,d2excae,d2mdiff, &
+   &                   zion,iexc,nc,nv,la,irmod,mmax)
 
- do kk=1,nv
-   write(6,'(1p,4d16.6)') (d2excps(kk,jj),jj=1,nv)
- end do
- write(6,'(/a,1p,e16.6)') 'rms 2nd derivative error',d2mdiff
+   write(6,'(/a/)') 'Polynomial model core charge'
+   write(6,'(/a/)') 'd2excps - pseudofunction derivatives with core correction'
 
- deallocate(vxcae,vxcpsp,vo)
- deallocate(dvxcae,dvxcps)
- deallocate(d2excae,d2excps)
+   do kk=1,nv
+      write(6,'(1p,4d16.6)') (d2excps(kk,jj),jj=1,nv)
+   end do
+   write(6,'(/a,1p,e16.6)') 'rms 2nd derivative error',d2mdiff
 
- return
+   deallocate(vxcae,vxcpsp,vo)
+   deallocate(dvxcae,dvxcps)
+   deallocate(d2excae,d2excps)
+
+   return
 end subroutine modcore

--- a/src/modcore2.f90
+++ b/src/modcore2.f90
@@ -2,17 +2,17 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
@@ -20,10 +20,10 @@
 ! core charge and 4 derivatives at "crossover" radius.
 ! Polynomial is 8th-order with no linear term.
 
-! Performs analysis and based on "hardness" criterion described in 
-! Teter, Phys. Rev. B 48, 5031 (1993) , Appendix, as 
+! Performs analysis and based on "hardness" criterion described in
+! Teter, Phys. Rev. B 48, 5031 (1993) , Appendix, as
 
- subroutine modcore2(icmod,rhops,rhotps,rhoc,rhoae,rhotae,rhomod, &
+subroutine modcore2(icmod,rhops,rhotps,rhoc,rhoae,rhotae,rhomod, &
 &                   fcfact,rcfact,irps,mmax,rr,nc,nv,la,zion,iexc)
 
 !icmod  3 coefficient optimizaion, 4 for specivied fcfact and rfact
@@ -44,177 +44,177 @@
 !zion  ion charge
 !iexc  exchange-correlation function to be used
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !Input variables
- integer :: icmod,nv,nc,iexc,irps,mmax
- integer :: la(30)
- real(dp) :: rhoae(mmax,nv),rhops(mmax,nv),rhotae(mmax)
- real(dp) :: rhotps(mmax),rhoc(mmax),rr(mmax)
- real(dp) :: zion,fcfact,rcfact
- logical :: srel
+   integer :: icmod,nv,nc,iexc,irps,mmax
+   integer :: la(30)
+   real(dp) :: rhoae(mmax,nv),rhops(mmax,nv),rhotae(mmax)
+   real(dp) :: rhotps(mmax),rhoc(mmax),rr(mmax)
+   real(dp) :: zion,fcfact,rcfact
+   logical :: srel
 
 !Output variables
- real(dp) :: rhomod(mmax,5)
+   real(dp) :: rhomod(mmax,5)
 
 !convergence criterion
- real(dp), parameter :: eps=1.0d-7
+   real(dp), parameter :: eps=1.0d-7
 
 !Local variables
- real(dp) :: al,eeel,eexc
- real(dp) :: d2mdiff,rmatch,rhocmatch
- real(dp) :: xx,yy,dy
- real(dp) :: x0max,x0min,a0,b0,r0,tt,ymatch,ytrial
- real(dp) :: fmatch(5)
- real(dp) :: drint,rtst,rint(20),fint(20) !ad-hoc smoothing variables
- real(dp), allocatable :: vxcae(:),vxcpsp(:),vo(:),d2excae(:,:),d2excps(:,:)
- real(dp), allocatable :: dvxcae(:,:),dvxcps(:,:),vxct(:)
- integer :: ii,ierr,ircc,irmod,iter,jj,kk
- integer :: iint !ad-hoc smoothing variables
+   real(dp) :: al,eeel,eexc
+   real(dp) :: d2mdiff,rmatch,rhocmatch
+   real(dp) :: xx,yy,dy
+   real(dp) :: x0max,x0min,a0,b0,r0,tt,ymatch,ytrial
+   real(dp) :: fmatch(5)
+   real(dp) :: drint,rtst,rint(20),fint(20)  !ad-hoc smoothing variables
+   real(dp), allocatable :: vxcae(:),vxcpsp(:),vo(:),d2excae(:,:),d2excps(:,:)
+   real(dp), allocatable :: dvxcae(:,:),dvxcps(:,:),vxct(:)
+   integer :: ii,ierr,ircc,irmod,iter,jj,kk
+   integer :: iint  !ad-hoc smoothing variables
 
- allocate(vxcae(mmax),vxcpsp(mmax),vo(mmax))
- allocate(dvxcae(mmax,nv),dvxcps(mmax,nv),vxct(mmax))
- allocate(d2excae(nv,nv),d2excps(nv,nv))
+   allocate(vxcae(mmax),vxcpsp(mmax),vo(mmax))
+   allocate(dvxcae(mmax,nv),dvxcps(mmax,nv),vxct(mmax))
+   allocate(d2excae(nv,nv),d2excps(nv,nv))
 
- d2excae(:,:)=0.0d0
- d2excps(:,:)=0.0d0
+   d2excae(:,:)=0.0d0
+   d2excps(:,:)=0.0d0
 
 ! find valence pseudocharge - core charge crossover
 ! this is needed for compatability with icmod=3 option
- ircc = 0
- do ii = mmax,1,-1
-   if(rhoc(ii) .gt. rhotps(ii)) then
-     ircc=ii
-     rmatch=rr(ircc)
-     rhocmatch=rhoc(ircc)
-     exit
-   end if
- end do
+   ircc = 0
+   do ii = mmax,1,-1
+      if(rhoc(ii) > rhotps(ii)) then
+         ircc=ii
+         rmatch=rr(ircc)
+         rhocmatch=rhoc(ircc)
+         exit
+      end if
+   end do
 
 ! find scaled valence pseudocharge - core charge crossover
- ircc = 0
- do ii = mmax,1,-1
-   if(rhoc(ii) .gt. fcfact*rhotps(ii)) then
-     ircc=ii
-     exit
+   ircc = 0
+   do ii = mmax,1,-1
+      if(rhoc(ii) > fcfact*rhotps(ii)) then
+         ircc=ii
+         exit
+      end if
+   end do
+
+   if(ircc == 0) then
+      write(6,'(/a)') 'modcore2: ERROR ircc (core-valence charge crossover) &
+      &        not found'
+      stop
    end if
- end do
- 
- if(ircc .eq. 0) then
-   write(6,'(/a)') 'modcore2: ERROR ircc (core-valence charge crossover) &
-&        not found'
-   stop
- end if
 
 !set limit for d2Exc calculation to radius beyond which rhomod=rhoc
    irmod=mmax
 
- write(6,'(/a/a)') 'Model core correction analysis',&
-&                  '  based on d2Exc/dn_idn_j'
+   write(6,'(/a/a)') 'Model core correction analysis',&
+   &                  '  based on d2Exc/dn_idn_j'
 
 
 ! get derivatives of all-electron xc energy
 
- call der2exc(rhotae,rhoc,rhoae,rr,d2excae,d2excps,d2mdiff, &
-&                   zion,iexc,nc,nv,la,irmod,mmax)
+   call der2exc(rhotae,rhoc,rhoae,rr,d2excae,d2excps,d2mdiff, &
+   &                   zion,iexc,nc,nv,la,irmod,mmax)
 
- write(6,'(/a/)') 'd2excae - all-electron derivatives'
- do kk=1,nv
-   write(6,'(1p,4d16.6)') (d2excae(kk,jj),jj=1,nv)
- end do
+   write(6,'(/a/)') 'd2excae - all-electron derivatives'
+   do kk=1,nv
+      write(6,'(1p,4d16.6)') (d2excae(kk,jj),jj=1,nv)
+   end do
 
- 
+
 ! set model charge to zero
- rhomod(:,:)=0.0d0
+   rhomod(:,:)=0.0d0
 
 ! compute d2excps with no core correction
- rhomod(:,:)=0.0d0
+   rhomod(:,:)=0.0d0
 
- call der2exc(rhotps,rhomod(1,1),rhops,rr,d2excps,d2excae,d2mdiff, &
-&                   zion,iexc,nc,nv,la,irmod,mmax)
+   call der2exc(rhotps,rhomod(1,1),rhops,rr,d2excps,d2excae,d2mdiff, &
+   &                   zion,iexc,nc,nv,la,irmod,mmax)
 
- write(6,'(/a/)') 'd2excps - pseudofunction derivatives with no core correction'
- do kk=1,nv
-   write(6,'(1p,4d16.6)') (d2excps(kk,jj),jj=1,nv)
- end do
- write(6,'(/a,1p,e16.6)') 'rms 2nd derivative error',d2mdiff
+   write(6,'(/a/)') 'd2excps - pseudofunction derivatives with no core correction'
+   do kk=1,nv
+      write(6,'(1p,4d16.6)') (d2excps(kk,jj),jj=1,nv)
+   end do
+   write(6,'(/a,1p,e16.6)') 'rms 2nd derivative error',d2mdiff
 
- al = 0.01d0 * dlog(rr(101) / rr(1))
+   al = 0.01d0 * dlog(rr(101) / rr(1))
 
 ! core charge density for Louie-Froyen-Cohen correction
 
- rhomod(:,1)= rhoc(:)
+   rhomod(:,1)= rhoc(:)
 
- xx=rr(ircc)
- fmatch(1)=rhoc(ircc)
+   xx=rr(ircc)
+   fmatch(1)=rhoc(ircc)
 
 ! core charge derivatives
 
 !7-point numerical first derivative
- jj=2; ii=ircc
-     rhomod(ii,jj)=(-rhomod(ii-3,jj-1)+ 9.d0*rhomod(ii-2,jj-1)&
-&     -45.d0*rhomod(ii-1,jj-1)+45.d0*rhomod(ii+1,jj-1)&
-&     -9.d0*rhomod(ii+2,jj-1)+rhomod(ii+3,jj-1))&
-&     /(60.d0*al*rr(ii))
- fmatch(jj)=rhomod(ircc,jj)
+   jj=2; ii=ircc
+   rhomod(ii,jj)=(-rhomod(ii-3,jj-1)+ 9.d0*rhomod(ii-2,jj-1)&
+   &     -45.d0*rhomod(ii-1,jj-1)+45.d0*rhomod(ii+1,jj-1)&
+   &     -9.d0*rhomod(ii+2,jj-1)+rhomod(ii+3,jj-1))&
+   &     /(60.d0*al*rr(ii))
+   fmatch(jj)=rhomod(ircc,jj)
 
 ! Fit Teter function to value and slope at ircc
 
- ymatch=rr(ircc)*fmatch(2)/fmatch(1)
+   ymatch=rr(ircc)*fmatch(2)/fmatch(1)
 
 ! interval-halving search for dimensionless match point
 
- x0max=1.48d0
- x0min=0.0d0
+   x0max=1.48d0
+   x0min=0.0d0
 
- do jj=1,50
+   do jj=1,50
 
-  xx=0.5d0*(x0max+x0min)
+      xx=0.5d0*(x0max+x0min)
 
-  call gg1cc(yy,xx)
-  call gp1cc(dy,xx)
-  ytrial=xx*dy/yy
+      call gg1cc(yy,xx)
+      call gp1cc(dy,xx)
+      ytrial=xx*dy/yy
 
-  if(abs(ytrial-ymatch)<eps) exit
+      if(abs(ytrial-ymatch)<eps) exit
 
-  if(ytrial<ymatch) then
-   x0max=xx
-  else
-   x0min=xx
-  end if
- end do
- 
- b0=xx/rr(ircc)
- a0=fmatch(1)/yy
+      if(ytrial<ymatch) then
+         x0max=xx
+      else
+         x0min=xx
+      end if
+   end do
 
- write(6,'(/a)') 'amplitude prefactor, scale prefactor'
- write(6,'(2f10.4)') a0/rhocmatch,1.0d0/(b0*rmatch)
+   b0=xx/rr(ircc)
+   a0=fmatch(1)/yy
+
+   write(6,'(/a)') 'amplitude prefactor, scale prefactor'
+   write(6,'(2f10.4)') a0/rhocmatch,1.0d0/(b0*rmatch)
 
 
- rhomod(:,:)=0.0d0
- do ii=1,mmax
-  xx=b0*rr(ii)
-  if(xx<3.0d0) then
-   call gg1cc(yy,xx)
-   rhomod(ii,1)=a0*yy
-   call gp1cc(yy,xx)
-   rhomod(ii,2)=a0*yy*b0
-   call gpp1cc(yy,xx)
-   rhomod(ii,3)=a0*yy*b0**2
-  end if
- end do
+   rhomod(:,:)=0.0d0
+   do ii=1,mmax
+      xx=b0*rr(ii)
+      if(xx<3.0d0) then
+         call gg1cc(yy,xx)
+         rhomod(ii,1)=a0*yy
+         call gp1cc(yy,xx)
+         rhomod(ii,2)=a0*yy*b0
+         call gpp1cc(yy,xx)
+         rhomod(ii,3)=a0*yy*b0**2
+      end if
+   end do
 
 ! test model
- call der2exc(rhotps,rhomod(1,1),rhops,rr,d2excps,d2excae,d2mdiff, &
-&                   zion,iexc,nc,nv,la,irmod,mmax)
- 
- write(6,'(/a/)') 'd2excps - pseudofunction derivatives with core correction'
+   call der2exc(rhotps,rhomod(1,1),rhops,rr,d2excps,d2excae,d2mdiff, &
+   &                   zion,iexc,nc,nv,la,irmod,mmax)
 
- do kk=1,nv
-   write(6,'(1p,4d16.6)') (d2excps(kk,jj),jj=1,nv)
- end do
- write(6,'(/a,1p,e16.6)') 'rms 2nd derivative error',d2mdiff
+   write(6,'(/a/)') 'd2excps - pseudofunction derivatives with core correction'
+
+   do kk=1,nv
+      write(6,'(1p,4d16.6)') (d2excps(kk,jj),jj=1,nv)
+   end do
+   write(6,'(/a,1p,e16.6)') 'rms 2nd derivative error',d2mdiff
 
 !7-point numerical first derivatives applied successively
 
@@ -232,83 +232,83 @@
 !set up a mesh on which 2nd derivative will have a stable
 !polynomial representation
 !assumes dpnint remains 7th order
- drint=0.05d0*rr(ircc)
- rtst=0.5d0*drint
- do jj=1,4
-   do ii=1,ircc
-     if(rr(ii)>rtst) then
-       rint(4+jj)=rr(ii)
-       rint(5-jj)=-rr(ii)
-       fint(4+jj)=rhomod(ii,3)
-       fint(5-jj)=rhomod(ii,3)
-       iint=ii
-       rtst=rr(ii)+drint
-       exit
-     end if
+   drint=0.05d0*rr(ircc)
+   rtst=0.5d0*drint
+   do jj=1,4
+      do ii=1,ircc
+         if(rr(ii)>rtst) then
+            rint(4+jj)=rr(ii)
+            rint(5-jj)=-rr(ii)
+            fint(4+jj)=rhomod(ii,3)
+            fint(5-jj)=rhomod(ii,3)
+            iint=ii
+            rtst=rr(ii)+drint
+            exit
+         end if
+      end do
    end do
- end do
 
- call dpnint(rint,fint,8,rr,rhomod(1,3),iint-1)
+   call dpnint(rint,fint,8,rr,rhomod(1,3),iint-1)
 
- jj=4
-  do ii=3*jj-8,mmax-3
-     rhomod(ii,jj)=(-rhomod(ii-3,jj-1)+ 9.d0*rhomod(ii-2,jj-1)&
-&     -45.d0*rhomod(ii-1,jj-1)+45.d0*rhomod(ii+1,jj-1)&
-&     -9.d0*rhomod(ii+2,jj-1)+rhomod(ii+3,jj-1))&
-&     /(60.d0*al*rr(ii))
-  end do
+   jj=4
+   do ii=3*jj-8,mmax-3
+      rhomod(ii,jj)=(-rhomod(ii-3,jj-1)+ 9.d0*rhomod(ii-2,jj-1)&
+      &     -45.d0*rhomod(ii-1,jj-1)+45.d0*rhomod(ii+1,jj-1)&
+      &     -9.d0*rhomod(ii+2,jj-1)+rhomod(ii+3,jj-1))&
+      &     /(60.d0*al*rr(ii))
+   end do
 
 !set up a mesh on which 3rd derivative will have a stable
- drint=0.95d0*drint
- rtst=0.5d0*drint
- rtst=0.5d0*drint
- do jj=1,4
-   do ii=1,ircc
-     if(rr(ii)>rtst) then
-       rint(4+jj)=rr(ii)
-       rint(5-jj)=-rr(ii)
-       fint(4+jj)=rhomod(ii,4)
-       fint(5-jj)=-rhomod(ii,4)
-       iint=ii
-       rtst=rr(ii)+drint
-       exit
-     end if
+   drint=0.95d0*drint
+   rtst=0.5d0*drint
+   rtst=0.5d0*drint
+   do jj=1,4
+      do ii=1,ircc
+         if(rr(ii)>rtst) then
+            rint(4+jj)=rr(ii)
+            rint(5-jj)=-rr(ii)
+            fint(4+jj)=rhomod(ii,4)
+            fint(5-jj)=-rhomod(ii,4)
+            iint=ii
+            rtst=rr(ii)+drint
+            exit
+         end if
+      end do
    end do
- end do
 
- call dpnint(rint,fint,8,rr,rhomod(1,4),iint-1)
+   call dpnint(rint,fint,8,rr,rhomod(1,4),iint-1)
 
- jj=5
-  do ii=3*jj-8,mmax-3
-     rhomod(ii,jj)=(-rhomod(ii-3,jj-1)+ 9.d0*rhomod(ii-2,jj-1)&
-&     -45.d0*rhomod(ii-1,jj-1)+45.d0*rhomod(ii+1,jj-1)&
-&     -9.d0*rhomod(ii+2,jj-1)+rhomod(ii+3,jj-1))&
-&     /(60.d0*al*rr(ii))
-  end do
+   jj=5
+   do ii=3*jj-8,mmax-3
+      rhomod(ii,jj)=(-rhomod(ii-3,jj-1)+ 9.d0*rhomod(ii-2,jj-1)&
+      &     -45.d0*rhomod(ii-1,jj-1)+45.d0*rhomod(ii+1,jj-1)&
+      &     -9.d0*rhomod(ii+2,jj-1)+rhomod(ii+3,jj-1))&
+      &     /(60.d0*al*rr(ii))
+   end do
 
 !set up a mesh on which 4th derivative will have a stable
- drint=0.95d0*drint
- rtst=0.5d0*drint
- do jj=1,4
-   do ii=1,ircc
-     if(rr(ii)>rtst) then
-       rint(4+jj)=rr(ii)
-       rint(5-jj)=-rr(ii)
-       fint(4+jj)=rhomod(ii,5)
-       fint(5-jj)=rhomod(ii,5)
-       iint=ii
-       rtst=rr(ii)+drint
-       exit
-     end if
+   drint=0.95d0*drint
+   rtst=0.5d0*drint
+   do jj=1,4
+      do ii=1,ircc
+         if(rr(ii)>rtst) then
+            rint(4+jj)=rr(ii)
+            rint(5-jj)=-rr(ii)
+            fint(4+jj)=rhomod(ii,5)
+            fint(5-jj)=rhomod(ii,5)
+            iint=ii
+            rtst=rr(ii)+drint
+            exit
+         end if
+      end do
    end do
- end do
 
- call dpnint(rint,fint,8,rr,rhomod(1,5),iint-1)
+   call dpnint(rint,fint,8,rr,rhomod(1,5),iint-1)
 
 
- deallocate(vxcae,vxcpsp,vo)
- deallocate(dvxcae,dvxcps)
- deallocate(d2excae,d2excps)
+   deallocate(vxcae,vxcpsp,vo)
+   deallocate(dvxcae,dvxcps)
+   deallocate(d2excae,d2excps)
 
- return
+   return
 end subroutine modcore2

--- a/src/modcore3.f90
+++ b/src/modcore3.f90
@@ -2,17 +2,17 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
@@ -20,10 +20,10 @@
 ! core charge and 4 derivatives at "crossover" radius.
 ! Polynomial is 8th-order with no linear term.
 
-! Performs analysis and based on "hardness" criterion described in 
-! Teter, Phys. Rev. B 48, 5031 (1993) , Appendix, as 
+! Performs analysis and based on "hardness" criterion described in
+! Teter, Phys. Rev. B 48, 5031 (1993) , Appendix, as
 
- subroutine modcore3(icmod,rhops,rhotps,rhoc,rhoae,rhotae,rhomod, &
+subroutine modcore3(icmod,rhops,rhotps,rhoc,rhoae,rhotae,rhomod, &
 &                   fcfact,rcfact,irps,mmax,rr,nc,nv,la,zion,iexc)
 
 !icmod  3 coefficient optimizaion, 4 for specivied fcfact and rfact
@@ -44,499 +44,499 @@
 !zion  ion charge
 !iexc  exchange-correlation function to be used
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !Input variables
- integer :: icmod,nv,nc,iexc,irps,mmax
- integer :: la(30)
- real(dp) :: rhoae(mmax,nv),rhops(mmax,nv),rhotae(mmax)
- real(dp) :: rhotps(mmax),rhoc(mmax),rr(mmax)
- real(dp) :: zion,fcfact,rcfact
- logical :: srel
+   integer :: icmod,nv,nc,iexc,irps,mmax
+   integer :: la(30)
+   real(dp) :: rhoae(mmax,nv),rhops(mmax,nv),rhotae(mmax)
+   real(dp) :: rhotps(mmax),rhoc(mmax),rr(mmax)
+   real(dp) :: zion,fcfact,rcfact
+   logical :: srel
 
 !Output variables
- real(dp) :: rhomod(mmax,5)
+   real(dp) :: rhomod(mmax,5)
 
 !convergence criterion
- real(dp), parameter :: eps=1.0d-7
- real(dp), parameter :: blend=2.0d0
+   real(dp), parameter :: eps=1.0d-7
+   real(dp), parameter :: blend=2.0d0
 
 !Local variables
- real(dp) :: al,eeel,eexc
- real(dp) :: d2mdiff,rmatch,rhocmatch,r0,rcross
- real(dp) :: gg,tt,yy
- real(dp) :: drint,rtst,rint(20),fint(20) !ad-hoc smoothing variables
- real(dp), allocatable :: vxcae(:),vxcpsp(:),vo(:),d2excae(:,:),d2excps(:,:)
- real(dp), allocatable :: dvxcae(:,:),dvxcps(:,:),vxct(:)
- integer :: ii,ierr,ircc,ircross,irmod,iter,jj,kk
- integer :: iint !ad-hoc smoothing variables
+   real(dp) :: al,eeel,eexc
+   real(dp) :: d2mdiff,rmatch,rhocmatch,r0,rcross
+   real(dp) :: gg,tt,yy
+   real(dp) :: drint,rtst,rint(20),fint(20)  !ad-hoc smoothing variables
+   real(dp), allocatable :: vxcae(:),vxcpsp(:),vo(:),d2excae(:,:),d2excps(:,:)
+   real(dp), allocatable :: dvxcae(:,:),dvxcps(:,:),vxct(:)
+   integer :: ii,ierr,ircc,ircross,irmod,iter,jj,kk
+   integer :: iint  !ad-hoc smoothing variables
 
 !2-dimensional Nelder-Mead variables
- real(dp), parameter :: alpha_nm=1.0d0
- real(dp), parameter :: gamma_nm=2.0d0
- real(dp), parameter :: rho_nm=-0.5d0
- real(dp), parameter :: sigma_nm=0.5d0
- real(dp) :: xx(2,3),ff(3),xt(2),ft,x0(2),xr(2),fr,xe(2),fe,xc(2),fc
- real(dp) :: d2ref,fta(10),d2min
+   real(dp), parameter :: alpha_nm=1.0d0
+   real(dp), parameter :: gamma_nm=2.0d0
+   real(dp), parameter :: rho_nm=-0.5d0
+   real(dp), parameter :: sigma_nm=0.5d0
+   real(dp) :: xx(2,3),ff(3),xt(2),ft,x0(2),xr(2),fr,xe(2),fe,xc(2),fc
+   real(dp) :: d2ref,fta(10),d2min
 
 
- allocate(vxcae(mmax),vxcpsp(mmax),vo(mmax))
- allocate(dvxcae(mmax,nv),dvxcps(mmax,nv),vxct(mmax))
- allocate(d2excae(nv,nv),d2excps(nv,nv))
+   allocate(vxcae(mmax),vxcpsp(mmax),vo(mmax))
+   allocate(dvxcae(mmax,nv),dvxcps(mmax,nv),vxct(mmax))
+   allocate(d2excae(nv,nv),d2excps(nv,nv))
 
- d2excae(:,:)=0.0d0
- d2excps(:,:)=0.0d0
+   d2excae(:,:)=0.0d0
+   d2excps(:,:)=0.0d0
 
 !set limit for d2Exc calculation to radius beyond which rhomod=rhoc
- irmod=mmax
+   irmod=mmax
 
- write(6,'(/a/a)') 'Model core correction analysis',&
-&                  '  based on d2Exc/dn_idn_j'
+   write(6,'(/a/a)') 'Model core correction analysis',&
+   &                  '  based on d2Exc/dn_idn_j'
 
- call der2exc(rhotae,rhoc,rhoae,rr,d2excae,d2excps,d2mdiff, &
-&                   zion,iexc,nc,nv,la,irmod,mmax)
+   call der2exc(rhotae,rhoc,rhoae,rr,d2excae,d2excps,d2mdiff, &
+   &                   zion,iexc,nc,nv,la,irmod,mmax)
 
- write(6,'(/a/)') 'd2excae - all-electron derivatives'
- do kk=1,nv
-   write(6,'(1p,4d16.6)') (d2excae(kk,jj),jj=1,nv)
- end do
+   write(6,'(/a/)') 'd2excae - all-electron derivatives'
+   do kk=1,nv
+      write(6,'(1p,4d16.6)') (d2excae(kk,jj),jj=1,nv)
+   end do
 
- 
+
 ! set model charge to zero
- rhomod(:,:)=0.0d0
+   rhomod(:,:)=0.0d0
 
 ! compute d2excps with no core correction
- rhomod(:,:)=0.0d0
+   rhomod(:,:)=0.0d0
 
- call der2exc(rhotps,rhomod(1,1),rhops,rr,d2excps,d2excae,d2mdiff, &
-&                   zion,iexc,nc,nv,la,irmod,mmax)
+   call der2exc(rhotps,rhomod(1,1),rhops,rr,d2excps,d2excae,d2mdiff, &
+   &                   zion,iexc,nc,nv,la,irmod,mmax)
 
- write(6,'(/a/)') 'd2excps - pseudofunction derivatives with no core correction'
- do kk=1,nv
-   write(6,'(1p,4d16.6)') (d2excps(kk,jj),jj=1,nv)
- end do
- write(6,'(/a,1p,e16.6)') 'rms 2nd derivative error',d2mdiff
+   write(6,'(/a/)') 'd2excps - pseudofunction derivatives with no core correction'
+   do kk=1,nv
+      write(6,'(1p,4d16.6)') (d2excps(kk,jj),jj=1,nv)
+   end do
+   write(6,'(/a,1p,e16.6)') 'rms 2nd derivative error',d2mdiff
 
- d2ref=d2mdiff
+   d2ref=d2mdiff
 
 ! find valence pseudocharge - core charge crossover
- ircc = 0
- do ii = mmax,1,-1
-   if(rhoc(ii) .gt. rhotps(ii)) then
-     ircc=ii
-     rmatch=rr(ircc)
-     rhocmatch=rhoc(ircc)
-     exit
+   ircc = 0
+   do ii = mmax,1,-1
+      if(rhoc(ii) > rhotps(ii)) then
+         ircc=ii
+         rmatch=rr(ircc)
+         rhocmatch=rhoc(ircc)
+         exit
+      end if
+   end do
+
+   if(ircc == 0) then
+      write(6,'(/a)') 'modcore3: ERROR ircc (core-valence charge crossover) &
+      &        not found'
+      stop
+   else
+      write(6,'(/a,2f10.4)') 'rmatch, rhocmatch',rmatch,rhocmatch
    end if
- end do
 
- if(ircc .eq. 0) then
-   write(6,'(/a)') 'modcore3: ERROR ircc (core-valence charge crossover) &
-&        not found'
-   stop
- else
-  write(6,'(/a,2f10.4)') 'rmatch, rhocmatch',rmatch,rhocmatch
- end if
-
- gg=0.d0
- yy=0.d0
+   gg=0.d0
+   yy=0.d0
 
 !option for optimization
- if(icmod==4) then
+   if(icmod==4) then
 
- fcfact=1.0d0
+      fcfact=1.0d0
 
 !Coarse-grid search for minimum
 
- write(6,'(/a)') 'Coarse scan for minimum error'
- write(6,'(a)') '  matrix elements: rms 2nd-derivative errors (mHa)'
- write(6,'(a)') '  column index : amplitude prefactor to rhocmatch'
- write(6,'(a)') '  row index : scale prefactor to rmatch'
+      write(6,'(/a)') 'Coarse scan for minimum error'
+      write(6,'(a)') '  matrix elements: rms 2nd-derivative errors (mHa)'
+      write(6,'(a)') '  column index : amplitude prefactor to rhocmatch'
+      write(6,'(a)') '  row index : scale prefactor to rmatch'
 
- d2min=10.0d0
- write(6,'(/7x,10f7.3/)') (1.5d0+0.5d0*(jj-1), jj=1,10)
- do  kk=1,10
-  xt(2)=(1.0d0+0.1d0*(kk-1))*rmatch
-  do jj=1,10
-   xt(1)=(1.5d0+0.5d0*(jj-1))*rhocmatch
+      d2min=10.0d0
+      write(6,'(/7x,10f7.3/)') (1.5d0+0.5d0*(jj-1), jj=1,10)
+      do  kk=1,10
+         xt(2)=(1.0d0+0.1d0*(kk-1))*rmatch
+         do jj=1,10
+            xt(1)=(1.5d0+0.5d0*(jj-1))*rhocmatch
 
-   r0=1.5d0*xt(2)
-   do ii=mmax,1,-1
-    if(rr(ii)<r0) then
-      call gg1cc(gg,yy)
-      if(xt(1)*gg<rhoc(ii)) then
-        rcross=rr(ii)
-        exit
-      end if
-    end if
-   end do
+            r0=1.5d0*xt(2)
+            do ii=mmax,1,-1
+               if(rr(ii)<r0) then
+                  call gg1cc(gg,yy)
+                  if(xt(1)*gg<rhoc(ii)) then
+                     rcross=rr(ii)
+                     exit
+                  end if
+               end if
+            end do
 
-   do ii=1,mmax
-    yy=rr(ii)/xt(2)
-    call gg1cc(gg,yy)
-    rhomod(ii,1)= xt(1)*gg
-   end do
+            do ii=1,mmax
+               yy=rr(ii)/xt(2)
+               call gg1cc(gg,yy)
+               rhomod(ii,1)= xt(1)*gg
+            end do
 
-   call der2exc(rhotps,rhomod(1,1),rhops,rr,d2excps,d2excae,d2mdiff, &
-&                     zion,iexc,nc,nv,la,irmod,mmax)
-   fta(jj)=1.0d3*d2mdiff
+            call der2exc(rhotps,rhomod(1,1),rhops,rr,d2excps,d2excae,d2mdiff, &
+            &                     zion,iexc,nc,nv,la,irmod,mmax)
+            fta(jj)=1.0d3*d2mdiff
 
-   if(d2mdiff<d2min) then
-    xx(:,1)=xt(:)
-    d2min=d2mdiff
-   end if
+            if(d2mdiff<d2min) then
+               xx(:,1)=xt(:)
+               d2min=d2mdiff
+            end if
 
-  end do
-  write(6,'(f5.1,f9.3,9f7.3)') 1.0d0+0.1d0*(kk-1),(fta(jj),jj=1,10)
- end do
+         end do
+         write(6,'(f5.1,f9.3,9f7.3)') 1.0d0+0.1d0*(kk-1),(fta(jj),jj=1,10)
+      end do
 
 !Initial Nelder-Mead simplex from coarse-search minimum
 
- xx(1,2)=xx(1,1)+0.25d0*rhocmatch
- xx(2,2)=xx(2,1)
- xx(1,3)=xx(1,1)
- xx(2,3)=xx(2,1)+0.05d0*rmatch
- xx(1,1)=xx(1,1)-0.125d0*rhocmatch
- xx(2,1)=xx(2,1)-0.025d0*rmatch
+      xx(1,2)=xx(1,1)+0.25d0*rhocmatch
+      xx(2,2)=xx(2,1)
+      xx(1,3)=xx(1,1)
+      xx(2,3)=xx(2,1)+0.05d0*rmatch
+      xx(1,1)=xx(1,1)-0.125d0*rhocmatch
+      xx(2,1)=xx(2,1)-0.025d0*rmatch
 
 !Fill function values for initial simplex
 
- do kk=1,3
-  xt(:)=xx(:,kk)
+      do kk=1,3
+         xt(:)=xx(:,kk)
 
 
-   r0=1.5d0*xt(2)
-   do ii=mmax,1,-1
-    if(rr(ii)<r0) then
-      call gg1cc(gg,yy)
-      if(xt(1)*gg<rhoc(ii)) then
-        rcross=rr(ii)
-        exit
-      end if
-    end if
-   end do
+         r0=1.5d0*xt(2)
+         do ii=mmax,1,-1
+            if(rr(ii)<r0) then
+               call gg1cc(gg,yy)
+               if(xt(1)*gg<rhoc(ii)) then
+                  rcross=rr(ii)
+                  exit
+               end if
+            end if
+         end do
 
-   do ii=1,mmax
-    yy=rr(ii)/xt(2)
-    call gg1cc(gg,yy)
-    tt=(rr(ii)-r0-2.0d0*rcross)/(r0-rcross)
-    rhomod(ii,1)= xt(1)*gg
-   end do
+         do ii=1,mmax
+            yy=rr(ii)/xt(2)
+            call gg1cc(gg,yy)
+            tt=(rr(ii)-r0-2.0d0*rcross)/(r0-rcross)
+            rhomod(ii,1)= xt(1)*gg
+         end do
 
-   call der2exc(rhotps,rhomod(1,1),rhops,rr,d2excps,d2excae,d2mdiff, &
- &                    zion,iexc,nc,nv,la,irmod,mmax)
-   ff(kk)=d2mdiff
+         call der2exc(rhotps,rhomod(1,1),rhops,rr,d2excps,d2excae,d2mdiff, &
+         &                    zion,iexc,nc,nv,la,irmod,mmax)
+         ff(kk)=d2mdiff
 
 !  write(6,'(i4,a,2f10.4,1p,e14.4)') kk,'  xt',xt(1),xt(2),ff(kk)
- end do
+      end do
 
 !Nelder-Mead iteration loop
- write(6,'(/a)') 'Nelder-Mead iteration'
- do kk=1,101
+      write(6,'(/a)') 'Nelder-Mead iteration'
+      do kk=1,101
 
 !(1) Order (dumb bubble sort)
-  do jj=1,3
-   if(ff(3)<ff(2)) then
-     ft=ff(2) ; xt(:)=xx(:,2)
-     ff(2)=ff(3) ; xx(:,2)=xx(:,3)
-     ff(3)=ft ; xx(:,3)=xt(:)
-   end if
-   if(ff(2)<ff(1)) then
-     ft=ff(1) ; xt(:)=xx(:,1)
-     ff(1)=ff(2) ; xx(:,1)=xx(:,2)
-     ff(2)=ft ; xx(:,2)=xt(:)
-   end if
-  end do
+         do jj=1,3
+            if(ff(3)<ff(2)) then
+               ft=ff(2) ; xt(:)=xx(:,2)
+               ff(2)=ff(3) ; xx(:,2)=xx(:,3)
+               ff(3)=ft ; xx(:,3)=xt(:)
+            end if
+            if(ff(2)<ff(1)) then
+               ft=ff(1) ; xt(:)=xx(:,1)
+               ff(1)=ff(2) ; xx(:,1)=xx(:,2)
+               ff(2)=ft ; xx(:,2)=xt(:)
+            end if
+         end do
 
 !stopping criterion
-  if(ff(3)-ff(1)<1.0d-4*d2ref) then
-    write(6,'(a,i4,a)') ' converged in',kk-1,' steps'
-    write(6,'(a)') 'amplitude prefactor, scale prefactor'
-    write(6,'(2f10.4)') xx(1,1)/rhocmatch,xx(2,1)/rmatch
-    exit
-  else if(kk==101) then
-    write(6,'(a,i4,a)') ' WARNING: not fully converged in 100 steps'
-    write(6,'(a)') 'amplitude prefactor, scale prefactor'
-    write(6,'(2f10.4)') xx(1,1)/rhocmatch,xx(2,1)/rmatch
-    exit
-  end if
+         if(ff(3)-ff(1)<1.0d-4*d2ref) then
+            write(6,'(a,i4,a)') ' converged in',kk-1,' steps'
+            write(6,'(a)') 'amplitude prefactor, scale prefactor'
+            write(6,'(2f10.4)') xx(1,1)/rhocmatch,xx(2,1)/rmatch
+            exit
+         else if(kk==101) then
+            write(6,'(a,i4,a)') ' WARNING: not fully converged in 100 steps'
+            write(6,'(a)') 'amplitude prefactor, scale prefactor'
+            write(6,'(2f10.4)') xx(1,1)/rhocmatch,xx(2,1)/rmatch
+            exit
+         end if
 
 !(2) Centroid
-  x0(:)=0.5d0*(xx(:,1)+xx(:,2))
+         x0(:)=0.5d0*(xx(:,1)+xx(:,2))
 
 !(3) Reflection
-  xr(:)=x0(:)+alpha_nm*(x0(:)-xx(:,3))
+         xr(:)=x0(:)+alpha_nm*(x0(:)-xx(:,3))
 
 
-   r0=1.5d0*xr(2)
-   do ii=mmax,1,-1
-    if(rr(ii)<r0) then
-      call gg1cc(gg,yy)
-      if(xr(1)*gg<rhoc(ii)) then
-        rcross=rr(ii)
-        exit
-      end if
-    end if
-   end do
+         r0=1.5d0*xr(2)
+         do ii=mmax,1,-1
+            if(rr(ii)<r0) then
+               call gg1cc(gg,yy)
+               if(xr(1)*gg<rhoc(ii)) then
+                  rcross=rr(ii)
+                  exit
+               end if
+            end if
+         end do
 
-   do ii=1,mmax
-    yy=rr(ii)/xr(2)
-    call gg1cc(gg,yy)
-    tt=(rr(ii)-r0-2.0d0*rcross)/(r0-rcross)
-    rhomod(ii,1)= xr(1)*gg
-   end do
+         do ii=1,mmax
+            yy=rr(ii)/xr(2)
+            call gg1cc(gg,yy)
+            tt=(rr(ii)-r0-2.0d0*rcross)/(r0-rcross)
+            rhomod(ii,1)= xr(1)*gg
+         end do
 
-  call der2exc(rhotps,rhomod(1,1),rhops,rr,d2excps,d2excae,d2mdiff, &
-&                    zion,iexc,nc,nv,la,irmod,mmax)
-  fr=d2mdiff
+         call der2exc(rhotps,rhomod(1,1),rhops,rr,d2excps,d2excae,d2mdiff, &
+         &                    zion,iexc,nc,nv,la,irmod,mmax)
+         fr=d2mdiff
 ! write(6,'(i4,a,2f10.4,1p,e14.4)') kk,'  xr',xr(1),xr(2),fr
 
-  if(ff(1)<= fr .and. fr<ff(2)) then
-   ff(3)=fr ; xx(:,3)=xr(:)
-   cycle !kk loop
-  end if
+         if(ff(1)<= fr .and. fr<ff(2)) then
+            ff(3)=fr ; xx(:,3)=xr(:)
+            cycle  !kk loop
+         end if
 
 !(4) Expansion
-  if(fr<ff(1)) then
-   xe(:)=x0(:)+gamma_nm*(x0(:)-xx(:,3))
+         if(fr<ff(1)) then
+            xe(:)=x0(:)+gamma_nm*(x0(:)-xx(:,3))
 
-   r0=1.5d0*xe(2)
-   do ii=mmax,1,-1
-    if(rr(ii)<r0) then
-      call gg1cc(gg,yy)
-      if(xe(1)*gg<rhoc(ii)) then
-        rcross=rr(ii)
-        exit
-      end if
-    end if
-   end do
+            r0=1.5d0*xe(2)
+            do ii=mmax,1,-1
+               if(rr(ii)<r0) then
+                  call gg1cc(gg,yy)
+                  if(xe(1)*gg<rhoc(ii)) then
+                     rcross=rr(ii)
+                     exit
+                  end if
+               end if
+            end do
 
-   do ii=1,mmax
-    yy=rr(ii)/xe(2)
-    call gg1cc(gg,yy)
-    tt=(rr(ii)-r0-2.0d0*rcross)/(r0-rcross)
-    rhomod(ii,1)= xe(1)*gg
-   end do
+            do ii=1,mmax
+               yy=rr(ii)/xe(2)
+               call gg1cc(gg,yy)
+               tt=(rr(ii)-r0-2.0d0*rcross)/(r0-rcross)
+               rhomod(ii,1)= xe(1)*gg
+            end do
 
-   call der2exc(rhotps,rhomod(1,1),rhops,rr,d2excps,d2excae,d2mdiff, &
-&                     zion,iexc,nc,nv,la,irmod,mmax)
-   fe=d2mdiff
+            call der2exc(rhotps,rhomod(1,1),rhops,rr,d2excps,d2excae,d2mdiff, &
+            &                     zion,iexc,nc,nv,la,irmod,mmax)
+            fe=d2mdiff
 ! write(6,'(i4,a,2f10.4,1p,e14.4)') kk,'  xe',xe(1),xe(2),fe
 
-   if(fe<fr) then
-    ff(3)=fe ; xx(:,3)=xe(:)
-    cycle !kk
-   else
-    ff(3)=fr ; xx(:,3)=xr(:)
-    cycle !kk
-   end if
-  end if
+            if(fe<fr) then
+               ff(3)=fe ; xx(:,3)=xe(:)
+               cycle  !kk
+            else
+               ff(3)=fr ; xx(:,3)=xr(:)
+               cycle  !kk
+            end if
+         end if
 
 !(5) Contraction
-  xc(:)=x0(:)+rho_nm*(x0(:)-xx(:,3))
+         xc(:)=x0(:)+rho_nm*(x0(:)-xx(:,3))
 
 
-   r0=1.5d0*xc(2)
-   do ii=mmax,1,-1
-    if(rr(ii)<r0) then
-      call gg1cc(gg,yy)
-      if(xc(1)*gg<rhoc(ii)) then
-        rcross=rr(ii)
-        exit
-      end if
-    end if
-   end do
+         r0=1.5d0*xc(2)
+         do ii=mmax,1,-1
+            if(rr(ii)<r0) then
+               call gg1cc(gg,yy)
+               if(xc(1)*gg<rhoc(ii)) then
+                  rcross=rr(ii)
+                  exit
+               end if
+            end if
+         end do
 
-   do ii=1,mmax
-    yy=rr(ii)/xc(2)
-    call gg1cc(gg,yy)
-    tt=(rr(ii)-r0-2.0d0*rcross)/(r0-rcross)
-    rhomod(ii,1)= xc(1)*gg
-   end do
+         do ii=1,mmax
+            yy=rr(ii)/xc(2)
+            call gg1cc(gg,yy)
+            tt=(rr(ii)-r0-2.0d0*rcross)/(r0-rcross)
+            rhomod(ii,1)= xc(1)*gg
+         end do
 
-  call der2exc(rhotps,rhomod(1,1),rhops,rr,d2excps,d2excae,d2mdiff, &
-&                    zion,iexc,nc,nv,la,irmod,mmax)
-  fc=d2mdiff
+         call der2exc(rhotps,rhomod(1,1),rhops,rr,d2excps,d2excae,d2mdiff, &
+         &                    zion,iexc,nc,nv,la,irmod,mmax)
+         fc=d2mdiff
 !  write(6,'(i4,a,2f10.4,1p,e14.4)') kk,'  xc',xc(1),xc(2),fc
-  if(fc<ff(3)) then
-   ff(3)=fc ; xx(:,3)=xc(:)
-   cycle !kk
-  end if
+         if(fc<ff(3)) then
+            ff(3)=fc ; xx(:,3)=xc(:)
+            cycle  !kk
+         end if
 
 !(6) Reduction
-  do jj=2,3
-   xx(:,jj)=xx(:,1)+sigma_nm*(xx(:,jj)-xx(:,1))
+         do jj=2,3
+            xx(:,jj)=xx(:,1)+sigma_nm*(xx(:,jj)-xx(:,1))
 
-   r0=1.5d0*xx(2,jj)
-   do ii=mmax,1,-1
-    if(rr(ii)<r0) then
-      call gg1cc(gg,yy)
-      if(xx(1,jj)*gg<rhoc(ii)) then
-        rcross=rr(ii)
-        exit
-      end if
-    end if
-   end do
+            r0=1.5d0*xx(2,jj)
+            do ii=mmax,1,-1
+               if(rr(ii)<r0) then
+                  call gg1cc(gg,yy)
+                  if(xx(1,jj)*gg<rhoc(ii)) then
+                     rcross=rr(ii)
+                     exit
+                  end if
+               end if
+            end do
 
-   do ii=1,mmax
-    yy=rr(ii)/xx(2,jj)
-    call gg1cc(gg,yy)
-    tt=(rr(ii)-r0-2.0d0*rcross)/(r0-rcross)
-    rhomod(ii,1)= xx(1,jj)*gg
-   end do
+            do ii=1,mmax
+               yy=rr(ii)/xx(2,jj)
+               call gg1cc(gg,yy)
+               tt=(rr(ii)-r0-2.0d0*rcross)/(r0-rcross)
+               rhomod(ii,1)= xx(1,jj)*gg
+            end do
 
-   call der2exc(rhotps,rhomod(1,1),rhops,rr,d2excps,d2excae,d2mdiff, &
-&                     zion,iexc,nc,nv,la,irmod,mmax)
-   ff(jj)=d2mdiff
+            call der2exc(rhotps,rhomod(1,1),rhops,rr,d2excps,d2excae,d2mdiff, &
+            &                     zion,iexc,nc,nv,la,irmod,mmax)
+            ff(jj)=d2mdiff
 !  write(6,'(i4,a,2f10.4,1p,e14.4)') kk,' xrd',xx(1,jj),xx(2,jj),ff(jj)
-  end do !jj
+         end do  !jj
 
- end do !kk
+      end do  !kk
 
- write(6,'(/a)') 'Optimized Teter model core charge'
+      write(6,'(/a)') 'Optimized Teter model core charge'
 
 !option for specifying prefactors as input
- else if(icmod==3) then
-  xx(1,1)=fcfact*rhocmatch
-  xx(2,1)=rcfact*rmatch
+   else if(icmod==3) then
+      xx(1,1)=fcfact*rhocmatch
+      xx(2,1)=rcfact*rmatch
 
-  write(6,'(/a/)') &
-&       'Teter function model core charge with specified parameters'
- end if
+      write(6,'(/a/)') &
+      &       'Teter function model core charge with specified parameters'
+   end if
 
- r0=1.5d0*xx(2,1)
- do ii=mmax,1,-1
-  if(rr(ii)<r0) then
-    call gg1cc(gg,yy)
-    if( xx(1,1)*gg<rhoc(ii)) then
-      rcross=rr(ii)
-      ircross=ii
-      exit
-    end if
-  end if
- end do
+   r0=1.5d0*xx(2,1)
+   do ii=mmax,1,-1
+      if(rr(ii)<r0) then
+         call gg1cc(gg,yy)
+         if( xx(1,1)*gg<rhoc(ii)) then
+            rcross=rr(ii)
+            ircross=ii
+            exit
+         end if
+      end if
+   end do
 
 ! blend the Teter function tail into the all-electron rhoc
 ! first two derivatives are filled in analytically before the blend starts
- rhomod(:,:)=0.0d0
- do ii=1,mmax
-  yy=rr(ii)/xx(2,1)
-  call gg1cc(gg,yy)
-  tt=(rr(ii)-r0-2.0d0*rr(ircross))/(r0-rr(ircross))
+   rhomod(:,:)=0.0d0
+   do ii=1,mmax
+      yy=rr(ii)/xx(2,1)
+      call gg1cc(gg,yy)
+      tt=(rr(ii)-r0-2.0d0*rr(ircross))/(r0-rr(ircross))
 
-  rhomod(ii,1)=xx(1,1)*gg
-  if(ii<ircross) then
-   call gp1cc(gg,yy)
-   rhomod(ii,2)=xx(1,1)*gg/xx(2,1)
-   call gpp1cc(gg,yy)
-   rhomod(ii,3)=xx(1,1)*gg/xx(2,1)**2
-  end if
- end do
+      rhomod(ii,1)=xx(1,1)*gg
+      if(ii<ircross) then
+         call gp1cc(gg,yy)
+         rhomod(ii,2)=xx(1,1)*gg/xx(2,1)
+         call gpp1cc(gg,yy)
+         rhomod(ii,3)=xx(1,1)*gg/xx(2,1)**2
+      end if
+   end do
 
- call der2exc(rhotps,rhomod(1,1),rhops,rr,d2excps,d2excae,d2mdiff, &
-&                   zion,iexc,nc,nv,la,irmod,mmax)
- 
-write(6,'(/a/)') 'd2excps - pseudofunction derivatives with core correction' 
- do kk=1,nv
-   write(6,'(1p,4d16.6)') (d2excps(kk,jj),jj=1,nv)
- end do
- write(6,'(/a,1p,e16.6)') 'rms 2nd derivative error',d2mdiff
+   call der2exc(rhotps,rhomod(1,1),rhops,rr,d2excps,d2excae,d2mdiff, &
+   &                   zion,iexc,nc,nv,la,irmod,mmax)
+
+   write(6,'(/a/)') 'd2excps - pseudofunction derivatives with core correction'
+   do kk=1,nv
+      write(6,'(1p,4d16.6)') (d2excps(kk,jj),jj=1,nv)
+   end do
+   write(6,'(/a,1p,e16.6)') 'rms 2nd derivative error',d2mdiff
 
 !7-point numerical first derivatives applied successively
 !skip non-blended section for 1st and 2nd derivatives
 
- al = 0.01d0 * dlog(rr(101) / rr(1))
+   al = 0.01d0 * dlog(rr(101) / rr(1))
 
- do jj=2,3
-  do ii=ircross-6,mmax-3
-     rhomod(ii,jj)=(-rhomod(ii-3,jj-1)+ 9.d0*rhomod(ii-2,jj-1)&
-&     -45.d0*rhomod(ii-1,jj-1)+45.d0*rhomod(ii+1,jj-1)&
-&     -9.d0*rhomod(ii+2,jj-1)+rhomod(ii+3,jj-1))&
-&     /(60.d0*al*rr(ii))
-  end do
- end do
+   do jj=2,3
+      do ii=ircross-6,mmax-3
+         rhomod(ii,jj)=(-rhomod(ii-3,jj-1)+ 9.d0*rhomod(ii-2,jj-1)&
+         &     -45.d0*rhomod(ii-1,jj-1)+45.d0*rhomod(ii+1,jj-1)&
+         &     -9.d0*rhomod(ii+2,jj-1)+rhomod(ii+3,jj-1))&
+         &     /(60.d0*al*rr(ii))
+      end do
+   end do
 
 !ad-hoc treatment of numerical noise near origin
 !set up a mesh on which 2nd derivative will have a stable
 !polynomial representation
 !assumes dpnint remains 7th order
- drint=0.02d0*rr(ircross)
- rtst=0.5d0*drint
- do jj=1,4
-   do ii=1,ircross
-     if(rr(ii)>rtst) then
-       rint(4+jj)=rr(ii)
-       rint(5-jj)=-rr(ii)
-       fint(4+jj)=rhomod(ii,3)
-       fint(5-jj)=rhomod(ii,3)
-       iint=ii
-       rtst=rr(ii)+drint
-       exit
-     end if
+   drint=0.02d0*rr(ircross)
+   rtst=0.5d0*drint
+   do jj=1,4
+      do ii=1,ircross
+         if(rr(ii)>rtst) then
+            rint(4+jj)=rr(ii)
+            rint(5-jj)=-rr(ii)
+            fint(4+jj)=rhomod(ii,3)
+            fint(5-jj)=rhomod(ii,3)
+            iint=ii
+            rtst=rr(ii)+drint
+            exit
+         end if
+      end do
    end do
- end do
 
- call dpnint(rint,fint,8,rr,rhomod(1,3),iint-1)
+   call dpnint(rint,fint,8,rr,rhomod(1,3),iint-1)
 
- jj=4
-  do ii=3*jj-8,mmax-3
-     rhomod(ii,jj)=(-rhomod(ii-3,jj-1)+ 9.d0*rhomod(ii-2,jj-1)&
-&     -45.d0*rhomod(ii-1,jj-1)+45.d0*rhomod(ii+1,jj-1)&
-&     -9.d0*rhomod(ii+2,jj-1)+rhomod(ii+3,jj-1))&
-&     /(60.d0*al*rr(ii))
-  end do
+   jj=4
+   do ii=3*jj-8,mmax-3
+      rhomod(ii,jj)=(-rhomod(ii-3,jj-1)+ 9.d0*rhomod(ii-2,jj-1)&
+      &     -45.d0*rhomod(ii-1,jj-1)+45.d0*rhomod(ii+1,jj-1)&
+      &     -9.d0*rhomod(ii+2,jj-1)+rhomod(ii+3,jj-1))&
+      &     /(60.d0*al*rr(ii))
+   end do
 
 !set up a mesh on which 3rd derivative will have a stable
- drint=0.95d0*drint
- rtst=0.5d0*drint
- rtst=0.5d0*drint
- do jj=1,4
-   do ii=1,ircross
-     if(rr(ii)>rtst) then
-       rint(4+jj)=rr(ii)
-       rint(5-jj)=-rr(ii)
-       fint(4+jj)=rhomod(ii,4)
-       fint(5-jj)=-rhomod(ii,4)
-       iint=ii
-       rtst=rr(ii)+drint
-       exit
-     end if
+   drint=0.95d0*drint
+   rtst=0.5d0*drint
+   rtst=0.5d0*drint
+   do jj=1,4
+      do ii=1,ircross
+         if(rr(ii)>rtst) then
+            rint(4+jj)=rr(ii)
+            rint(5-jj)=-rr(ii)
+            fint(4+jj)=rhomod(ii,4)
+            fint(5-jj)=-rhomod(ii,4)
+            iint=ii
+            rtst=rr(ii)+drint
+            exit
+         end if
+      end do
    end do
- end do
 
- call dpnint(rint,fint,8,rr,rhomod(1,4),iint-1)
+   call dpnint(rint,fint,8,rr,rhomod(1,4),iint-1)
 
- jj=5
-  do ii=3*jj-8,mmax-3
-     rhomod(ii,jj)=(-rhomod(ii-3,jj-1)+ 9.d0*rhomod(ii-2,jj-1)&
-&     -45.d0*rhomod(ii-1,jj-1)+45.d0*rhomod(ii+1,jj-1)&
-&     -9.d0*rhomod(ii+2,jj-1)+rhomod(ii+3,jj-1))&
-&     /(60.d0*al*rr(ii))
-  end do
+   jj=5
+   do ii=3*jj-8,mmax-3
+      rhomod(ii,jj)=(-rhomod(ii-3,jj-1)+ 9.d0*rhomod(ii-2,jj-1)&
+      &     -45.d0*rhomod(ii-1,jj-1)+45.d0*rhomod(ii+1,jj-1)&
+      &     -9.d0*rhomod(ii+2,jj-1)+rhomod(ii+3,jj-1))&
+      &     /(60.d0*al*rr(ii))
+   end do
 
 !set up a mesh on which 4th derivative will have a stable
- drint=0.95d0*drint
- rtst=0.5d0*drint
- do jj=1,4
-   do ii=1,ircross
-     if(rr(ii)>rtst) then
-       rint(4+jj)=rr(ii)
-       rint(5-jj)=-rr(ii)
-       fint(4+jj)=rhomod(ii,5)
-       fint(5-jj)=rhomod(ii,5)
-       iint=ii
-       rtst=rr(ii)+drint
-       exit
-     end if
+   drint=0.95d0*drint
+   rtst=0.5d0*drint
+   do jj=1,4
+      do ii=1,ircross
+         if(rr(ii)>rtst) then
+            rint(4+jj)=rr(ii)
+            rint(5-jj)=-rr(ii)
+            fint(4+jj)=rhomod(ii,5)
+            fint(5-jj)=rhomod(ii,5)
+            iint=ii
+            rtst=rr(ii)+drint
+            exit
+         end if
+      end do
    end do
- end do
 
- call dpnint(rint,fint,8,rr,rhomod(1,5),iint-1)
+   call dpnint(rint,fint,8,rr,rhomod(1,5),iint-1)
 
- deallocate(vxcae,vxcpsp,vo)
- deallocate(dvxcae,dvxcps)
- deallocate(d2excae,d2excps)
+   deallocate(vxcae,vxcpsp,vo)
+   deallocate(dvxcae,dvxcps)
+   deallocate(d2excae,d2excps)
 
- return
+   return
 end subroutine modcore3

--- a/src/oncpsp_nr.f90
+++ b/src/oncpsp_nr.f90
@@ -2,21 +2,21 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- program oncvpsp
+program oncvpsp
 !
 ! Creates and tests optimized norm-conserving Vanderbilt or Kleinman-Bylander
 ! pseudopotentials based on D. R. Hamann, Phys. Rev. B 88, 085117 (2013)
@@ -32,431 +32,431 @@
 !
 !   Output format for ABINIT pspcod=8 and upf format for quantumespresso
 !
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !
- integer :: ii,ierr,iexc,iexct,ios,iprint,irps,it,icmod,lpopt
- integer :: jj,kk,ll,l1,lloc,lmax,lt,inline
- integer :: mch,mchf,mmax,n1,n2,nc,nlim,nlloc,nlmax,irpsh,nrl
- integer :: nv,irct,ncnf,nvt
- integer :: iprj,mxprj
- integer,allocatable :: npa(:,:)
+   integer :: ii,ierr,iexc,iexct,ios,iprint,irps,it,icmod,lpopt
+   integer :: jj,kk,ll,l1,lloc,lmax,lt,inline
+   integer :: mch,mchf,mmax,n1,n2,nc,nlim,nlloc,nlmax,irpsh,nrl
+   integer :: nv,irct,ncnf,nvt
+   integer :: iprj,mxprj
+   integer,allocatable :: npa(:,:)
 !
- integer :: dtime(8),na(30),la(30),np(6)
- integer :: nacnf(30,5),lacnf(30,5),nvcnf(5)
- integer :: nat(30),lat(30),indxr(30),indxe(30)
- integer :: irc(6),nodes(4)
- integer :: nproj(6),npx(6),lpx(6)
- integer :: ncon(6),nbas(6)
+   integer :: dtime(8),na(30),la(30),np(6)
+   integer :: nacnf(30,5),lacnf(30,5),nvcnf(5)
+   integer :: nat(30),lat(30),indxr(30),indxe(30)
+   integer :: irc(6),nodes(4)
+   integer :: nproj(6),npx(6),lpx(6)
+   integer :: ncon(6),nbas(6)
 
- real(dp) :: al,amesh,csc,csc1,deblt,depsh,depsht,drl,eeel
- real(dp) :: eeig,eexc
- real(dp) :: emax,epsh1,epsh1t,epsh2,epsh2t
- real(dp) :: et,etest,emin,sls
- real(dp) :: fcfact,rcfact,dvloc0
- real(dp) :: rr1,rcion,rciont,rcmax,rct,rlmax,rpkt
- real(dp) :: sf,zz,zion,zval,etot
- real(dp) :: xdummy
+   real(dp) :: al,amesh,csc,csc1,deblt,depsh,depsht,drl,eeel
+   real(dp) :: eeig,eexc
+   real(dp) :: emax,epsh1,epsh1t,epsh2,epsh2t
+   real(dp) :: et,etest,emin,sls
+   real(dp) :: fcfact,rcfact,dvloc0
+   real(dp) :: rr1,rcion,rciont,rcmax,rct,rlmax,rpkt
+   real(dp) :: sf,zz,zion,zval,etot
+   real(dp) :: xdummy
 !
- real(dp) :: cl(6),debl(6),ea(30),ep(6),fa(30),facnf(30,5)
- real(dp) :: fat(30,2)
- real(dp) :: fnp(6),fp(6)
- real(dp) :: qcut(6),qmsbf(6),rc(6),rc0(6)
- real(dp) :: rpk(30)
- real(dp) :: epx(6),fpx(6)
- real(dp) :: epstot
- real(dp), parameter :: eps=1.0d-8
+   real(dp) :: cl(6),debl(6),ea(30),ep(6),fa(30),facnf(30,5)
+   real(dp) :: fat(30,2)
+   real(dp) :: fnp(6),fp(6)
+   real(dp) :: qcut(6),qmsbf(6),rc(6),rc0(6)
+   real(dp) :: rpk(30)
+   real(dp) :: epx(6),fpx(6)
+   real(dp) :: epstot
+   real(dp), parameter :: eps=1.0d-8
 
- real(dp), allocatable :: evkb(:,:),cvgplt(:,:,:,:),qq(:,:)
- real(dp), allocatable :: rr(:)
- real(dp), allocatable :: rho(:),rhoc(:),rhot(:)
- real(dp), allocatable :: uu(:),up(:)
- real(dp), allocatable :: vp(:,:),vfull(:),vkb(:,:,:),pswf(:,:,:)
- real(dp), allocatable :: vwell(:)
- real(dp), allocatable :: vpuns(:,:)
- real(dp), allocatable :: vo(:),vxc(:)
- real(dp), allocatable :: rhomod(:,:),rhoae(:,:),rhops(:,:),rhotae(:)
- real(dp), allocatable :: uupsa(:,:) !pseudo-atomic orbitals array
- real(dp), allocatable :: epa(:,:),fpa(:,:)
- real(dp), allocatable :: uua(:,:),upa(:,:)
- real(dp), allocatable :: vr(:,:,:)
+   real(dp), allocatable :: evkb(:,:),cvgplt(:,:,:,:),qq(:,:)
+   real(dp), allocatable :: rr(:)
+   real(dp), allocatable :: rho(:),rhoc(:),rhot(:)
+   real(dp), allocatable :: uu(:),up(:)
+   real(dp), allocatable :: vp(:,:),vfull(:),vkb(:,:,:),pswf(:,:,:)
+   real(dp), allocatable :: vwell(:)
+   real(dp), allocatable :: vpuns(:,:)
+   real(dp), allocatable :: vo(:),vxc(:)
+   real(dp), allocatable :: rhomod(:,:),rhoae(:,:),rhops(:,:),rhotae(:)
+   real(dp), allocatable :: uupsa(:,:)  !pseudo-atomic orbitals array
+   real(dp), allocatable :: epa(:,:),fpa(:,:)
+   real(dp), allocatable :: uua(:,:),upa(:,:)
+   real(dp), allocatable :: vr(:,:,:)
 
- character*2 :: atsym
- character*4 :: psfile
+   character(len=2) :: atsym
+   character(len=4) :: psfile
 
- logical :: srel,cset
+   logical :: srel,cset
 
- write(6,'(a/a//)') &
-&      'ONCVPSP  (Optimized Norm-Conservinng Vanderbilt PSeudopotential)', &
-&      'scalar-relativistic version 4.0.1 03/01/2019'
+   write(6,'(a/a//)') &
+   &      'ONCVPSP  (Optimized Norm-Conservinng Vanderbilt PSeudopotential)', &
+   &      'scalar-relativistic version 4.0.1 03/01/2019'
 
- write(6,'(a/a/a//)') &
-&      'While it is not required under the terms of the GNU GPL, it is',&
-&      'suggested that you cite D. R. Hamann, Phys. Rev. B 88, 085117 (2013)', &
-&      'in any publication utilizing these pseudopotentials.'
+   write(6,'(a/a/a//)') &
+   &      'While it is not required under the terms of the GNU GPL, it is',&
+   &      'suggested that you cite D. R. Hamann, Phys. Rev. B 88, 085117 (2013)', &
+   &      'in any publication utilizing these pseudopotentials.'
 
- srel=.true.
+   srel=.true.
 !srel=.false.
 
- nproj(:)=0
- fcfact=0.0d0
- rcfact=0.0d0
- rc(:)=0.0d0
- ep(:)=0.0d0
+   nproj(:)=0
+   fcfact=0.0d0
+   rcfact=0.0d0
+   rc(:)=0.0d0
+   ep(:)=0.0d0
 
 ! read input data
- inline=0
+   inline=0
 
 ! atom and reference configuration
- call cmtskp(inline)
- read(5,*,iostat=ios) atsym,zz,nc,nv,iexc,psfile
- call read_error(ios,inline)
-
- call cmtskp(inline)
- do ii=1,nc+nv
-   read(5,*,iostat=ios) na(ii),la(ii),fa(ii)
+   call cmtskp(inline)
+   read(5,*,iostat=ios) atsym,zz,nc,nv,iexc,psfile
    call read_error(ios,inline)
- end do
+
+   call cmtskp(inline)
+   do ii=1,nc+nv
+      read(5,*,iostat=ios) na(ii),la(ii),fa(ii)
+      call read_error(ios,inline)
+   end do
 
 ! pseudopotential and optimization
- call cmtskp(inline)
- read(5,*,iostat=ios) lmax
- call read_error(ios,inline)
-
- call cmtskp(inline)
- do l1=1,lmax+1
-   read(5,*,iostat=ios) lt,rc(l1),ep(l1),ncon(l1),nbas(l1),qcut(l1)
-   if(lt/=l1-1) ios=999
+   call cmtskp(inline)
+   read(5,*,iostat=ios) lmax
    call read_error(ios,inline)
- end do
+
+   call cmtskp(inline)
+   do l1=1,lmax+1
+      read(5,*,iostat=ios) lt,rc(l1),ep(l1),ncon(l1),nbas(l1),qcut(l1)
+      if(lt/=l1-1) ios=999
+      call read_error(ios,inline)
+   end do
 
 ! local potential
- call cmtskp(inline)
- read(5,*, iostat=ios) lloc,lpopt,rc(5),dvloc0
- call read_error(ios,inline)
+   call cmtskp(inline)
+   read(5,*, iostat=ios) lloc,lpopt,rc(5),dvloc0
+   call read_error(ios,inline)
 
 ! Vanderbilt-Kleinman-Bylander projectors
- call cmtskp(inline)
- do l1=1,lmax+1
-   read(5,*,iostat=ios) lt,nproj(l1),debl(l1)
-   if(lt/=l1-1) ios=999
-   call read_error(ios,inline)
- end do
+   call cmtskp(inline)
+   do l1=1,lmax+1
+      read(5,*,iostat=ios) lt,nproj(l1),debl(l1)
+      if(lt/=l1-1) ios=999
+      call read_error(ios,inline)
+   end do
 
 ! model core charge
- call cmtskp(inline)
- read(5,*, iostat=ios) icmod, fcfact
- if(ios==0 .and. icmod==3) then
-  backspace(5)
-  read(5,*, iostat=ios) icmod, fcfact, rcfact
- end if
- call read_error(ios,inline)
+   call cmtskp(inline)
+   read(5,*, iostat=ios) icmod, fcfact
+   if(ios==0 .and. icmod==3) then
+      backspace(5)
+      read(5,*, iostat=ios) icmod, fcfact, rcfact
+   end if
+   call read_error(ios,inline)
 
 ! log derivative analysis
- call cmtskp(inline)
- read(5,*,iostat=ios) epsh1, epsh2, depsh
- call read_error(ios,inline)
+   call cmtskp(inline)
+   read(5,*,iostat=ios) epsh1, epsh2, depsh
+   call read_error(ios,inline)
 
 ! output grid
- call cmtskp(inline)
- read(5,*,iostat=ios) rlmax,drl
- call read_error(ios,inline)
+   call cmtskp(inline)
+   read(5,*,iostat=ios) rlmax,drl
+   call read_error(ios,inline)
 
 ! test configurations
- call cmtskp(inline)
- read(5,*,iostat=ios) ncnf
- call read_error(ios,inline)
-
- do jj=2,ncnf+1
    call cmtskp(inline)
-   read(5,*,iostat=ios) nvcnf(jj)
+   read(5,*,iostat=ios) ncnf
    call read_error(ios,inline)
-   do ii=nc+1,nc+nvcnf(jj)
-     call cmtskp(inline)
-     read(5,*,iostat=ios) nacnf(ii,jj),lacnf(ii,jj),facnf(ii,jj)
-     call read_error(ios,inline)
+
+   do jj=2,ncnf+1
+      call cmtskp(inline)
+      read(5,*,iostat=ios) nvcnf(jj)
+      call read_error(ios,inline)
+      do ii=nc+1,nc+nvcnf(jj)
+         call cmtskp(inline)
+         read(5,*,iostat=ios) nacnf(ii,jj),lacnf(ii,jj),facnf(ii,jj)
+         call read_error(ios,inline)
+      end do
    end do
- end do
 
 ! end of reading input data
 
- nvcnf(1)=nv
- do ii=1,nc+nv
-   nacnf(ii,1)=na(ii)
-   lacnf(ii,1)=la(ii)
-   facnf(ii,1)=fa(ii)
- end do
-
- do jj=2,ncnf+1
-   do ii=1,nc
-     nacnf(ii,jj)=na(ii)
-     lacnf(ii,jj)=la(ii)
-     facnf(ii,jj)=fa(ii)
+   nvcnf(1)=nv
+   do ii=1,nc+nv
+      nacnf(ii,1)=na(ii)
+      lacnf(ii,1)=la(ii)
+      facnf(ii,1)=fa(ii)
    end do
- end do
 
- if(icmod==0) then
-   fcfact=0.0d0
- end if
+   do jj=2,ncnf+1
+      do ii=1,nc
+         nacnf(ii,jj)=na(ii)
+         lacnf(ii,jj)=la(ii)
+         facnf(ii,jj)=fa(ii)
+      end do
+   end do
 
- call check_data(atsym,zz,fcfact,rcfact,epsh1,epsh2,depsh,rlmax,drl,fa,facnf, &
-&                rc,ep,qcut,debl,nc,nv,iexc,lmax,lloc,lpopt,icmod, &
-&                ncnf,na,la,nvcnf,nacnf,lacnf,ncon,nbas,nproj,psfile)
+   if(icmod==0) then
+      fcfact=0.0d0
+   end if
 
- nrl=int((rlmax/drl)-0.5d0)+1
+   call check_data(atsym,zz,fcfact,rcfact,epsh1,epsh2,depsh,rlmax,drl,fa,facnf, &
+   &                rc,ep,qcut,debl,nc,nv,iexc,lmax,lloc,lpopt,icmod, &
+   &                ncnf,na,la,nvcnf,nacnf,lacnf,ncon,nbas,nproj,psfile)
+
+   nrl=int((rlmax/drl)-0.5d0)+1
 
 !PWSCF wants an even number of mesh pointe
 !if(trim(psfile)=='upf') then
-  if(mod(nrl,2)/=0) nrl=nrl+1
+   if(mod(nrl,2)/=0) nrl=nrl+1
 !end if
 
 !amesh=1.012d0
- amesh=1.006d0
+   amesh=1.006d0
 !amesh=1.003d0
 !amesh=1.0015d0
 
- mxprj=5
+   mxprj=5
 
- al=dlog(amesh)
- rr1=0.0005d0/zz
- rr1=dmin1(rr1,0.0005d0/10)
- mmax=dlog(45.0d0 /rr1)/al
+   al=dlog(amesh)
+   rr1=0.0005d0/zz
+   rr1=dmin1(rr1,0.0005d0/10)
+   mmax=dlog(45.0d0 /rr1)/al
 
 !calculate zion for output
- zion=zz
- do ii=1,nc
-  zion=zion-fa(ii)
- end do
+   zion=zz
+   do ii=1,nc
+      zion=zion-fa(ii)
+   end do
 
 
- allocate(rr(mmax))
- allocate(rho(mmax),rhoc(mmax),rhot(mmax))
- allocate(uu(mmax),up(mmax),uupsa(mmax,30))
- allocate(evkb(mxprj,4), cvgplt(2,7,mxprj,4),qq(mxprj,mxprj))
- allocate(vp(mmax,5),vfull(mmax),vkb(mmax,mxprj,4),pswf(mmax,mxprj,4))
- allocate(vwell(mmax))
- allocate(vpuns(mmax,5))
- allocate(vo(mmax),vxc(mmax))
- allocate(rhoae(mmax,nv),rhops(mmax,nv),rhotae(mmax))
- allocate(npa(mxprj,6))
- allocate(epa(mxprj,6),fpa(mxprj,6))
- allocate(uua(mmax,mxprj),upa(mmax,mxprj))
- allocate(vr(mmax,mxprj,6))
+   allocate(rr(mmax))
+   allocate(rho(mmax),rhoc(mmax),rhot(mmax))
+   allocate(uu(mmax),up(mmax),uupsa(mmax,30))
+   allocate(evkb(mxprj,4), cvgplt(2,7,mxprj,4),qq(mxprj,mxprj))
+   allocate(vp(mmax,5),vfull(mmax),vkb(mmax,mxprj,4),pswf(mmax,mxprj,4))
+   allocate(vwell(mmax))
+   allocate(vpuns(mmax,5))
+   allocate(vo(mmax),vxc(mmax))
+   allocate(rhoae(mmax,nv),rhops(mmax,nv),rhotae(mmax))
+   allocate(npa(mxprj,6))
+   allocate(epa(mxprj,6),fpa(mxprj,6))
+   allocate(uua(mmax,mxprj),upa(mmax,mxprj))
+   allocate(vr(mmax,mxprj,6))
 
- vr(:,:,:)=0.0d0
- vp(:,:)=0.0d0
- vkb(:,:,:)=0.0d0
- epa(:,:)=0.0d0
+   vr(:,:,:)=0.0d0
+   vp(:,:)=0.0d0
+   vkb(:,:,:)=0.0d0
+   epa(:,:)=0.0d0
 
- do ii=1,mmax
-  rr(ii)=rr1*exp(al*(ii-1))
- end do
+   do ii=1,mmax
+      rr(ii)=rr1*exp(al*(ii-1))
+   end do
 
 !
 ! full potential atom solution
 !
    call sratom(na,la,ea,fa,rpk,nc,nc+nv,it,rhoc,rho, &
-&              rr,vfull,zz,mmax,iexc,etot,ierr,srel)
+   &              rr,vfull,zz,mmax,iexc,etot,ierr,srel)
 !
 !
 
 ! Drop digits beyond 5 decimals for input rcs before making any use of them
- do l1=1,max(lmax+1,lloc+1)
-    jj=int(rc(l1)*10.0d5)
-    rc(l1)=jj/10.0d5
- end do
+   do l1=1,max(lmax+1,lloc+1)
+      jj=int(rc(l1)*10.0d5)
+      rc(l1)=jj/10.0d5
+   end do
 
- rcmax=0.0d0
- do l1=1,lmax+1
-   rcmax=dmax1(rcmax,rc(l1))
- end do
- do l1=1,lmax+1
-   if(rc(l1)==0.0d0) then
-     rc(l1)=rcmax
-   end if
- end do
+   rcmax=0.0d0
+   do l1=1,lmax+1
+      rcmax=dmax1(rcmax,rc(l1))
+   end do
+   do l1=1,lmax+1
+      if(rc(l1)==0.0d0) then
+         rc(l1)=rcmax
+      end if
+   end do
 
- nproj(lloc+1)=0
- rc0(:)=rc(:)
+   nproj(lloc+1)=0
+   rc0(:)=rc(:)
 
 ! output printing (echos input data, with all-electron eigenvalues added)
 
- write(6,'(a)') '# ATOM AND REFERENCE CONFIGURATION'
- write(6,'(a)') '# atsym  z   nc   nv     iexc    psfile'
- write(6,'(a,a,f6.2,2i5,i8,2a)') '  ',trim(atsym),zz,nc,nv,iexc, &
-&      '      ',psfile
- write(6,'(a/a)') '#','#   n    l    f        energy (Ha)'
- do ii=1,nc+nv
-   write(6,'(2i5,f8.2,1pe18.7)') na(ii),la(ii),fa(ii),ea(ii)
- end do
-
- write(6,'(a/a/a)') '#','# PSEUDOPOTENTIAL AND OPTIMIZATION','# lmax'
- write(6,'(i5)')  lmax
- write(6,'(a/a)') '#','#   l,   rc,      ep,       ncon, nbas, qcut'
- do l1=1,lmax+1
-   write(6,'(i5,2f10.5,2i5,f10.5)') l1-1,rc(l1),ep(l1),ncon(l1),&
-&        nbas(l1),qcut(l1)
- end do
-
- write(6,'(a/a/a,a)') '#','# LOCAL POTENTIAL','# lloc, lpopt,  rc(5),', &
-&      '   dvloc0'
- write(6,'(2i5,f10.5,a,f10.5)') lloc,lpopt,rc(5),'   ',dvloc0
-
- write(6,'(a/a/a)') '#','# VANDERBILT-KLEINMAN-BYLANDER PROJECTORs', &
-&      '# l, nproj, debl'
- do l1=1,lmax+1
-   write(6,'(2i5,f10.5)') l1-1,nproj(l1),debl(l1)
- end do
-
- write(6,'(a/a/a)') '#','# MODEL CORE CHARGE', &
-&      '# icmod, fcfact, rcfact'
- write(6,'(i5,2f10.5)') icmod,fcfact,rcfact
-
- write(6,'(a/a/a)') '#','# LOG DERIVATIVE ANALYSIS', &
-&      '# epsh1, epsh2, depsh'
- write(6,'(3f8.2)') epsh1,epsh2,depsh
-
- write(6,'(a/a/a)') '#','# OUTPUT GRID','# rlmax, drl'
- write(6,'(2f8.4)') rlmax,drl
-
- write(6,'(a/a/a)') '#','# TEST CONFIGURATIONS','# ncnf'
- write(6,'(i5)') ncnf
- write(6,'(a/a)') '# nvcnf','#   n    l    f'
- do jj=2,ncnf+1
-   write(6,'(i5)') nvcnf(jj)
-   do ii=nc+1,nc+nvcnf(jj)
-     write(6,'(2i5,f8.2)') nacnf(ii,jj),lacnf(ii,jj),facnf(ii,jj)
+   write(6,'(a)') '# ATOM AND REFERENCE CONFIGURATION'
+   write(6,'(a)') '# atsym  z   nc   nv     iexc    psfile'
+   write(6,'(a,a,f6.2,2i5,i8,2a)') '  ',trim(atsym),zz,nc,nv,iexc, &
+   &      '      ',psfile
+   write(6,'(a/a)') '#','#   n    l    f        energy (Ha)'
+   do ii=1,nc+nv
+      write(6,'(2i5,f8.2,1pe18.7)') na(ii),la(ii),fa(ii),ea(ii)
    end do
-   write(6,'(a)') '#'
- end do
 
- write(6,'(//a)') 'Reference configufation results'
- write(6,'(a,i6)') '  iterations',it
- if(it .ge. 100) then
-  write(6,'(a)') 'oncvpsp: ERROR all-electron reference atom not converged'
-  stop
- end if
- write(6,'(a,1p,d18.8)') '  all-electron total energy (Ha)',etot
-  
-!find log mesh point nearest input rc
- rcmax=0.0d0
- irc(:)=0
- do l1=1,max(lmax+1,lloc+1)
-  rct=rc(l1)
-  irc(l1)=0
-  do ii=2,mmax
-   if(rr(ii)>rct) then
-    irc(l1)=ii
-    rc(l1)=rr(ii)
-    exit
+   write(6,'(a/a/a)') '#','# PSEUDOPOTENTIAL AND OPTIMIZATION','# lmax'
+   write(6,'(i5)')  lmax
+   write(6,'(a/a)') '#','#   l,   rc,      ep,       ncon, nbas, qcut'
+   do l1=1,lmax+1
+      write(6,'(i5,2f10.5,2i5,f10.5)') l1-1,rc(l1),ep(l1),ncon(l1),&
+      &        nbas(l1),qcut(l1)
+   end do
+
+   write(6,'(a/a/a,a)') '#','# LOCAL POTENTIAL','# lloc, lpopt,  rc(5),', &
+   &      '   dvloc0'
+   write(6,'(2i5,f10.5,a,f10.5)') lloc,lpopt,rc(5),'   ',dvloc0
+
+   write(6,'(a/a/a)') '#','# VANDERBILT-KLEINMAN-BYLANDER PROJECTORs', &
+   &      '# l, nproj, debl'
+   do l1=1,lmax+1
+      write(6,'(2i5,f10.5)') l1-1,nproj(l1),debl(l1)
+   end do
+
+   write(6,'(a/a/a)') '#','# MODEL CORE CHARGE', &
+   &      '# icmod, fcfact, rcfact'
+   write(6,'(i5,2f10.5)') icmod,fcfact,rcfact
+
+   write(6,'(a/a/a)') '#','# LOG DERIVATIVE ANALYSIS', &
+   &      '# epsh1, epsh2, depsh'
+   write(6,'(3f8.2)') epsh1,epsh2,depsh
+
+   write(6,'(a/a/a)') '#','# OUTPUT GRID','# rlmax, drl'
+   write(6,'(2f8.4)') rlmax,drl
+
+   write(6,'(a/a/a)') '#','# TEST CONFIGURATIONS','# ncnf'
+   write(6,'(i5)') ncnf
+   write(6,'(a/a)') '# nvcnf','#   n    l    f'
+   do jj=2,ncnf+1
+      write(6,'(i5)') nvcnf(jj)
+      do ii=nc+1,nc+nvcnf(jj)
+         write(6,'(2i5,f8.2)') nacnf(ii,jj),lacnf(ii,jj),facnf(ii,jj)
+      end do
+      write(6,'(a)') '#'
+   end do
+
+   write(6,'(//a)') 'Reference configufation results'
+   write(6,'(a,i6)') '  iterations',it
+   if(it >= 100) then
+      write(6,'(a)') 'oncvpsp: ERROR all-electron reference atom not converged'
+      stop
    end if
-  end do
-  rcmax=dmax1(rcmax,rc(l1))
- end do
+   write(6,'(a,1p,d18.8)') '  all-electron total energy (Ha)',etot
+
+!find log mesh point nearest input rc
+   rcmax=0.0d0
+   irc(:)=0
+   do l1=1,max(lmax+1,lloc+1)
+      rct=rc(l1)
+      irc(l1)=0
+      do ii=2,mmax
+         if(rr(ii)>rct) then
+            irc(l1)=ii
+            rc(l1)=rr(ii)
+            exit
+         end if
+      end do
+      rcmax=dmax1(rcmax,rc(l1))
+   end do
 
 !
- cvgplt(:,:,:,:)=0.0d0
+   cvgplt(:,:,:,:)=0.0d0
 !
 ! loop to construct pseudopotentials for all angular momenta
 !
- write(6,'(/a/a)') 'Begin loop to  construct optimized pseudo wave functions',&
-&      'and semi-local pseudopoentials for all angular momenta'
+   write(6,'(/a/a)') 'Begin loop to  construct optimized pseudo wave functions',&
+   &      'and semi-local pseudopoentials for all angular momenta'
 
 !temporarily set this to 1 so that the pseudo wave function needed for the
 !local potential will be generated.  Reset after run_vkb.
- nproj(lloc+1)=1
- do l1=1,lmax+1
-   ll=l1-1
-   uu(:)=0.0d0; qq(:,:)=0.0d0
-   iprj=0
+   nproj(lloc+1)=1
+   do l1=1,lmax+1
+      ll=l1-1
+      uu(:)=0.0d0; qq(:,:)=0.0d0
+      iprj=0
 
 !get principal quantum number for the highest core state for this l
-   npa(1,l1)=l1
-   do kk=1,nc
-     if(la(kk)==l1-1) npa(1,l1)=na(kk)+1
-   end do !kk
+      npa(1,l1)=l1
+      do kk=1,nc
+         if(la(kk)==l1-1) npa(1,l1)=na(kk)+1
+      end do  !kk
 
 !get all-electron bound states for projectors
-   if(nv/=0) then
-     do kk=nc+1,nc+nv
-       if(la(kk)==l1-1) then
-         iprj=iprj+1
-         et=ea(kk)
-         call lschfb(na(kk),la(kk),ierr,et, &
-&                      rr,vfull,uu,up,zz,mmax,mch,srel)
-         if(ierr /= 0) then
-           write(6,'(/a,3i4)') 'oncvpsp-387: lschfb convergence ERROR n,l,iter=', &
-&           na(ii),la(ii),it
-           stop
-         end if
-         epa(iprj,l1)=ea(kk)
-         npa(iprj,l1)=na(kk)
-         uua(:,iprj)=uu(:)
-         upa(:,iprj)=up(:)
-       end if !la(kk)==l1-1
-       if(iprj==nproj(l1)) exit
-     end do !kk
-   end if !nv/=0
+      if(nv/=0) then
+         do kk=nc+1,nc+nv
+            if(la(kk)==l1-1) then
+               iprj=iprj+1
+               et=ea(kk)
+               call lschfb(na(kk),la(kk),ierr,et, &
+               &                      rr,vfull,uu,up,zz,mmax,mch,srel)
+               if(ierr /= 0) then
+                  write(6,'(/a,3i4)') 'oncvpsp-387: lschfb convergence ERROR n,l,iter=', &
+                  &           na(ii),la(ii),it
+                  stop
+               end if
+               epa(iprj,l1)=ea(kk)
+               npa(iprj,l1)=na(kk)
+               uua(:,iprj)=uu(:)
+               upa(:,iprj)=up(:)
+            end if  !la(kk)==l1-1
+            if(iprj==nproj(l1)) exit
+         end do  !kk
+      end if  !nv/=0
 
 !get all-electron well states for projectors
 !if there were no valence states, use ep from input data for 1st well state
 !otherwise shift up by input debl
-   if(iprj==0) epa(1,l1)=ep(l1)
-   if(iprj<nproj(l1))then
-     do kk=1,nproj(l1)-iprj
-       iprj=iprj+1
-       if(iprj>1 .and. debl(l1)<=0.0d0) then
-         write(6,'(a,f8.3,a/a)') 'oncvpsp: ERROR debl =',debl, 'for l=', &
-&              ' ERROR not allowed with 2 or more scattering states', &
-&              'program will stop'
-         stop
-       end if
-       if(iprj>1) then
-         epa(iprj,l1)=epa(iprj-1,l1)+debl(l1)
-         npa(iprj,l1)=npa(iprj-1,l1)+1
-       end if
+      if(iprj==0) epa(1,l1)=ep(l1)
+      if(iprj<nproj(l1))then
+         do kk=1,nproj(l1)-iprj
+            iprj=iprj+1
+            if(iprj>1 .and. debl(l1)<=0.0d0) then
+               write(6,'(a,f8.3,a/a)') 'oncvpsp: ERROR debl =',debl, 'for l=', &
+               &              ' ERROR not allowed with 2 or more scattering states', &
+               &              'program will stop'
+               stop
+            end if
+            if(iprj>1) then
+               epa(iprj,l1)=epa(iprj-1,l1)+debl(l1)
+               npa(iprj,l1)=npa(iprj-1,l1)+1
+            end if
 
-       call wellstate(npa(iprj,l1),ll,irc(l1),epa(iprj,l1),rr, &
-&                     vfull,uu,up,zz,mmax,mch,srel)
-       uua(:,iprj)=uu(:)
-       upa(:,iprj)=up(:)
-     end do !kk
-   end if !iprj<nproj(l1)
+            call wellstate(npa(iprj,l1),ll,irc(l1),epa(iprj,l1),rr, &
+            &                     vfull,uu,up,zz,mmax,mch,srel)
+            uua(:,iprj)=uu(:)
+            upa(:,iprj)=up(:)
+         end do  !kk
+      end if  !iprj<nproj(l1)
 
-   do iprj=1,nproj(l1)
+      do iprj=1,nproj(l1)
 
 !calculate relativistic correction to potential to force projectors to 0 at rc
-     call vrel(ll,epa(iprj,l1),rr,vfull,vr(1,iprj,l1),uua(1,iprj),upa(1,iprj), &
-&              zz,mmax,irc(l1),srel)
+         call vrel(ll,epa(iprj,l1),rr,vfull,vr(1,iprj,l1),uua(1,iprj),upa(1,iprj), &
+         &              zz,mmax,irc(l1),srel)
 
-   end do
+      end do
 
 !get all-electron overlap matrix
-   do jj=1,nproj(l1)
-     do ii=1,jj
-       call fpovlp(uua(1,ii),uua(1,jj),irc(l1),ll,zz,qq(ii,jj),rr,srel)
-       qq(jj,ii)=qq(ii,jj)
-     end do
-   end do
+      do jj=1,nproj(l1)
+         do ii=1,jj
+            call fpovlp(uua(1,ii),uua(1,jj),irc(l1),ll,zz,qq(ii,jj),rr,srel)
+            qq(jj,ii)=qq(ii,jj)
+         end do
+      end do
 
-   call run_optimize(epa(1,l1),ll,mmax,mxprj,rr,uua,qq, &
-&                    irc(l1),qcut(l1),qmsbf(l1),ncon(l1),nbas(l1),nproj(l1), &
-&                    pswf(1,1,l1),vp(1,l1),vkb(1,1,l1),vfull,cvgplt(1,1,1,l1))
+      call run_optimize(epa(1,l1),ll,mmax,mxprj,rr,uua,qq, &
+      &                    irc(l1),qcut(l1),qmsbf(l1),ncon(l1),nbas(l1),nproj(l1), &
+      &                    pswf(1,1,l1),vp(1,l1),vkb(1,1,l1),vfull,cvgplt(1,1,1,l1))
 
- end do !l1
+   end do  !l1
 
 ! construct Vanderbilt / Kleinman-Bylander projectors
 
- write(6,'(/a,a)') 'Construct Vanderbilt / Kleinmman-Bylander projectors'
+   write(6,'(/a,a)') 'Construct Vanderbilt / Kleinmman-Bylander projectors'
 
- call run_vkb(lmax,lloc,lpopt,dvloc0,irc,nproj,rr,mmax,mxprj,pswf,vfull,vp, &
-&             evkb,vkb,nlim,vr)
+   call run_vkb(lmax,lloc,lpopt,dvloc0,irc,nproj,rr,mmax,mxprj,pswf,vfull,vp, &
+   &             evkb,vkb,nlim,vr)
 
 !restore this to its proper value
- nproj(lloc+1)=0
+   nproj(lloc+1)=0
 
- deallocate(uua,upa)
+   deallocate(uua,upa)
 
 ! accumulate charge and eigenvalues
 ! pseudo wave functions are calculated with VKB projectors for
@@ -465,195 +465,195 @@
 ! charge densities
 
 ! null charge and eigenvalue accumulators
- uupsa(:,:)=0.0d0
- eeig=0.0d0
- zval=0.0d0
- rho(:)=0.0d0
- nodes(:)=0
- rhotae(:)=0.0d0
- irps=0
- do kk=1,nv
+   uupsa(:,:)=0.0d0
+   eeig=0.0d0
+   zval=0.0d0
+   rho(:)=0.0d0
+   nodes(:)=0
+   rhotae(:)=0.0d0
+   irps=0
+   do kk=1,nv
 
-   et=ea(nc+kk)
-   ll=la(nc+kk)
-   l1=ll+1
-   call lschfb(na(nc+kk),ll,ierr,et, &
-&                rr,vfull,uu,up,zz,mmax,mch,srel)
-   if(ierr /= 0) then
-     write(6,'(/a,3i4)') 'oncvpsp-461: lschfb convergence ERROR n,l,iter=', &
-&     na(ii),la(ii),it
-     stop
-   end if
+      et=ea(nc+kk)
+      ll=la(nc+kk)
+      l1=ll+1
+      call lschfb(na(nc+kk),ll,ierr,et, &
+      &                rr,vfull,uu,up,zz,mmax,mch,srel)
+      if(ierr /= 0) then
+         write(6,'(/a,3i4)') 'oncvpsp-461: lschfb convergence ERROR n,l,iter=', &
+         &     na(ii),la(ii),it
+         stop
+      end if
 
-   rhoae(:,kk)=(uu(:)/rr(:))**2
+      rhoae(:,kk)=(uu(:)/rr(:))**2
 
-   rhotae(:)=rhotae(:) + fa(nc+kk)*rhoae(:,kk)
+      rhotae(:)=rhotae(:) + fa(nc+kk)*rhoae(:,kk)
 
-   emax=0.75d0*et
-   emin=1.25d0*et
+      emax=0.75d0*et
+      emin=1.25d0*et
 
-   call lschvkbb(ll+nodes(l1)+1,ll,nproj(l1),ierr,et,emin,emax, &
-&                rr,vp(1,lloc+1),vkb(1,1,l1),evkb(1,l1), &
-&                uu,up,mmax,mch)
+      call lschvkbb(ll+nodes(l1)+1,ll,nproj(l1),ierr,et,emin,emax, &
+      &                rr,vp(1,lloc+1),vkb(1,1,l1),evkb(1,l1), &
+      &                uu,up,mmax,mch)
 
-   if(ierr/=0) then 
-     write(6,'(a,3i4)') 'oncvpsp: lschvkbb ERROR',ll+nodes(l1)+1,ll,ierr
-     flush(6)
-     stop
-   end if
+      if(ierr/=0) then
+         write(6,'(a,3i4)') 'oncvpsp: lschvkbb ERROR',ll+nodes(l1)+1,ll,ierr
+         flush(6)
+         stop
+      end if
 
 ! save valence pseudo wave functions for upfout
-   uupsa(:,kk)=uu(:)
+      uupsa(:,kk)=uu(:)
 
-   rhops(:,kk)=(uu(:)/rr(:))**2
-   rho(:)=rho(:)+fa(nc+kk)*rhops(:,kk)
-   eeig=eeig+fa(nc+kk)*et
+      rhops(:,kk)=(uu(:)/rr(:))**2
+      rho(:)=rho(:)+fa(nc+kk)*rhops(:,kk)
+      eeig=eeig+fa(nc+kk)*et
 
-   zval=zval+fa(nc+kk)
-   nodes(l1)=nodes(l1)+1
-   irps=max(irps,irc(l1))
- end do !kk
+      zval=zval+fa(nc+kk)
+      nodes(l1)=nodes(l1)+1
+      irps=max(irps,irc(l1))
+   end do  !kk
 
- allocate(rhomod(mmax,5))
+   allocate(rhomod(mmax,5))
 
- rhomod(:,:)=0.0d0
+   rhomod(:,:)=0.0d0
 
 ! construct model core charge based on monotonic polynomial fit
 ! or Teter function fit
 
- if(icmod==1) then
-   call modcore(icmod,rhops,rho,rhoc,rhoae,rhotae,rhomod, &
-&               fcfact,rcfact,irps,mmax,rr,nc,nv,la,zion,iexc)
+   if(icmod==1) then
+      call modcore(icmod,rhops,rho,rhoc,rhoae,rhotae,rhomod, &
+      &               fcfact,rcfact,irps,mmax,rr,nc,nv,la,zion,iexc)
 
- else if(icmod==2) then
-   call modcore2(icmod,rhops,rho,rhoc,rhoae,rhotae,rhomod, &
-&               fcfact,rcfact,irps,mmax,rr,nc,nv,la,zion,iexc)
+   else if(icmod==2) then
+      call modcore2(icmod,rhops,rho,rhoc,rhoae,rhotae,rhomod, &
+      &               fcfact,rcfact,irps,mmax,rr,nc,nv,la,zion,iexc)
 
- else if(icmod>=3) then
-   call modcore3(icmod,rhops,rho,rhoc,rhoae,rhotae,rhomod, &
-&               fcfact,rcfact,irps,mmax,rr,nc,nv,la,zion,iexc)
+   else if(icmod>=3) then
+      call modcore3(icmod,rhops,rho,rhoc,rhoae,rhotae,rhomod, &
+      &               fcfact,rcfact,irps,mmax,rr,nc,nv,la,zion,iexc)
 
- end if
+   end if
 
 ! screening potential for pseudocharge
 
- call vout(1,rho,rhomod(1,1),vo,vxc,zval,eeel,eexc,rr,mmax,iexc)
+   call vout(1,rho,rhomod(1,1),vo,vxc,zval,eeel,eexc,rr,mmax,iexc)
 
 ! total energy output
 
- epstot= eeig + eexc - 0.5d0*eeel
- write(6,'(/a,f12.6/)') 'Pseudoatom total energy', epstot
+   epstot= eeig + eexc - 0.5d0*eeel
+   write(6,'(/a,f12.6/)') 'Pseudoatom total energy', epstot
 
- call run_diag(lmax,npa,epa,lloc,irc, &
-&                    vkb,evkb,nproj,rr,vfull,vp,zz,mmax,mxprj,srel)
+   call run_diag(lmax,npa,epa,lloc,irc, &
+   &                    vkb,evkb,nproj,rr,vfull,vp,zz,mmax,mxprj,srel)
 
- call run_ghosts(lmax,la,ea,nc,nv,lloc,irc,qmsbf, &
-&                    vkb,evkb,nproj,rr,vp,mmax,mxprj)
+   call run_ghosts(lmax,la,ea,nc,nv,lloc,irc,qmsbf, &
+   &                    vkb,evkb,nproj,rr,vp,mmax,mxprj)
 
 ! unscreen semi-local potentials
 
- do l1=1,max(lmax+1,lloc+1)
-   vpuns(:,l1)=vp(:,l1)-vo(:)
- end do
+   do l1=1,max(lmax+1,lloc+1)
+      vpuns(:,l1)=vp(:,l1)-vo(:)
+   end do
 
 !fix unscreening error due to greater range of all-electron charge
- do ii=mmax,1,-1
-   if(rho(ii)==0.0d0) then 
-     do l1=1,max(lmax+1,lloc+1)
-       vpuns(ii,l1)=-zion/rr(ii)
-     end do
-   else
-     exit
-   end if
- end do
+   do ii=mmax,1,-1
+      if(rho(ii)==0.0d0) then
+         do l1=1,max(lmax+1,lloc+1)
+            vpuns(ii,l1)=-zion/rr(ii)
+         end do
+      else
+         exit
+      end if
+   end do
 
 
 ! loop over reference plus test atom configurations
 !if(.false.) then
 
 !ncnf=0
- rhot(:)=rho(:)
- do jj=1,ncnf+1
+   rhot(:)=rho(:)
+   do jj=1,ncnf+1
 
-   write(6,'(/a,i2)') 'Test configuration',jj-1
+      write(6,'(/a,i2)') 'Test configuration',jj-1
 
 ! charge density is initialized to that of reference configuration
 
-   rhot(:)=rho(:)
+      rhot(:)=rho(:)
 
-   call run_config(jj,nacnf,lacnf,facnf,nc,nvcnf,rhot,rhomod,rr,zz, &
-&                  rcmax,mmax,mxprj,iexc,ea,etot,epstot,nproj,vpuns, &
-&                  lloc,vkb,evkb,srel)
+      call run_config(jj,nacnf,lacnf,facnf,nc,nvcnf,rhot,rhomod,rr,zz, &
+      &                  rcmax,mmax,mxprj,iexc,ea,etot,epstot,nproj,vpuns, &
+      &                  lloc,vkb,evkb,srel)
 
- end do !jj
+   end do  !jj
 
- call run_plot(lmax,npa,epa,lloc,irc, &
-&                    vkb,evkb,nproj,rr,vfull,vp,vpuns,zz,mmax,mxprj,drl,nrl, &
-&                    rho,rhoc,rhomod,srel,cvgplt)
-
-
-
- call run_phsft(lmax,lloc,nproj,epa,epsh1,epsh2,depsh,vkb,evkb, &
-&               rr,vfull,vp,zz,mmax,mxprj,irc,srel)
- 
- call gnu_script(epa,evkb,lmax,lloc,mxprj,nproj)
-
- if(trim(psfile)=='psp8' .or. trim(psfile)=='both') then
+   call run_plot(lmax,npa,epa,lloc,irc, &
+   &                    vkb,evkb,nproj,rr,vfull,vp,vpuns,zz,mmax,mxprj,drl,nrl, &
+   &                    rho,rhoc,rhomod,srel,cvgplt)
 
 
-  call linout(lmax,lloc,rc,vkb,evkb,nproj,rr,vpuns,rho,rhomod, &
-&             rhotae,rhoc,zz,zion,mmax,mxprj,iexc,icmod,nrl,drl,atsym, &
-&             na,la,ncon,nbas,nvcnf,nacnf,lacnf,nc,nv,lpopt,ncnf, &
-&             fa,rc0,ep,qcut,debl,facnf,dvloc0,fcfact,rcfact, &
-&             epsh1,epsh2,depsh,rlmax,psfile)
- end if
 
- if(trim(psfile)=='upf' .or. trim(psfile)=='both') then
-  call upfout(lmax,lloc,rc,vkb,evkb,nproj,rr,vpuns,rho,rhomod, &
-&             zz,zion,mmax,mxprj,iexc,icmod,nrl,drl,atsym,epstot, &
-&             na,la,ncon,nbas,nvcnf,nacnf,lacnf,nc,nv,lpopt,ncnf, &
-&             fa,rc0,ep,qcut,debl,facnf,dvloc0,fcfact,rcfact, &
-&             epsh1,epsh2,depsh,rlmax,psfile,uupsa,ea)
- end if
+   call run_phsft(lmax,lloc,nproj,epa,epsh1,epsh2,depsh,vkb,evkb, &
+   &               rr,vfull,vp,zz,mmax,mxprj,irc,srel)
 
- stop
- end program oncvpsp
+   call gnu_script(epa,evkb,lmax,lloc,mxprj,nproj)
+
+   if(trim(psfile)=='psp8' .or. trim(psfile)=='both') then
 
 
- subroutine cmtskp(inline)
+      call linout(lmax,lloc,rc,vkb,evkb,nproj,rr,vpuns,rho,rhomod, &
+      &             rhotae,rhoc,zz,zion,mmax,mxprj,iexc,icmod,nrl,drl,atsym, &
+      &             na,la,ncon,nbas,nvcnf,nacnf,lacnf,nc,nv,lpopt,ncnf, &
+      &             fa,rc0,ep,qcut,debl,facnf,dvloc0,fcfact,rcfact, &
+      &             epsh1,epsh2,depsh,rlmax,psfile)
+   end if
+
+   if(trim(psfile)=='upf' .or. trim(psfile)=='both') then
+      call upfout(lmax,lloc,rc,vkb,evkb,nproj,rr,vpuns,rho,rhomod, &
+      &             zz,zion,mmax,mxprj,iexc,icmod,nrl,drl,atsym,epstot, &
+      &             na,la,ncon,nbas,nvcnf,nacnf,lacnf,nc,nv,lpopt,ncnf, &
+      &             fa,rc0,ep,qcut,debl,facnf,dvloc0,fcfact,rcfact, &
+      &             epsh1,epsh2,depsh,rlmax,psfile,uupsa,ea)
+   end if
+
+   stop
+end program oncvpsp
+
+
+subroutine cmtskp(inline)
 ! skips lines of standard input (file 5) whose first character is #
- implicit none
+   implicit none
 
 !In/Out variable
- integer :: inline
+   integer :: inline
 
 !Local variable
- character*1 tst
+   character(len=1) :: tst
 
- tst='#'
- do while (tst=='#')
-  read(5,*) tst
-  inline=inline+1
- end do
- backspace(5)
- inline=inline-1
+   tst='#'
+   do while (tst=='#')
+      read(5,*) tst
+      inline=inline+1
+   end do
+   backspace(5)
+   inline=inline-1
 
- return
- end subroutine cmtskp
+   return
+end subroutine cmtskp
 
- subroutine read_error(ios,inline)
+subroutine read_error(ios,inline)
 ! report data read error and stop
- implicit none
+   implicit none
 
 !Input variables
- integer :: ios,inline
+   integer :: ios,inline
 
- inline=inline+1
- if(ios/=0) then
-  write(6,'(a,i4)') 'Read ERROR, input data file line',inline
-  write(6,'(a)') 'Program will stop'
-  stop
- end if
+   inline=inline+1
+   if(ios/=0) then
+      write(6,'(a,i4)') 'Read ERROR, input data file line',inline
+      write(6,'(a)') 'Program will stop'
+      stop
+   end if
 
- return
- end subroutine read_error
+   return
+end subroutine read_error

--- a/src/oncvpsp.f90
+++ b/src/oncvpsp.f90
@@ -2,21 +2,21 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- program oncvpsp
+program oncvpsp
 !
 ! Creates and tests optimized norm-conserving Vanderbilt or Kleinman-Bylander
 ! pseudopotentials based on D. R. Hamann, Phys. Rev. B 88, 085117 (2013)
@@ -32,432 +32,432 @@
 !
 !   Output format for ABINIT pspcod=8 and upf format for quantumespresso
 !
- use m_psmlout, only: psmlout
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   use m_psmlout, only: psmlout
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !
- integer :: ii,ierr,iexc,iexct,ios,iprint,irps,it,icmod,lpopt
- integer :: jj,kk,ll,l1,lloc,lmax,lt,inline
- integer :: mch,mchf,mmax,n1,n2,nc,nlim,nlloc,nlmax,irpsh,nrl
- integer :: nv,irct,ncnf,nvt
- integer :: iprj,mxprj
- integer,allocatable :: npa(:,:)
+   integer :: ii,ierr,iexc,iexct,ios,iprint,irps,it,icmod,lpopt
+   integer :: jj,kk,ll,l1,lloc,lmax,lt,inline
+   integer :: mch,mchf,mmax,n1,n2,nc,nlim,nlloc,nlmax,irpsh,nrl
+   integer :: nv,irct,ncnf,nvt
+   integer :: iprj,mxprj
+   integer,allocatable :: npa(:,:)
 !
- integer :: dtime(8),na(30),la(30),np(6)
- integer :: nacnf(30,5),lacnf(30,5),nvcnf(5)
- integer :: nat(30),lat(30),indxr(30),indxe(30)
- integer :: irc(6),nodes(4)
- integer :: nproj(6),npx(6),lpx(6)
- integer :: ncon(6),nbas(6)
+   integer :: dtime(8),na(30),la(30),np(6)
+   integer :: nacnf(30,5),lacnf(30,5),nvcnf(5)
+   integer :: nat(30),lat(30),indxr(30),indxe(30)
+   integer :: irc(6),nodes(4)
+   integer :: nproj(6),npx(6),lpx(6)
+   integer :: ncon(6),nbas(6)
 
- real(dp) :: al,amesh,csc,csc1,deblt,depsh,depsht,drl,eeel
- real(dp) :: eeig,eexc
- real(dp) :: emax,epsh1,epsh1t,epsh2,epsh2t
- real(dp) :: et,etest,emin,sls
- real(dp) :: fcfact,rcfact,dvloc0
- real(dp) :: rr1,rcion,rciont,rcmax,rct,rlmax,rpkt
- real(dp) :: sf,zz,zion,zval,etot
- real(dp) :: xdummy
+   real(dp) :: al,amesh,csc,csc1,deblt,depsh,depsht,drl,eeel
+   real(dp) :: eeig,eexc
+   real(dp) :: emax,epsh1,epsh1t,epsh2,epsh2t
+   real(dp) :: et,etest,emin,sls
+   real(dp) :: fcfact,rcfact,dvloc0
+   real(dp) :: rr1,rcion,rciont,rcmax,rct,rlmax,rpkt
+   real(dp) :: sf,zz,zion,zval,etot
+   real(dp) :: xdummy
 !
- real(dp) :: cl(6),debl(6),ea(30),ep(6),fa(30),facnf(30,5)
- real(dp) :: fat(30,2)
- real(dp) :: fnp(6),fp(6)
- real(dp) :: qcut(6),qmsbf(6),rc(6),rc0(6)
- real(dp) :: rpk(30)
- real(dp) :: epx(6),fpx(6)
- real(dp) :: epstot
- real(dp), parameter :: eps=1.0d-8
+   real(dp) :: cl(6),debl(6),ea(30),ep(6),fa(30),facnf(30,5)
+   real(dp) :: fat(30,2)
+   real(dp) :: fnp(6),fp(6)
+   real(dp) :: qcut(6),qmsbf(6),rc(6),rc0(6)
+   real(dp) :: rpk(30)
+   real(dp) :: epx(6),fpx(6)
+   real(dp) :: epstot
+   real(dp), parameter :: eps=1.0d-8
 
- real(dp), allocatable :: evkb(:,:),cvgplt(:,:,:,:),qq(:,:)
- real(dp), allocatable :: rr(:)
- real(dp), allocatable :: rho(:),rhoc(:),rhot(:)
- real(dp), allocatable :: uu(:),up(:)
- real(dp), allocatable :: vp(:,:),vfull(:),vkb(:,:,:),pswf(:,:,:)
- real(dp), allocatable :: vwell(:)
- real(dp), allocatable :: vpuns(:,:)
- real(dp), allocatable :: vo(:),vxc(:)
- real(dp), allocatable :: rhomod(:,:),rhoae(:,:),rhops(:,:),rhotae(:)
- real(dp), allocatable :: uupsa(:,:) !pseudo-atomic orbitals array
- real(dp), allocatable :: epa(:,:),fpa(:,:)
- real(dp), allocatable :: uua(:,:),upa(:,:)
- real(dp), allocatable :: vr(:,:,:)
+   real(dp), allocatable :: evkb(:,:),cvgplt(:,:,:,:),qq(:,:)
+   real(dp), allocatable :: rr(:)
+   real(dp), allocatable :: rho(:),rhoc(:),rhot(:)
+   real(dp), allocatable :: uu(:),up(:)
+   real(dp), allocatable :: vp(:,:),vfull(:),vkb(:,:,:),pswf(:,:,:)
+   real(dp), allocatable :: vwell(:)
+   real(dp), allocatable :: vpuns(:,:)
+   real(dp), allocatable :: vo(:),vxc(:)
+   real(dp), allocatable :: rhomod(:,:),rhoae(:,:),rhops(:,:),rhotae(:)
+   real(dp), allocatable :: uupsa(:,:)  !pseudo-atomic orbitals array
+   real(dp), allocatable :: epa(:,:),fpa(:,:)
+   real(dp), allocatable :: uua(:,:),upa(:,:)
+   real(dp), allocatable :: vr(:,:,:)
 
- character*2 :: atsym
- character*4 :: psfile
+   character(len=2) :: atsym
+   character(len=4) :: psfile
 
- logical :: srel,cset
+   logical :: srel,cset
 
- write(6,'(a/a//)') &
-&      'ONCVPSP  (Optimized Norm-Conservinng Vanderbilt PSeudopotential)', &
-&      'scalar-relativistic version 4.0.1 03/01/2019'
+   write(6,'(a/a//)') &
+   &      'ONCVPSP  (Optimized Norm-Conservinng Vanderbilt PSeudopotential)', &
+   &      'scalar-relativistic version 4.0.1 03/01/2019'
 
- write(6,'(a/a/a//)') &
-&      'While it is not required under the terms of the GNU GPL, it is',&
-&      'suggested that you cite D. R. Hamann, Phys. Rev. B 88, 085117 (2013)', &
-&      'in any publication utilizing these pseudopotentials.'
+   write(6,'(a/a/a//)') &
+   &      'While it is not required under the terms of the GNU GPL, it is',&
+   &      'suggested that you cite D. R. Hamann, Phys. Rev. B 88, 085117 (2013)', &
+   &      'in any publication utilizing these pseudopotentials.'
 
- srel=.true.
+   srel=.true.
 !srel=.false.
 
- nproj(:)=0
- fcfact=0.0d0
- rcfact=0.0d0
- rc(:)=0.0d0
- ep(:)=0.0d0
+   nproj(:)=0
+   fcfact=0.0d0
+   rcfact=0.0d0
+   rc(:)=0.0d0
+   ep(:)=0.0d0
 
 ! read input data
- inline=0
+   inline=0
 
 ! atom and reference configuration
- call cmtskp(inline)
- read(5,*,iostat=ios) atsym,zz,nc,nv,iexc,psfile
- call read_error(ios,inline)
-
- call cmtskp(inline)
- do ii=1,nc+nv
-   read(5,*,iostat=ios) na(ii),la(ii),fa(ii)
+   call cmtskp(inline)
+   read(5,*,iostat=ios) atsym,zz,nc,nv,iexc,psfile
    call read_error(ios,inline)
- end do
+
+   call cmtskp(inline)
+   do ii=1,nc+nv
+      read(5,*,iostat=ios) na(ii),la(ii),fa(ii)
+      call read_error(ios,inline)
+   end do
 
 ! pseudopotential and optimization
- call cmtskp(inline)
- read(5,*,iostat=ios) lmax
- call read_error(ios,inline)
-
- call cmtskp(inline)
- do l1=1,lmax+1
-   read(5,*,iostat=ios) lt,rc(l1),ep(l1),ncon(l1),nbas(l1),qcut(l1)
-   if(lt/=l1-1) ios=999
+   call cmtskp(inline)
+   read(5,*,iostat=ios) lmax
    call read_error(ios,inline)
- end do
+
+   call cmtskp(inline)
+   do l1=1,lmax+1
+      read(5,*,iostat=ios) lt,rc(l1),ep(l1),ncon(l1),nbas(l1),qcut(l1)
+      if(lt/=l1-1) ios=999
+      call read_error(ios,inline)
+   end do
 
 ! local potential
- call cmtskp(inline)
- read(5,*, iostat=ios) lloc,lpopt,rc(5),dvloc0
- call read_error(ios,inline)
+   call cmtskp(inline)
+   read(5,*, iostat=ios) lloc,lpopt,rc(5),dvloc0
+   call read_error(ios,inline)
 
 ! Vanderbilt-Kleinman-Bylander projectors
- call cmtskp(inline)
- do l1=1,lmax+1
-   read(5,*,iostat=ios) lt,nproj(l1),debl(l1)
-   if(lt/=l1-1) ios=999
-   call read_error(ios,inline)
- end do
+   call cmtskp(inline)
+   do l1=1,lmax+1
+      read(5,*,iostat=ios) lt,nproj(l1),debl(l1)
+      if(lt/=l1-1) ios=999
+      call read_error(ios,inline)
+   end do
 
 ! model core charge
- call cmtskp(inline)
- read(5,*, iostat=ios) icmod, fcfact
- if(ios==0 .and. icmod==3) then
-  backspace(5)
-  read(5,*, iostat=ios) icmod, fcfact, rcfact
- end if
- call read_error(ios,inline)
+   call cmtskp(inline)
+   read(5,*, iostat=ios) icmod, fcfact
+   if(ios==0 .and. icmod==3) then
+      backspace(5)
+      read(5,*, iostat=ios) icmod, fcfact, rcfact
+   end if
+   call read_error(ios,inline)
 
 ! log derivative analysis
- call cmtskp(inline)
- read(5,*,iostat=ios) epsh1, epsh2, depsh
- call read_error(ios,inline)
+   call cmtskp(inline)
+   read(5,*,iostat=ios) epsh1, epsh2, depsh
+   call read_error(ios,inline)
 
 ! output grid
- call cmtskp(inline)
- read(5,*,iostat=ios) rlmax,drl
- call read_error(ios,inline)
+   call cmtskp(inline)
+   read(5,*,iostat=ios) rlmax,drl
+   call read_error(ios,inline)
 
 ! test configurations
- call cmtskp(inline)
- read(5,*,iostat=ios) ncnf
- call read_error(ios,inline)
-
- do jj=2,ncnf+1
    call cmtskp(inline)
-   read(5,*,iostat=ios) nvcnf(jj)
+   read(5,*,iostat=ios) ncnf
    call read_error(ios,inline)
-   do ii=nc+1,nc+nvcnf(jj)
-     call cmtskp(inline)
-     read(5,*,iostat=ios) nacnf(ii,jj),lacnf(ii,jj),facnf(ii,jj)
-     call read_error(ios,inline)
+
+   do jj=2,ncnf+1
+      call cmtskp(inline)
+      read(5,*,iostat=ios) nvcnf(jj)
+      call read_error(ios,inline)
+      do ii=nc+1,nc+nvcnf(jj)
+         call cmtskp(inline)
+         read(5,*,iostat=ios) nacnf(ii,jj),lacnf(ii,jj),facnf(ii,jj)
+         call read_error(ios,inline)
+      end do
    end do
- end do
 
 ! end of reading input data
 
- nvcnf(1)=nv
- do ii=1,nc+nv
-   nacnf(ii,1)=na(ii)
-   lacnf(ii,1)=la(ii)
-   facnf(ii,1)=fa(ii)
- end do
-
- do jj=2,ncnf+1
-   do ii=1,nc
-     nacnf(ii,jj)=na(ii)
-     lacnf(ii,jj)=la(ii)
-     facnf(ii,jj)=fa(ii)
+   nvcnf(1)=nv
+   do ii=1,nc+nv
+      nacnf(ii,1)=na(ii)
+      lacnf(ii,1)=la(ii)
+      facnf(ii,1)=fa(ii)
    end do
- end do
 
- if(icmod==0) then
-   fcfact=0.0d0
- end if
+   do jj=2,ncnf+1
+      do ii=1,nc
+         nacnf(ii,jj)=na(ii)
+         lacnf(ii,jj)=la(ii)
+         facnf(ii,jj)=fa(ii)
+      end do
+   end do
 
- call check_data(atsym,zz,fcfact,rcfact,epsh1,epsh2,depsh,rlmax,drl,fa,facnf, &
-&                rc,ep,qcut,debl,nc,nv,iexc,lmax,lloc,lpopt,icmod, &
-&                ncnf,na,la,nvcnf,nacnf,lacnf,ncon,nbas,nproj,psfile)
+   if(icmod==0) then
+      fcfact=0.0d0
+   end if
 
- nrl=int((rlmax/drl)-0.5d0)+1
+   call check_data(atsym,zz,fcfact,rcfact,epsh1,epsh2,depsh,rlmax,drl,fa,facnf, &
+   &                rc,ep,qcut,debl,nc,nv,iexc,lmax,lloc,lpopt,icmod, &
+   &                ncnf,na,la,nvcnf,nacnf,lacnf,ncon,nbas,nproj,psfile)
+
+   nrl=int((rlmax/drl)-0.5d0)+1
 
 !PWSCF wants an even number of mesh pointe
 !if(trim(psfile)=='upf') then
-  if(mod(nrl,2)/=0) nrl=nrl+1
+   if(mod(nrl,2)/=0) nrl=nrl+1
 !end if
 
 !amesh=1.012d0
- amesh=1.006d0
+   amesh=1.006d0
 !amesh=1.003d0
 !amesh=1.0015d0
 
- mxprj=5
+   mxprj=5
 
- al=dlog(amesh)
- rr1=0.0005d0/zz
- rr1=dmin1(rr1,0.0005d0/10)
- mmax=dlog(45.0d0 /rr1)/al
+   al=dlog(amesh)
+   rr1=0.0005d0/zz
+   rr1=dmin1(rr1,0.0005d0/10)
+   mmax=dlog(45.0d0 /rr1)/al
 
 !calculate zion for output
- zion=zz
- do ii=1,nc
-  zion=zion-fa(ii)
- end do
+   zion=zz
+   do ii=1,nc
+      zion=zion-fa(ii)
+   end do
 
 
- allocate(rr(mmax))
- allocate(rho(mmax),rhoc(mmax),rhot(mmax))
- allocate(uu(mmax),up(mmax),uupsa(mmax,30))
- allocate(evkb(mxprj,4), cvgplt(2,7,mxprj,4),qq(mxprj,mxprj))
- allocate(vp(mmax,5),vfull(mmax),vkb(mmax,mxprj,4),pswf(mmax,mxprj,4))
- allocate(vwell(mmax))
- allocate(vpuns(mmax,5))
- allocate(vo(mmax),vxc(mmax))
- allocate(rhoae(mmax,nv),rhops(mmax,nv),rhotae(mmax))
- allocate(npa(mxprj,6))
- allocate(epa(mxprj,6),fpa(mxprj,6))
- allocate(uua(mmax,mxprj),upa(mmax,mxprj))
- allocate(vr(mmax,mxprj,6))
+   allocate(rr(mmax))
+   allocate(rho(mmax),rhoc(mmax),rhot(mmax))
+   allocate(uu(mmax),up(mmax),uupsa(mmax,30))
+   allocate(evkb(mxprj,4), cvgplt(2,7,mxprj,4),qq(mxprj,mxprj))
+   allocate(vp(mmax,5),vfull(mmax),vkb(mmax,mxprj,4),pswf(mmax,mxprj,4))
+   allocate(vwell(mmax))
+   allocate(vpuns(mmax,5))
+   allocate(vo(mmax),vxc(mmax))
+   allocate(rhoae(mmax,nv),rhops(mmax,nv),rhotae(mmax))
+   allocate(npa(mxprj,6))
+   allocate(epa(mxprj,6),fpa(mxprj,6))
+   allocate(uua(mmax,mxprj),upa(mmax,mxprj))
+   allocate(vr(mmax,mxprj,6))
 
- vr(:,:,:)=0.0d0
- vp(:,:)=0.0d0
- vkb(:,:,:)=0.0d0
- epa(:,:)=0.0d0
+   vr(:,:,:)=0.0d0
+   vp(:,:)=0.0d0
+   vkb(:,:,:)=0.0d0
+   epa(:,:)=0.0d0
 
- do ii=1,mmax
-  rr(ii)=rr1*exp(al*(ii-1))
- end do
+   do ii=1,mmax
+      rr(ii)=rr1*exp(al*(ii-1))
+   end do
 
 !
 ! full potential atom solution
 !
    call sratom(na,la,ea,fa,rpk,nc,nc+nv,it,rhoc,rho, &
-&              rr,vfull,zz,mmax,iexc,etot,ierr,srel)
+   &              rr,vfull,zz,mmax,iexc,etot,ierr,srel)
 !
 !
 
 ! Drop digits beyond 5 decimals for input rcs before making any use of them
- do l1=1,max(lmax+1,lloc+1)
-    jj=int(rc(l1)*10.0d5)
-    rc(l1)=jj/10.0d5
- end do
+   do l1=1,max(lmax+1,lloc+1)
+      jj=int(rc(l1)*10.0d5)
+      rc(l1)=jj/10.0d5
+   end do
 
- rcmax=0.0d0
- do l1=1,lmax+1
-   rcmax=dmax1(rcmax,rc(l1))
- end do
- do l1=1,lmax+1
-   if(rc(l1)==0.0d0) then
-     rc(l1)=rcmax
-   end if
- end do
+   rcmax=0.0d0
+   do l1=1,lmax+1
+      rcmax=dmax1(rcmax,rc(l1))
+   end do
+   do l1=1,lmax+1
+      if(rc(l1)==0.0d0) then
+         rc(l1)=rcmax
+      end if
+   end do
 
- nproj(lloc+1)=0
- rc0(:)=rc(:)
+   nproj(lloc+1)=0
+   rc0(:)=rc(:)
 
 ! output printing (echos input data, with all-electron eigenvalues added)
 
- write(6,'(a)') '# ATOM AND REFERENCE CONFIGURATION'
- write(6,'(a)') '# atsym  z   nc   nv     iexc    psfile'
- write(6,'(a,a,f6.2,2i5,i8,2a)') '  ',trim(atsym),zz,nc,nv,iexc, &
-&      '      ',psfile
- write(6,'(a/a)') '#','#   n    l    f        energy (Ha)'
- do ii=1,nc+nv
-   write(6,'(2i5,f8.2,1pe18.7)') na(ii),la(ii),fa(ii),ea(ii)
- end do
-
- write(6,'(a/a/a)') '#','# PSEUDOPOTENTIAL AND OPTIMIZATION','# lmax'
- write(6,'(i5)')  lmax
- write(6,'(a/a)') '#','#   l,   rc,      ep,       ncon, nbas, qcut'
- do l1=1,lmax+1
-   write(6,'(i5,2f10.5,2i5,f10.5)') l1-1,rc(l1),ep(l1),ncon(l1),&
-&        nbas(l1),qcut(l1)
- end do
-
- write(6,'(a/a/a,a)') '#','# LOCAL POTENTIAL','# lloc, lpopt,  rc(5),', &
-&      '   dvloc0'
- write(6,'(2i5,f10.5,a,f10.5)') lloc,lpopt,rc(5),'   ',dvloc0
-
- write(6,'(a/a/a)') '#','# VANDERBILT-KLEINMAN-BYLANDER PROJECTORs', &
-&      '# l, nproj, debl'
- do l1=1,lmax+1
-   write(6,'(2i5,f10.5)') l1-1,nproj(l1),debl(l1)
- end do
-
- write(6,'(a/a/a)') '#','# MODEL CORE CHARGE', &
-&      '# icmod, fcfact, rcfact'
- write(6,'(i5,2f10.5)') icmod,fcfact,rcfact
-
- write(6,'(a/a/a)') '#','# LOG DERIVATIVE ANALYSIS', &
-&      '# epsh1, epsh2, depsh'
- write(6,'(3f8.2)') epsh1,epsh2,depsh
-
- write(6,'(a/a/a)') '#','# OUTPUT GRID','# rlmax, drl'
- write(6,'(2f8.4)') rlmax,drl
-
- write(6,'(a/a/a)') '#','# TEST CONFIGURATIONS','# ncnf'
- write(6,'(i5)') ncnf
- write(6,'(a/a)') '# nvcnf','#   n    l    f'
- do jj=2,ncnf+1
-   write(6,'(i5)') nvcnf(jj)
-   do ii=nc+1,nc+nvcnf(jj)
-     write(6,'(2i5,f8.2)') nacnf(ii,jj),lacnf(ii,jj),facnf(ii,jj)
+   write(6,'(a)') '# ATOM AND REFERENCE CONFIGURATION'
+   write(6,'(a)') '# atsym  z   nc   nv     iexc    psfile'
+   write(6,'(a,a,f6.2,2i5,i8,2a)') '  ',trim(atsym),zz,nc,nv,iexc, &
+   &      '      ',psfile
+   write(6,'(a/a)') '#','#   n    l    f        energy (Ha)'
+   do ii=1,nc+nv
+      write(6,'(2i5,f8.2,1pe18.7)') na(ii),la(ii),fa(ii),ea(ii)
    end do
-   write(6,'(a)') '#'
- end do
 
- write(6,'(//a)') 'Reference configufation results'
- write(6,'(a,i6)') '  iterations',it
- if(it .ge. 100) then
-  write(6,'(a)') 'oncvpsp: ERROR all-electron reference atom not converged'
-  stop
- end if
- write(6,'(a,1p,d18.8)') '  all-electron total energy (Ha)',etot
-  
-!find log mesh point nearest input rc
- rcmax=0.0d0
- irc(:)=0
- do l1=1,max(lmax+1,lloc+1)
-  rct=rc(l1)
-  irc(l1)=0
-  do ii=2,mmax
-   if(rr(ii)>rct) then
-    irc(l1)=ii
-    rc(l1)=rr(ii)
-    exit
+   write(6,'(a/a/a)') '#','# PSEUDOPOTENTIAL AND OPTIMIZATION','# lmax'
+   write(6,'(i5)')  lmax
+   write(6,'(a/a)') '#','#   l,   rc,      ep,       ncon, nbas, qcut'
+   do l1=1,lmax+1
+      write(6,'(i5,2f10.5,2i5,f10.5)') l1-1,rc(l1),ep(l1),ncon(l1),&
+      &        nbas(l1),qcut(l1)
+   end do
+
+   write(6,'(a/a/a,a)') '#','# LOCAL POTENTIAL','# lloc, lpopt,  rc(5),', &
+   &      '   dvloc0'
+   write(6,'(2i5,f10.5,a,f10.5)') lloc,lpopt,rc(5),'   ',dvloc0
+
+   write(6,'(a/a/a)') '#','# VANDERBILT-KLEINMAN-BYLANDER PROJECTORs', &
+   &      '# l, nproj, debl'
+   do l1=1,lmax+1
+      write(6,'(2i5,f10.5)') l1-1,nproj(l1),debl(l1)
+   end do
+
+   write(6,'(a/a/a)') '#','# MODEL CORE CHARGE', &
+   &      '# icmod, fcfact, rcfact'
+   write(6,'(i5,2f10.5)') icmod,fcfact,rcfact
+
+   write(6,'(a/a/a)') '#','# LOG DERIVATIVE ANALYSIS', &
+   &      '# epsh1, epsh2, depsh'
+   write(6,'(3f8.2)') epsh1,epsh2,depsh
+
+   write(6,'(a/a/a)') '#','# OUTPUT GRID','# rlmax, drl'
+   write(6,'(2f8.4)') rlmax,drl
+
+   write(6,'(a/a/a)') '#','# TEST CONFIGURATIONS','# ncnf'
+   write(6,'(i5)') ncnf
+   write(6,'(a/a)') '# nvcnf','#   n    l    f'
+   do jj=2,ncnf+1
+      write(6,'(i5)') nvcnf(jj)
+      do ii=nc+1,nc+nvcnf(jj)
+         write(6,'(2i5,f8.2)') nacnf(ii,jj),lacnf(ii,jj),facnf(ii,jj)
+      end do
+      write(6,'(a)') '#'
+   end do
+
+   write(6,'(//a)') 'Reference configufation results'
+   write(6,'(a,i6)') '  iterations',it
+   if(it >= 100) then
+      write(6,'(a)') 'oncvpsp: ERROR all-electron reference atom not converged'
+      stop
    end if
-  end do
-  rcmax=dmax1(rcmax,rc(l1))
- end do
+   write(6,'(a,1p,d18.8)') '  all-electron total energy (Ha)',etot
+
+!find log mesh point nearest input rc
+   rcmax=0.0d0
+   irc(:)=0
+   do l1=1,max(lmax+1,lloc+1)
+      rct=rc(l1)
+      irc(l1)=0
+      do ii=2,mmax
+         if(rr(ii)>rct) then
+            irc(l1)=ii
+            rc(l1)=rr(ii)
+            exit
+         end if
+      end do
+      rcmax=dmax1(rcmax,rc(l1))
+   end do
 
 !
- cvgplt(:,:,:,:)=0.0d0
+   cvgplt(:,:,:,:)=0.0d0
 !
 ! loop to construct pseudopotentials for all angular momenta
 !
- write(6,'(/a/a)') 'Begin loop to  construct optimized pseudo wave functions',&
-&      'and semi-local pseudopoentials for all angular momenta'
+   write(6,'(/a/a)') 'Begin loop to  construct optimized pseudo wave functions',&
+   &      'and semi-local pseudopoentials for all angular momenta'
 
 !temporarily set this to 1 so that the pseudo wave function needed for the
 !local potential will be generated.  Reset after run_vkb.
- nproj(lloc+1)=1
- do l1=1,lmax+1
-   ll=l1-1
-   uu(:)=0.0d0; qq(:,:)=0.0d0
-   iprj=0
+   nproj(lloc+1)=1
+   do l1=1,lmax+1
+      ll=l1-1
+      uu(:)=0.0d0; qq(:,:)=0.0d0
+      iprj=0
 
 !get principal quantum number for the highest core state for this l
-   npa(1,l1)=l1
-   do kk=1,nc
-     if(la(kk)==l1-1) npa(1,l1)=na(kk)+1
-   end do !kk
+      npa(1,l1)=l1
+      do kk=1,nc
+         if(la(kk)==l1-1) npa(1,l1)=na(kk)+1
+      end do  !kk
 
 !get all-electron bound states for projectors
-   if(nv/=0) then
-     do kk=nc+1,nc+nv
-       if(la(kk)==l1-1) then
-         iprj=iprj+1
-         et=ea(kk)
-         call lschfb(na(kk),la(kk),ierr,et, &
-&                      rr,vfull,uu,up,zz,mmax,mch,srel)
-         if(ierr /= 0) then
-           write(6,'(/a,3i4)') 'oncvpsp-387: lschfb convergence ERROR n,l,iter=', &
-&           na(ii),la(ii),it
-           stop
-         end if
-         epa(iprj,l1)=ea(kk)
-         npa(iprj,l1)=na(kk)
-         uua(:,iprj)=uu(:)
-         upa(:,iprj)=up(:)
-       end if !la(kk)==l1-1
-       if(iprj==nproj(l1)) exit
-     end do !kk
-   end if !nv/=0
+      if(nv/=0) then
+         do kk=nc+1,nc+nv
+            if(la(kk)==l1-1) then
+               iprj=iprj+1
+               et=ea(kk)
+               call lschfb(na(kk),la(kk),ierr,et, &
+               &                      rr,vfull,uu,up,zz,mmax,mch,srel)
+               if(ierr /= 0) then
+                  write(6,'(/a,3i4)') 'oncvpsp-387: lschfb convergence ERROR n,l,iter=', &
+                  &           na(ii),la(ii),it
+                  stop
+               end if
+               epa(iprj,l1)=ea(kk)
+               npa(iprj,l1)=na(kk)
+               uua(:,iprj)=uu(:)
+               upa(:,iprj)=up(:)
+            end if  !la(kk)==l1-1
+            if(iprj==nproj(l1)) exit
+         end do  !kk
+      end if  !nv/=0
 
 !get all-electron well states for projectors
 !if there were no valence states, use ep from input data for 1st well state
 !otherwise shift up by input debl
-   if(iprj==0) epa(1,l1)=ep(l1)
-   if(iprj<nproj(l1))then
-     do kk=1,nproj(l1)-iprj
-       iprj=iprj+1
-       if(iprj>1 .and. debl(l1)<=0.0d0) then
-         write(6,'(a,f8.3,a/a)') 'oncvpsp: ERROR debl =',debl, 'for l=', &
-&              ' ERROR not allowed with 2 or more scattering states', &
-&              'program will stop'
-         stop
-       end if
-       if(iprj>1) then
-         epa(iprj,l1)=epa(iprj-1,l1)+debl(l1)
-         npa(iprj,l1)=npa(iprj-1,l1)+1
-       end if
+      if(iprj==0) epa(1,l1)=ep(l1)
+      if(iprj<nproj(l1))then
+         do kk=1,nproj(l1)-iprj
+            iprj=iprj+1
+            if(iprj>1 .and. debl(l1)<=0.0d0) then
+               write(6,'(a,f8.3,a/a)') 'oncvpsp: ERROR debl =',debl, 'for l=', &
+               &              ' ERROR not allowed with 2 or more scattering states', &
+               &              'program will stop'
+               stop
+            end if
+            if(iprj>1) then
+               epa(iprj,l1)=epa(iprj-1,l1)+debl(l1)
+               npa(iprj,l1)=npa(iprj-1,l1)+1
+            end if
 
-       call wellstate(npa(iprj,l1),ll,irc(l1),epa(iprj,l1),rr, &
-&                     vfull,uu,up,zz,mmax,mch,srel)
-       uua(:,iprj)=uu(:)
-       upa(:,iprj)=up(:)
-     end do !kk
-   end if !iprj<nproj(l1)
+            call wellstate(npa(iprj,l1),ll,irc(l1),epa(iprj,l1),rr, &
+            &                     vfull,uu,up,zz,mmax,mch,srel)
+            uua(:,iprj)=uu(:)
+            upa(:,iprj)=up(:)
+         end do  !kk
+      end if  !iprj<nproj(l1)
 
-   do iprj=1,nproj(l1)
+      do iprj=1,nproj(l1)
 
 !calculate relativistic correction to potential to force projectors to 0 at rc
-     call vrel(ll,epa(iprj,l1),rr,vfull,vr(1,iprj,l1),uua(1,iprj),upa(1,iprj), &
-&              zz,mmax,irc(l1),srel)
+         call vrel(ll,epa(iprj,l1),rr,vfull,vr(1,iprj,l1),uua(1,iprj),upa(1,iprj), &
+         &              zz,mmax,irc(l1),srel)
 
-   end do
+      end do
 
 !get all-electron overlap matrix
-   do jj=1,nproj(l1)
-     do ii=1,jj
-       call fpovlp(uua(1,ii),uua(1,jj),irc(l1),ll,zz,qq(ii,jj),rr,srel)
-       qq(jj,ii)=qq(ii,jj)
-     end do
-   end do
+      do jj=1,nproj(l1)
+         do ii=1,jj
+            call fpovlp(uua(1,ii),uua(1,jj),irc(l1),ll,zz,qq(ii,jj),rr,srel)
+            qq(jj,ii)=qq(ii,jj)
+         end do
+      end do
 
-   call run_optimize(epa(1,l1),ll,mmax,mxprj,rr,uua,qq, &
-&                    irc(l1),qcut(l1),qmsbf(l1),ncon(l1),nbas(l1),nproj(l1), &
-&                    pswf(1,1,l1),vp(1,l1),vkb(1,1,l1),vfull,cvgplt(1,1,1,l1))
+      call run_optimize(epa(1,l1),ll,mmax,mxprj,rr,uua,qq, &
+      &                    irc(l1),qcut(l1),qmsbf(l1),ncon(l1),nbas(l1),nproj(l1), &
+      &                    pswf(1,1,l1),vp(1,l1),vkb(1,1,l1),vfull,cvgplt(1,1,1,l1))
 
- end do !l1
+   end do  !l1
 
 ! construct Vanderbilt / Kleinman-Bylander projectors
 
- write(6,'(/a,a)') 'Construct Vanderbilt / Kleinmman-Bylander projectors'
+   write(6,'(/a,a)') 'Construct Vanderbilt / Kleinmman-Bylander projectors'
 
- call run_vkb(lmax,lloc,lpopt,dvloc0,irc,nproj,rr,mmax,mxprj,pswf,vfull,vp, &
-&             evkb,vkb,nlim,vr)
+   call run_vkb(lmax,lloc,lpopt,dvloc0,irc,nproj,rr,mmax,mxprj,pswf,vfull,vp, &
+   &             evkb,vkb,nlim,vr)
 
 !restore this to its proper value
- nproj(lloc+1)=0
+   nproj(lloc+1)=0
 
- deallocate(uua,upa)
+   deallocate(uua,upa)
 
 ! accumulate charge and eigenvalues
 ! pseudo wave functions are calculated with VKB projectors for
@@ -466,209 +466,209 @@
 ! charge densities
 
 ! null charge and eigenvalue accumulators
- uupsa(:,:)=0.0d0
- eeig=0.0d0
- zval=0.0d0
- rho(:)=0.0d0
- nodes(:)=0
- rhotae(:)=0.0d0
- irps=0
- do kk=1,nv
+   uupsa(:,:)=0.0d0
+   eeig=0.0d0
+   zval=0.0d0
+   rho(:)=0.0d0
+   nodes(:)=0
+   rhotae(:)=0.0d0
+   irps=0
+   do kk=1,nv
 
-   et=ea(nc+kk)
-   ll=la(nc+kk)
-   l1=ll+1
-   call lschfb(na(nc+kk),ll,ierr,et, &
-&                rr,vfull,uu,up,zz,mmax,mch,srel)
-   if(ierr /= 0) then
-     write(6,'(/a,3i4)') 'oncvpsp-461: lschfb convergence ERROR n,l,iter=', &
-&     na(ii),la(ii),it
-     stop
-   end if
+      et=ea(nc+kk)
+      ll=la(nc+kk)
+      l1=ll+1
+      call lschfb(na(nc+kk),ll,ierr,et, &
+      &                rr,vfull,uu,up,zz,mmax,mch,srel)
+      if(ierr /= 0) then
+         write(6,'(/a,3i4)') 'oncvpsp-461: lschfb convergence ERROR n,l,iter=', &
+         &     na(ii),la(ii),it
+         stop
+      end if
 
-   rhoae(:,kk)=(uu(:)/rr(:))**2
+      rhoae(:,kk)=(uu(:)/rr(:))**2
 
-   rhotae(:)=rhotae(:) + fa(nc+kk)*rhoae(:,kk)
+      rhotae(:)=rhotae(:) + fa(nc+kk)*rhoae(:,kk)
 
-   emax=0.75d0*et
-   emin=1.25d0*et
+      emax=0.75d0*et
+      emin=1.25d0*et
 
-   call lschvkbb(ll+nodes(l1)+1,ll,nproj(l1),ierr,et,emin,emax, &
-&                rr,vp(1,lloc+1),vkb(1,1,l1),evkb(1,l1), &
-&                uu,up,mmax,mch)
+      call lschvkbb(ll+nodes(l1)+1,ll,nproj(l1),ierr,et,emin,emax, &
+      &                rr,vp(1,lloc+1),vkb(1,1,l1),evkb(1,l1), &
+      &                uu,up,mmax,mch)
 
-   if(ierr/=0) then 
-     write(6,'(a,3i4)') 'oncvpsp: lschvkbb ERROR',ll+nodes(l1)+1,ll,ierr
-     flush(6)
-     stop
-   end if
+      if(ierr/=0) then
+         write(6,'(a,3i4)') 'oncvpsp: lschvkbb ERROR',ll+nodes(l1)+1,ll,ierr
+         flush(6)
+         stop
+      end if
 
 ! save valence pseudo wave functions for upfout
-   uupsa(:,kk)=uu(:)
+      uupsa(:,kk)=uu(:)
 
-   rhops(:,kk)=(uu(:)/rr(:))**2
-   rho(:)=rho(:)+fa(nc+kk)*rhops(:,kk)
-   eeig=eeig+fa(nc+kk)*et
+      rhops(:,kk)=(uu(:)/rr(:))**2
+      rho(:)=rho(:)+fa(nc+kk)*rhops(:,kk)
+      eeig=eeig+fa(nc+kk)*et
 
-   zval=zval+fa(nc+kk)
-   nodes(l1)=nodes(l1)+1
-   irps=max(irps,irc(l1))
- end do !kk
+      zval=zval+fa(nc+kk)
+      nodes(l1)=nodes(l1)+1
+      irps=max(irps,irc(l1))
+   end do  !kk
 
- allocate(rhomod(mmax,5))
+   allocate(rhomod(mmax,5))
 
- rhomod(:,:)=0.0d0
+   rhomod(:,:)=0.0d0
 
 ! construct model core charge based on monotonic polynomial fit
 ! or Teter function fit
 
- if(icmod==1) then
-   call modcore(icmod,rhops,rho,rhoc,rhoae,rhotae,rhomod, &
-&               fcfact,rcfact,irps,mmax,rr,nc,nv,la,zion,iexc)
+   if(icmod==1) then
+      call modcore(icmod,rhops,rho,rhoc,rhoae,rhotae,rhomod, &
+      &               fcfact,rcfact,irps,mmax,rr,nc,nv,la,zion,iexc)
 
- else if(icmod==2) then
-   call modcore2(icmod,rhops,rho,rhoc,rhoae,rhotae,rhomod, &
-&               fcfact,rcfact,irps,mmax,rr,nc,nv,la,zion,iexc)
+   else if(icmod==2) then
+      call modcore2(icmod,rhops,rho,rhoc,rhoae,rhotae,rhomod, &
+      &               fcfact,rcfact,irps,mmax,rr,nc,nv,la,zion,iexc)
 
- else if(icmod>=3) then
-   call modcore3(icmod,rhops,rho,rhoc,rhoae,rhotae,rhomod, &
-&               fcfact,rcfact,irps,mmax,rr,nc,nv,la,zion,iexc)
+   else if(icmod>=3) then
+      call modcore3(icmod,rhops,rho,rhoc,rhoae,rhotae,rhomod, &
+      &               fcfact,rcfact,irps,mmax,rr,nc,nv,la,zion,iexc)
 
- end if
+   end if
 
 ! screening potential for pseudocharge
 
- call vout(1,rho,rhomod(1,1),vo,vxc,zval,eeel,eexc,rr,mmax,iexc)
+   call vout(1,rho,rhomod(1,1),vo,vxc,zval,eeel,eexc,rr,mmax,iexc)
 
 ! total energy output
 
- epstot= eeig + eexc - 0.5d0*eeel
- write(6,'(/a,f12.6/)') 'Pseudoatom total energy', epstot
+   epstot= eeig + eexc - 0.5d0*eeel
+   write(6,'(/a,f12.6/)') 'Pseudoatom total energy', epstot
 
- call run_diag(lmax,npa,epa,lloc,irc, &
-&                    vkb,evkb,nproj,rr,vfull,vp,zz,mmax,mxprj,srel)
+   call run_diag(lmax,npa,epa,lloc,irc, &
+   &                    vkb,evkb,nproj,rr,vfull,vp,zz,mmax,mxprj,srel)
 
- call run_ghosts(lmax,la,ea,nc,nv,lloc,irc,qmsbf, &
-&                    vkb,evkb,nproj,rr,vp,mmax,mxprj)
+   call run_ghosts(lmax,la,ea,nc,nv,lloc,irc,qmsbf, &
+   &                    vkb,evkb,nproj,rr,vp,mmax,mxprj)
 
 ! unscreen semi-local potentials
 
- do l1=1,max(lmax+1,lloc+1)
-   vpuns(:,l1)=vp(:,l1)-vo(:)
- end do
+   do l1=1,max(lmax+1,lloc+1)
+      vpuns(:,l1)=vp(:,l1)-vo(:)
+   end do
 
 !fix unscreening error due to greater range of all-electron charge
- do ii=mmax,1,-1
-   if(rho(ii)==0.0d0) then 
-     do l1=1,max(lmax+1,lloc+1)
-       vpuns(ii,l1)=-zion/rr(ii)
-     end do
-   else
-     exit
-   end if
- end do
+   do ii=mmax,1,-1
+      if(rho(ii)==0.0d0) then
+         do l1=1,max(lmax+1,lloc+1)
+            vpuns(ii,l1)=-zion/rr(ii)
+         end do
+      else
+         exit
+      end if
+   end do
 
 
 ! loop over reference plus test atom configurations
 !if(.false.) then
 
 !ncnf=0
- rhot(:)=rho(:)
- do jj=1,ncnf+1
+   rhot(:)=rho(:)
+   do jj=1,ncnf+1
 
-   write(6,'(/a,i2)') 'Test configuration',jj-1
+      write(6,'(/a,i2)') 'Test configuration',jj-1
 
 ! charge density is initialized to that of reference configuration
 
-   rhot(:)=rho(:)
+      rhot(:)=rho(:)
 
-   call run_config(jj,nacnf,lacnf,facnf,nc,nvcnf,rhot,rhomod,rr,zz, &
-&                  rcmax,mmax,mxprj,iexc,ea,etot,epstot,nproj,vpuns, &
-&                  lloc,vkb,evkb,srel)
+      call run_config(jj,nacnf,lacnf,facnf,nc,nvcnf,rhot,rhomod,rr,zz, &
+      &                  rcmax,mmax,mxprj,iexc,ea,etot,epstot,nproj,vpuns, &
+      &                  lloc,vkb,evkb,srel)
 
- end do !jj
+   end do  !jj
 
- call run_plot(lmax,npa,epa,lloc,irc, &
-&                    vkb,evkb,nproj,rr,vfull,vp,vpuns,zz,mmax,mxprj,drl,nrl, &
-&                    rho,rhoc,rhomod,srel,cvgplt)
-
-
-
- call run_phsft(lmax,lloc,nproj,epa,epsh1,epsh2,depsh,vkb,evkb, &
-&               rr,vfull,vp,zz,mmax,mxprj,irc,srel)
- 
- call gnu_script(epa,evkb,lmax,lloc,mxprj,nproj)
-
- if(trim(psfile)=='psp8' .or. trim(psfile)=='both') then
+   call run_plot(lmax,npa,epa,lloc,irc, &
+   &                    vkb,evkb,nproj,rr,vfull,vp,vpuns,zz,mmax,mxprj,drl,nrl, &
+   &                    rho,rhoc,rhomod,srel,cvgplt)
 
 
-  call linout(lmax,lloc,rc,vkb,evkb,nproj,rr,vpuns,rho,rhomod, &
-&             rhotae,rhoc,zz,zion,mmax,mxprj,iexc,icmod,nrl,drl,atsym, &
-&             na,la,ncon,nbas,nvcnf,nacnf,lacnf,nc,nv,lpopt,ncnf, &
-&             fa,rc0,ep,qcut,debl,facnf,dvloc0,fcfact,rcfact, &
-&             epsh1,epsh2,depsh,rlmax,psfile)
- end if
 
- if(trim(psfile)=='upf' .or. trim(psfile)=='both') then
-  call upfout(lmax,lloc,rc,vkb,evkb,nproj,rr,vpuns,rho,rhomod, &
-&             zz,zion,mmax,mxprj,iexc,icmod,nrl,drl,atsym,epstot, &
-&             na,la,ncon,nbas,nvcnf,nacnf,lacnf,nc,nv,lpopt,ncnf, &
-&             fa,rc0,ep,qcut,debl,facnf,dvloc0,fcfact,rcfact, &
-&             epsh1,epsh2,depsh,rlmax,psfile,uupsa,ea)
- end if
+   call run_phsft(lmax,lloc,nproj,epa,epsh1,epsh2,depsh,vkb,evkb, &
+   &               rr,vfull,vp,zz,mmax,mxprj,irc,srel)
+
+   call gnu_script(epa,evkb,lmax,lloc,mxprj,nproj)
+
+   if(trim(psfile)=='psp8' .or. trim(psfile)=='both') then
 
 
- if(trim(psfile)=='psml' .or. trim(psfile)=='both') then
+      call linout(lmax,lloc,rc,vkb,evkb,nproj,rr,vpuns,rho,rhomod, &
+      &             rhotae,rhoc,zz,zion,mmax,mxprj,iexc,icmod,nrl,drl,atsym, &
+      &             na,la,ncon,nbas,nvcnf,nacnf,lacnf,nc,nv,lpopt,ncnf, &
+      &             fa,rc0,ep,qcut,debl,facnf,dvloc0,fcfact,rcfact, &
+      &             epsh1,epsh2,depsh,rlmax,psfile)
+   end if
+
+   if(trim(psfile)=='upf' .or. trim(psfile)=='both') then
+      call upfout(lmax,lloc,rc,vkb,evkb,nproj,rr,vpuns,rho,rhomod, &
+      &             zz,zion,mmax,mxprj,iexc,icmod,nrl,drl,atsym,epstot, &
+      &             na,la,ncon,nbas,nvcnf,nacnf,lacnf,nc,nv,lpopt,ncnf, &
+      &             fa,rc0,ep,qcut,debl,facnf,dvloc0,fcfact,rcfact, &
+      &             epsh1,epsh2,depsh,rlmax,psfile,uupsa,ea)
+   end if
+
+
+   if(trim(psfile)=='psml' .or. trim(psfile)=='both') then
 !
 ! Write info for PSML format
 !
-   print *, 'calling psmlout'
-   call psmlout(lmax,lloc,rc,vkb,evkb,nproj,rr,vpuns,rho,rhomod, &
-&             irct, srel, &
-&             zz,zion,mmax,iexc,icmod,nrl,drl,atsym,epstot, &
-&             na,la,ncon,nbas,nvcnf,nacnf,lacnf,nc,nv,lpopt,ncnf, &
-&             fa,rc0,ep,qcut,debl,facnf,dvloc0,fcfact, &
-&             epsh1,epsh2,depsh,rlmax,psfile)
- end if
+      print *, 'calling psmlout'
+      call psmlout(lmax,lloc,rc,vkb,evkb,nproj,rr,vpuns,rho,rhomod, &
+      &             irct, srel, &
+      &             zz,zion,mmax,iexc,icmod,nrl,drl,atsym,epstot, &
+      &             na,la,ncon,nbas,nvcnf,nacnf,lacnf,nc,nv,lpopt,ncnf, &
+      &             fa,rc0,ep,qcut,debl,facnf,dvloc0,fcfact, &
+      &             epsh1,epsh2,depsh,rlmax,psfile)
+   end if
 
- stop
- end program oncvpsp
+   stop
+end program oncvpsp
 
 
- subroutine cmtskp(inline)
+subroutine cmtskp(inline)
 ! skips lines of standard input (file 5) whose first character is #
- implicit none
+   implicit none
 
 !In/Out variable
- integer :: inline
+   integer :: inline
 
 !Local variable
- character*1 tst
+   character(len=1) :: tst
 
- tst='#'
- do while (tst=='#')
-  read(5,*) tst
-  inline=inline+1
- end do
- backspace(5)
- inline=inline-1
+   tst='#'
+   do while (tst=='#')
+      read(5,*) tst
+      inline=inline+1
+   end do
+   backspace(5)
+   inline=inline-1
 
- return
- end subroutine cmtskp
+   return
+end subroutine cmtskp
 
- subroutine read_error(ios,inline)
+subroutine read_error(ios,inline)
 ! report data read error and stop
- implicit none
+   implicit none
 
 !Input variables
- integer :: ios,inline
+   integer :: ios,inline
 
- inline=inline+1
- if(ios/=0) then
-  write(6,'(a,i4)') 'Read ERROR, input data file line',inline
-  write(6,'(a)') 'Program will stop'
-  stop
- end if
+   inline=inline+1
+   if(ios/=0) then
+      write(6,'(a,i4)') 'Read ERROR, input data file line',inline
+      write(6,'(a)') 'Program will stop'
+      stop
+   end if
 
- return
- end subroutine read_error
+   return
+end subroutine read_error

--- a/src/oncvpsp_nr.f90
+++ b/src/oncvpsp_nr.f90
@@ -2,21 +2,21 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- program oncvpsp
+program oncvpsp
 !
 ! Creates and tests optimized norm-conserving Vanderbilt or Kleinman-Bylander
 ! pseudopotentials based on D. R. Hamann, Phys. Rev. B 88, 085117 (2013)
@@ -32,432 +32,432 @@
 !
 !   Output format for ABINIT pspcod=8 and upf format for quantumespresso
 !
- use m_psmlout, only: psmlout
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   use m_psmlout, only: psmlout
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !
- integer :: ii,ierr,iexc,iexct,ios,iprint,irps,it,icmod,lpopt
- integer :: jj,kk,ll,l1,lloc,lmax,lt,inline
- integer :: mch,mchf,mmax,n1,n2,nc,nlim,nlloc,nlmax,irpsh,nrl
- integer :: nv,irct,ncnf,nvt
- integer :: iprj,mxprj
- integer,allocatable :: npa(:,:)
+   integer :: ii,ierr,iexc,iexct,ios,iprint,irps,it,icmod,lpopt
+   integer :: jj,kk,ll,l1,lloc,lmax,lt,inline
+   integer :: mch,mchf,mmax,n1,n2,nc,nlim,nlloc,nlmax,irpsh,nrl
+   integer :: nv,irct,ncnf,nvt
+   integer :: iprj,mxprj
+   integer,allocatable :: npa(:,:)
 !
- integer :: dtime(8),na(30),la(30),np(6)
- integer :: nacnf(30,5),lacnf(30,5),nvcnf(5)
- integer :: nat(30),lat(30),indxr(30),indxe(30)
- integer :: irc(6),nodes(4)
- integer :: nproj(6),npx(6),lpx(6)
- integer :: ncon(6),nbas(6)
+   integer :: dtime(8),na(30),la(30),np(6)
+   integer :: nacnf(30,5),lacnf(30,5),nvcnf(5)
+   integer :: nat(30),lat(30),indxr(30),indxe(30)
+   integer :: irc(6),nodes(4)
+   integer :: nproj(6),npx(6),lpx(6)
+   integer :: ncon(6),nbas(6)
 
- real(dp) :: al,amesh,csc,csc1,deblt,depsh,depsht,drl,eeel
- real(dp) :: eeig,eexc
- real(dp) :: emax,epsh1,epsh1t,epsh2,epsh2t
- real(dp) :: et,etest,emin,sls
- real(dp) :: fcfact,rcfact,dvloc0
- real(dp) :: rr1,rcion,rciont,rcmax,rct,rlmax,rpkt
- real(dp) :: sf,zz,zion,zval,etot
- real(dp) :: xdummy
+   real(dp) :: al,amesh,csc,csc1,deblt,depsh,depsht,drl,eeel
+   real(dp) :: eeig,eexc
+   real(dp) :: emax,epsh1,epsh1t,epsh2,epsh2t
+   real(dp) :: et,etest,emin,sls
+   real(dp) :: fcfact,rcfact,dvloc0
+   real(dp) :: rr1,rcion,rciont,rcmax,rct,rlmax,rpkt
+   real(dp) :: sf,zz,zion,zval,etot
+   real(dp) :: xdummy
 !
- real(dp) :: cl(6),debl(6),ea(30),ep(6),fa(30),facnf(30,5)
- real(dp) :: fat(30,2)
- real(dp) :: fnp(6),fp(6)
- real(dp) :: qcut(6),qmsbf(6),rc(6),rc0(6)
- real(dp) :: rpk(30)
- real(dp) :: epx(6),fpx(6)
- real(dp) :: epstot
- real(dp), parameter :: eps=1.0d-8
+   real(dp) :: cl(6),debl(6),ea(30),ep(6),fa(30),facnf(30,5)
+   real(dp) :: fat(30,2)
+   real(dp) :: fnp(6),fp(6)
+   real(dp) :: qcut(6),qmsbf(6),rc(6),rc0(6)
+   real(dp) :: rpk(30)
+   real(dp) :: epx(6),fpx(6)
+   real(dp) :: epstot
+   real(dp), parameter :: eps=1.0d-8
 
- real(dp), allocatable :: evkb(:,:),cvgplt(:,:,:,:),qq(:,:)
- real(dp), allocatable :: rr(:)
- real(dp), allocatable :: rho(:),rhoc(:),rhot(:)
- real(dp), allocatable :: uu(:),up(:)
- real(dp), allocatable :: vp(:,:),vfull(:),vkb(:,:,:),pswf(:,:,:)
- real(dp), allocatable :: vwell(:)
- real(dp), allocatable :: vpuns(:,:)
- real(dp), allocatable :: vo(:),vxc(:)
- real(dp), allocatable :: rhomod(:,:),rhoae(:,:),rhops(:,:),rhotae(:)
- real(dp), allocatable :: uupsa(:,:) !pseudo-atomic orbitals array
- real(dp), allocatable :: epa(:,:),fpa(:,:)
- real(dp), allocatable :: uua(:,:),upa(:,:)
- real(dp), allocatable :: vr(:,:,:)
+   real(dp), allocatable :: evkb(:,:),cvgplt(:,:,:,:),qq(:,:)
+   real(dp), allocatable :: rr(:)
+   real(dp), allocatable :: rho(:),rhoc(:),rhot(:)
+   real(dp), allocatable :: uu(:),up(:)
+   real(dp), allocatable :: vp(:,:),vfull(:),vkb(:,:,:),pswf(:,:,:)
+   real(dp), allocatable :: vwell(:)
+   real(dp), allocatable :: vpuns(:,:)
+   real(dp), allocatable :: vo(:),vxc(:)
+   real(dp), allocatable :: rhomod(:,:),rhoae(:,:),rhops(:,:),rhotae(:)
+   real(dp), allocatable :: uupsa(:,:)  !pseudo-atomic orbitals array
+   real(dp), allocatable :: epa(:,:),fpa(:,:)
+   real(dp), allocatable :: uua(:,:),upa(:,:)
+   real(dp), allocatable :: vr(:,:,:)
 
- character*2 :: atsym
- character*4 :: psfile
+   character(len=2) :: atsym
+   character(len=4) :: psfile
 
- logical :: srel,cset
+   logical :: srel,cset
 
- write(6,'(a/a//)') &
-&      'ONCVPSP  (Optimized Norm-Conservinng Vanderbilt PSeudopotential)', &
-&      'scalar-relativistic version 4.0.1 03/01/2019'
+   write(6,'(a/a//)') &
+   &      'ONCVPSP  (Optimized Norm-Conservinng Vanderbilt PSeudopotential)', &
+   &      'scalar-relativistic version 4.0.1 03/01/2019'
 
- write(6,'(a/a/a//)') &
-&      'While it is not required under the terms of the GNU GPL, it is',&
-&      'suggested that you cite D. R. Hamann, Phys. Rev. B 88, 085117 (2013)', &
-&      'in any publication utilizing these pseudopotentials.'
+   write(6,'(a/a/a//)') &
+   &      'While it is not required under the terms of the GNU GPL, it is',&
+   &      'suggested that you cite D. R. Hamann, Phys. Rev. B 88, 085117 (2013)', &
+   &      'in any publication utilizing these pseudopotentials.'
 
 !srel=.true.
- srel=.false.
+   srel=.false.
 
- nproj(:)=0
- fcfact=0.0d0
- rcfact=0.0d0
- rc(:)=0.0d0
- ep(:)=0.0d0
+   nproj(:)=0
+   fcfact=0.0d0
+   rcfact=0.0d0
+   rc(:)=0.0d0
+   ep(:)=0.0d0
 
 ! read input data
- inline=0
+   inline=0
 
 ! atom and reference configuration
- call cmtskp(inline)
- read(5,*,iostat=ios) atsym,zz,nc,nv,iexc,psfile
- call read_error(ios,inline)
-
- call cmtskp(inline)
- do ii=1,nc+nv
-   read(5,*,iostat=ios) na(ii),la(ii),fa(ii)
+   call cmtskp(inline)
+   read(5,*,iostat=ios) atsym,zz,nc,nv,iexc,psfile
    call read_error(ios,inline)
- end do
+
+   call cmtskp(inline)
+   do ii=1,nc+nv
+      read(5,*,iostat=ios) na(ii),la(ii),fa(ii)
+      call read_error(ios,inline)
+   end do
 
 ! pseudopotential and optimization
- call cmtskp(inline)
- read(5,*,iostat=ios) lmax
- call read_error(ios,inline)
-
- call cmtskp(inline)
- do l1=1,lmax+1
-   read(5,*,iostat=ios) lt,rc(l1),ep(l1),ncon(l1),nbas(l1),qcut(l1)
-   if(lt/=l1-1) ios=999
+   call cmtskp(inline)
+   read(5,*,iostat=ios) lmax
    call read_error(ios,inline)
- end do
+
+   call cmtskp(inline)
+   do l1=1,lmax+1
+      read(5,*,iostat=ios) lt,rc(l1),ep(l1),ncon(l1),nbas(l1),qcut(l1)
+      if(lt/=l1-1) ios=999
+      call read_error(ios,inline)
+   end do
 
 ! local potential
- call cmtskp(inline)
- read(5,*, iostat=ios) lloc,lpopt,rc(5),dvloc0
- call read_error(ios,inline)
+   call cmtskp(inline)
+   read(5,*, iostat=ios) lloc,lpopt,rc(5),dvloc0
+   call read_error(ios,inline)
 
 ! Vanderbilt-Kleinman-Bylander projectors
- call cmtskp(inline)
- do l1=1,lmax+1
-   read(5,*,iostat=ios) lt,nproj(l1),debl(l1)
-   if(lt/=l1-1) ios=999
-   call read_error(ios,inline)
- end do
+   call cmtskp(inline)
+   do l1=1,lmax+1
+      read(5,*,iostat=ios) lt,nproj(l1),debl(l1)
+      if(lt/=l1-1) ios=999
+      call read_error(ios,inline)
+   end do
 
 ! model core charge
- call cmtskp(inline)
- read(5,*, iostat=ios) icmod, fcfact
- if(ios==0 .and. icmod==3) then
-  backspace(5)
-  read(5,*, iostat=ios) icmod, fcfact, rcfact
- end if
- call read_error(ios,inline)
+   call cmtskp(inline)
+   read(5,*, iostat=ios) icmod, fcfact
+   if(ios==0 .and. icmod==3) then
+      backspace(5)
+      read(5,*, iostat=ios) icmod, fcfact, rcfact
+   end if
+   call read_error(ios,inline)
 
 ! log derivative analysis
- call cmtskp(inline)
- read(5,*,iostat=ios) epsh1, epsh2, depsh
- call read_error(ios,inline)
+   call cmtskp(inline)
+   read(5,*,iostat=ios) epsh1, epsh2, depsh
+   call read_error(ios,inline)
 
 ! output grid
- call cmtskp(inline)
- read(5,*,iostat=ios) rlmax,drl
- call read_error(ios,inline)
+   call cmtskp(inline)
+   read(5,*,iostat=ios) rlmax,drl
+   call read_error(ios,inline)
 
 ! test configurations
- call cmtskp(inline)
- read(5,*,iostat=ios) ncnf
- call read_error(ios,inline)
-
- do jj=2,ncnf+1
    call cmtskp(inline)
-   read(5,*,iostat=ios) nvcnf(jj)
+   read(5,*,iostat=ios) ncnf
    call read_error(ios,inline)
-   do ii=nc+1,nc+nvcnf(jj)
-     call cmtskp(inline)
-     read(5,*,iostat=ios) nacnf(ii,jj),lacnf(ii,jj),facnf(ii,jj)
-     call read_error(ios,inline)
+
+   do jj=2,ncnf+1
+      call cmtskp(inline)
+      read(5,*,iostat=ios) nvcnf(jj)
+      call read_error(ios,inline)
+      do ii=nc+1,nc+nvcnf(jj)
+         call cmtskp(inline)
+         read(5,*,iostat=ios) nacnf(ii,jj),lacnf(ii,jj),facnf(ii,jj)
+         call read_error(ios,inline)
+      end do
    end do
- end do
 
 ! end of reading input data
 
- nvcnf(1)=nv
- do ii=1,nc+nv
-   nacnf(ii,1)=na(ii)
-   lacnf(ii,1)=la(ii)
-   facnf(ii,1)=fa(ii)
- end do
-
- do jj=2,ncnf+1
-   do ii=1,nc
-     nacnf(ii,jj)=na(ii)
-     lacnf(ii,jj)=la(ii)
-     facnf(ii,jj)=fa(ii)
+   nvcnf(1)=nv
+   do ii=1,nc+nv
+      nacnf(ii,1)=na(ii)
+      lacnf(ii,1)=la(ii)
+      facnf(ii,1)=fa(ii)
    end do
- end do
 
- if(icmod==0) then
-   fcfact=0.0d0
- end if
+   do jj=2,ncnf+1
+      do ii=1,nc
+         nacnf(ii,jj)=na(ii)
+         lacnf(ii,jj)=la(ii)
+         facnf(ii,jj)=fa(ii)
+      end do
+   end do
 
- call check_data(atsym,zz,fcfact,rcfact,epsh1,epsh2,depsh,rlmax,drl,fa,facnf, &
-&                rc,ep,qcut,debl,nc,nv,iexc,lmax,lloc,lpopt,icmod, &
-&                ncnf,na,la,nvcnf,nacnf,lacnf,ncon,nbas,nproj,psfile)
+   if(icmod==0) then
+      fcfact=0.0d0
+   end if
 
- nrl=int((rlmax/drl)-0.5d0)+1
+   call check_data(atsym,zz,fcfact,rcfact,epsh1,epsh2,depsh,rlmax,drl,fa,facnf, &
+   &                rc,ep,qcut,debl,nc,nv,iexc,lmax,lloc,lpopt,icmod, &
+   &                ncnf,na,la,nvcnf,nacnf,lacnf,ncon,nbas,nproj,psfile)
+
+   nrl=int((rlmax/drl)-0.5d0)+1
 
 !PWSCF wants an even number of mesh pointe
 !if(trim(psfile)=='upf') then
-  if(mod(nrl,2)/=0) nrl=nrl+1
+   if(mod(nrl,2)/=0) nrl=nrl+1
 !end if
 
 !amesh=1.012d0
- amesh=1.006d0
+   amesh=1.006d0
 !amesh=1.003d0
 !amesh=1.0015d0
 
- mxprj=5
+   mxprj=5
 
- al=dlog(amesh)
- rr1=0.0005d0/zz
- rr1=dmin1(rr1,0.0005d0/10)
- mmax=dlog(45.0d0 /rr1)/al
+   al=dlog(amesh)
+   rr1=0.0005d0/zz
+   rr1=dmin1(rr1,0.0005d0/10)
+   mmax=dlog(45.0d0 /rr1)/al
 
 !calculate zion for output
- zion=zz
- do ii=1,nc
-  zion=zion-fa(ii)
- end do
+   zion=zz
+   do ii=1,nc
+      zion=zion-fa(ii)
+   end do
 
 
- allocate(rr(mmax))
- allocate(rho(mmax),rhoc(mmax),rhot(mmax))
- allocate(uu(mmax),up(mmax),uupsa(mmax,30))
- allocate(evkb(mxprj,4), cvgplt(2,7,mxprj,4),qq(mxprj,mxprj))
- allocate(vp(mmax,5),vfull(mmax),vkb(mmax,mxprj,4),pswf(mmax,mxprj,4))
- allocate(vwell(mmax))
- allocate(vpuns(mmax,5))
- allocate(vo(mmax),vxc(mmax))
- allocate(rhoae(mmax,nv),rhops(mmax,nv),rhotae(mmax))
- allocate(npa(mxprj,6))
- allocate(epa(mxprj,6),fpa(mxprj,6))
- allocate(uua(mmax,mxprj),upa(mmax,mxprj))
- allocate(vr(mmax,mxprj,6))
+   allocate(rr(mmax))
+   allocate(rho(mmax),rhoc(mmax),rhot(mmax))
+   allocate(uu(mmax),up(mmax),uupsa(mmax,30))
+   allocate(evkb(mxprj,4), cvgplt(2,7,mxprj,4),qq(mxprj,mxprj))
+   allocate(vp(mmax,5),vfull(mmax),vkb(mmax,mxprj,4),pswf(mmax,mxprj,4))
+   allocate(vwell(mmax))
+   allocate(vpuns(mmax,5))
+   allocate(vo(mmax),vxc(mmax))
+   allocate(rhoae(mmax,nv),rhops(mmax,nv),rhotae(mmax))
+   allocate(npa(mxprj,6))
+   allocate(epa(mxprj,6),fpa(mxprj,6))
+   allocate(uua(mmax,mxprj),upa(mmax,mxprj))
+   allocate(vr(mmax,mxprj,6))
 
- vr(:,:,:)=0.0d0
- vp(:,:)=0.0d0
- vkb(:,:,:)=0.0d0
- epa(:,:)=0.0d0
+   vr(:,:,:)=0.0d0
+   vp(:,:)=0.0d0
+   vkb(:,:,:)=0.0d0
+   epa(:,:)=0.0d0
 
- do ii=1,mmax
-  rr(ii)=rr1*exp(al*(ii-1))
- end do
+   do ii=1,mmax
+      rr(ii)=rr1*exp(al*(ii-1))
+   end do
 
 !
 ! full potential atom solution
 !
    call sratom(na,la,ea,fa,rpk,nc,nc+nv,it,rhoc,rho, &
-&              rr,vfull,zz,mmax,iexc,etot,ierr,srel)
+   &              rr,vfull,zz,mmax,iexc,etot,ierr,srel)
 !
 !
 
 ! Drop digits beyond 5 decimals for input rcs before making any use of them
- do l1=1,max(lmax+1,lloc+1)
-    jj=int(rc(l1)*10.0d5)
-    rc(l1)=jj/10.0d5
- end do
+   do l1=1,max(lmax+1,lloc+1)
+      jj=int(rc(l1)*10.0d5)
+      rc(l1)=jj/10.0d5
+   end do
 
- rcmax=0.0d0
- do l1=1,lmax+1
-   rcmax=dmax1(rcmax,rc(l1))
- end do
- do l1=1,lmax+1
-   if(rc(l1)==0.0d0) then
-     rc(l1)=rcmax
-   end if
- end do
+   rcmax=0.0d0
+   do l1=1,lmax+1
+      rcmax=dmax1(rcmax,rc(l1))
+   end do
+   do l1=1,lmax+1
+      if(rc(l1)==0.0d0) then
+         rc(l1)=rcmax
+      end if
+   end do
 
- nproj(lloc+1)=0
- rc0(:)=rc(:)
+   nproj(lloc+1)=0
+   rc0(:)=rc(:)
 
 ! output printing (echos input data, with all-electron eigenvalues added)
 
- write(6,'(a)') '# ATOM AND REFERENCE CONFIGURATION'
- write(6,'(a)') '# atsym  z   nc   nv     iexc    psfile'
- write(6,'(a,a,f6.2,2i5,i8,2a)') '  ',trim(atsym),zz,nc,nv,iexc, &
-&      '      ',psfile
- write(6,'(a/a)') '#','#   n    l    f        energy (Ha)'
- do ii=1,nc+nv
-   write(6,'(2i5,f8.2,1pe18.7)') na(ii),la(ii),fa(ii),ea(ii)
- end do
-
- write(6,'(a/a/a)') '#','# PSEUDOPOTENTIAL AND OPTIMIZATION','# lmax'
- write(6,'(i5)')  lmax
- write(6,'(a/a)') '#','#   l,   rc,      ep,       ncon, nbas, qcut'
- do l1=1,lmax+1
-   write(6,'(i5,2f10.5,2i5,f10.5)') l1-1,rc(l1),ep(l1),ncon(l1),&
-&        nbas(l1),qcut(l1)
- end do
-
- write(6,'(a/a/a,a)') '#','# LOCAL POTENTIAL','# lloc, lpopt,  rc(5),', &
-&      '   dvloc0'
- write(6,'(2i5,f10.5,a,f10.5)') lloc,lpopt,rc(5),'   ',dvloc0
-
- write(6,'(a/a/a)') '#','# VANDERBILT-KLEINMAN-BYLANDER PROJECTORs', &
-&      '# l, nproj, debl'
- do l1=1,lmax+1
-   write(6,'(2i5,f10.5)') l1-1,nproj(l1),debl(l1)
- end do
-
- write(6,'(a/a/a)') '#','# MODEL CORE CHARGE', &
-&      '# icmod, fcfact, rcfact'
- write(6,'(i5,2f10.5)') icmod,fcfact,rcfact
-
- write(6,'(a/a/a)') '#','# LOG DERIVATIVE ANALYSIS', &
-&      '# epsh1, epsh2, depsh'
- write(6,'(3f8.2)') epsh1,epsh2,depsh
-
- write(6,'(a/a/a)') '#','# OUTPUT GRID','# rlmax, drl'
- write(6,'(2f8.4)') rlmax,drl
-
- write(6,'(a/a/a)') '#','# TEST CONFIGURATIONS','# ncnf'
- write(6,'(i5)') ncnf
- write(6,'(a/a)') '# nvcnf','#   n    l    f'
- do jj=2,ncnf+1
-   write(6,'(i5)') nvcnf(jj)
-   do ii=nc+1,nc+nvcnf(jj)
-     write(6,'(2i5,f8.2)') nacnf(ii,jj),lacnf(ii,jj),facnf(ii,jj)
+   write(6,'(a)') '# ATOM AND REFERENCE CONFIGURATION'
+   write(6,'(a)') '# atsym  z   nc   nv     iexc    psfile'
+   write(6,'(a,a,f6.2,2i5,i8,2a)') '  ',trim(atsym),zz,nc,nv,iexc, &
+   &      '      ',psfile
+   write(6,'(a/a)') '#','#   n    l    f        energy (Ha)'
+   do ii=1,nc+nv
+      write(6,'(2i5,f8.2,1pe18.7)') na(ii),la(ii),fa(ii),ea(ii)
    end do
-   write(6,'(a)') '#'
- end do
 
- write(6,'(//a)') 'Reference configufation results'
- write(6,'(a,i6)') '  iterations',it
- if(it .ge. 100) then
-  write(6,'(a)') 'oncvpsp: ERROR all-electron reference atom not converged'
-  stop
- end if
- write(6,'(a,1p,d18.8)') '  all-electron total energy (Ha)',etot
-  
-!find log mesh point nearest input rc
- rcmax=0.0d0
- irc(:)=0
- do l1=1,max(lmax+1,lloc+1)
-  rct=rc(l1)
-  irc(l1)=0
-  do ii=2,mmax
-   if(rr(ii)>rct) then
-    irc(l1)=ii
-    rc(l1)=rr(ii)
-    exit
+   write(6,'(a/a/a)') '#','# PSEUDOPOTENTIAL AND OPTIMIZATION','# lmax'
+   write(6,'(i5)')  lmax
+   write(6,'(a/a)') '#','#   l,   rc,      ep,       ncon, nbas, qcut'
+   do l1=1,lmax+1
+      write(6,'(i5,2f10.5,2i5,f10.5)') l1-1,rc(l1),ep(l1),ncon(l1),&
+      &        nbas(l1),qcut(l1)
+   end do
+
+   write(6,'(a/a/a,a)') '#','# LOCAL POTENTIAL','# lloc, lpopt,  rc(5),', &
+   &      '   dvloc0'
+   write(6,'(2i5,f10.5,a,f10.5)') lloc,lpopt,rc(5),'   ',dvloc0
+
+   write(6,'(a/a/a)') '#','# VANDERBILT-KLEINMAN-BYLANDER PROJECTORs', &
+   &      '# l, nproj, debl'
+   do l1=1,lmax+1
+      write(6,'(2i5,f10.5)') l1-1,nproj(l1),debl(l1)
+   end do
+
+   write(6,'(a/a/a)') '#','# MODEL CORE CHARGE', &
+   &      '# icmod, fcfact, rcfact'
+   write(6,'(i5,2f10.5)') icmod,fcfact,rcfact
+
+   write(6,'(a/a/a)') '#','# LOG DERIVATIVE ANALYSIS', &
+   &      '# epsh1, epsh2, depsh'
+   write(6,'(3f8.2)') epsh1,epsh2,depsh
+
+   write(6,'(a/a/a)') '#','# OUTPUT GRID','# rlmax, drl'
+   write(6,'(2f8.4)') rlmax,drl
+
+   write(6,'(a/a/a)') '#','# TEST CONFIGURATIONS','# ncnf'
+   write(6,'(i5)') ncnf
+   write(6,'(a/a)') '# nvcnf','#   n    l    f'
+   do jj=2,ncnf+1
+      write(6,'(i5)') nvcnf(jj)
+      do ii=nc+1,nc+nvcnf(jj)
+         write(6,'(2i5,f8.2)') nacnf(ii,jj),lacnf(ii,jj),facnf(ii,jj)
+      end do
+      write(6,'(a)') '#'
+   end do
+
+   write(6,'(//a)') 'Reference configufation results'
+   write(6,'(a,i6)') '  iterations',it
+   if(it >= 100) then
+      write(6,'(a)') 'oncvpsp: ERROR all-electron reference atom not converged'
+      stop
    end if
-  end do
-  rcmax=dmax1(rcmax,rc(l1))
- end do
+   write(6,'(a,1p,d18.8)') '  all-electron total energy (Ha)',etot
+
+!find log mesh point nearest input rc
+   rcmax=0.0d0
+   irc(:)=0
+   do l1=1,max(lmax+1,lloc+1)
+      rct=rc(l1)
+      irc(l1)=0
+      do ii=2,mmax
+         if(rr(ii)>rct) then
+            irc(l1)=ii
+            rc(l1)=rr(ii)
+            exit
+         end if
+      end do
+      rcmax=dmax1(rcmax,rc(l1))
+   end do
 
 !
- cvgplt(:,:,:,:)=0.0d0
+   cvgplt(:,:,:,:)=0.0d0
 !
 ! loop to construct pseudopotentials for all angular momenta
 !
- write(6,'(/a/a)') 'Begin loop to  construct optimized pseudo wave functions',&
-&      'and semi-local pseudopoentials for all angular momenta'
+   write(6,'(/a/a)') 'Begin loop to  construct optimized pseudo wave functions',&
+   &      'and semi-local pseudopoentials for all angular momenta'
 
 !temporarily set this to 1 so that the pseudo wave function needed for the
 !local potential will be generated.  Reset after run_vkb.
- nproj(lloc+1)=1
- do l1=1,lmax+1
-   ll=l1-1
-   uu(:)=0.0d0; qq(:,:)=0.0d0
-   iprj=0
+   nproj(lloc+1)=1
+   do l1=1,lmax+1
+      ll=l1-1
+      uu(:)=0.0d0; qq(:,:)=0.0d0
+      iprj=0
 
 !get principal quantum number for the highest core state for this l
-   npa(1,l1)=l1
-   do kk=1,nc
-     if(la(kk)==l1-1) npa(1,l1)=na(kk)+1
-   end do !kk
+      npa(1,l1)=l1
+      do kk=1,nc
+         if(la(kk)==l1-1) npa(1,l1)=na(kk)+1
+      end do  !kk
 
 !get all-electron bound states for projectors
-   if(nv/=0) then
-     do kk=nc+1,nc+nv
-       if(la(kk)==l1-1) then
-         iprj=iprj+1
-         et=ea(kk)
-         call lschfb(na(kk),la(kk),ierr,et, &
-&                      rr,vfull,uu,up,zz,mmax,mch,srel)
-         if(ierr /= 0) then
-           write(6,'(/a,3i4)') 'oncvpsp-387: lschfb convergence ERROR n,l,iter=', &
-&           na(ii),la(ii),it
-           stop
-         end if
-         epa(iprj,l1)=ea(kk)
-         npa(iprj,l1)=na(kk)
-         uua(:,iprj)=uu(:)
-         upa(:,iprj)=up(:)
-       end if !la(kk)==l1-1
-       if(iprj==nproj(l1)) exit
-     end do !kk
-   end if !nv/=0
+      if(nv/=0) then
+         do kk=nc+1,nc+nv
+            if(la(kk)==l1-1) then
+               iprj=iprj+1
+               et=ea(kk)
+               call lschfb(na(kk),la(kk),ierr,et, &
+               &                      rr,vfull,uu,up,zz,mmax,mch,srel)
+               if(ierr /= 0) then
+                  write(6,'(/a,3i4)') 'oncvpsp-387: lschfb convergence ERROR n,l,iter=', &
+                  &           na(ii),la(ii),it
+                  stop
+               end if
+               epa(iprj,l1)=ea(kk)
+               npa(iprj,l1)=na(kk)
+               uua(:,iprj)=uu(:)
+               upa(:,iprj)=up(:)
+            end if  !la(kk)==l1-1
+            if(iprj==nproj(l1)) exit
+         end do  !kk
+      end if  !nv/=0
 
 !get all-electron well states for projectors
 !if there were no valence states, use ep from input data for 1st well state
 !otherwise shift up by input debl
-   if(iprj==0) epa(1,l1)=ep(l1)
-   if(iprj<nproj(l1))then
-     do kk=1,nproj(l1)-iprj
-       iprj=iprj+1
-       if(iprj>1 .and. debl(l1)<=0.0d0) then
-         write(6,'(a,f8.3,a/a)') 'oncvpsp: ERROR debl =',debl, 'for l=', &
-&              ' ERROR not allowed with 2 or more scattering states', &
-&              'program will stop'
-         stop
-       end if
-       if(iprj>1) then
-         epa(iprj,l1)=epa(iprj-1,l1)+debl(l1)
-         npa(iprj,l1)=npa(iprj-1,l1)+1
-       end if
+      if(iprj==0) epa(1,l1)=ep(l1)
+      if(iprj<nproj(l1))then
+         do kk=1,nproj(l1)-iprj
+            iprj=iprj+1
+            if(iprj>1 .and. debl(l1)<=0.0d0) then
+               write(6,'(a,f8.3,a/a)') 'oncvpsp: ERROR debl =',debl, 'for l=', &
+               &              ' ERROR not allowed with 2 or more scattering states', &
+               &              'program will stop'
+               stop
+            end if
+            if(iprj>1) then
+               epa(iprj,l1)=epa(iprj-1,l1)+debl(l1)
+               npa(iprj,l1)=npa(iprj-1,l1)+1
+            end if
 
-       call wellstate(npa(iprj,l1),ll,irc(l1),epa(iprj,l1),rr, &
-&                     vfull,uu,up,zz,mmax,mch,srel)
-       uua(:,iprj)=uu(:)
-       upa(:,iprj)=up(:)
-     end do !kk
-   end if !iprj<nproj(l1)
+            call wellstate(npa(iprj,l1),ll,irc(l1),epa(iprj,l1),rr, &
+            &                     vfull,uu,up,zz,mmax,mch,srel)
+            uua(:,iprj)=uu(:)
+            upa(:,iprj)=up(:)
+         end do  !kk
+      end if  !iprj<nproj(l1)
 
-   do iprj=1,nproj(l1)
+      do iprj=1,nproj(l1)
 
 !calculate relativistic correction to potential to force projectors to 0 at rc
-     call vrel(ll,epa(iprj,l1),rr,vfull,vr(1,iprj,l1),uua(1,iprj),upa(1,iprj), &
-&              zz,mmax,irc(l1),srel)
+         call vrel(ll,epa(iprj,l1),rr,vfull,vr(1,iprj,l1),uua(1,iprj),upa(1,iprj), &
+         &              zz,mmax,irc(l1),srel)
 
-   end do
+      end do
 
 !get all-electron overlap matrix
-   do jj=1,nproj(l1)
-     do ii=1,jj
-       call fpovlp(uua(1,ii),uua(1,jj),irc(l1),ll,zz,qq(ii,jj),rr,srel)
-       qq(jj,ii)=qq(ii,jj)
-     end do
-   end do
+      do jj=1,nproj(l1)
+         do ii=1,jj
+            call fpovlp(uua(1,ii),uua(1,jj),irc(l1),ll,zz,qq(ii,jj),rr,srel)
+            qq(jj,ii)=qq(ii,jj)
+         end do
+      end do
 
-   call run_optimize(epa(1,l1),ll,mmax,mxprj,rr,uua,qq, &
-&                    irc(l1),qcut(l1),qmsbf(l1),ncon(l1),nbas(l1),nproj(l1), &
-&                    pswf(1,1,l1),vp(1,l1),vkb(1,1,l1),vfull,cvgplt(1,1,1,l1))
+      call run_optimize(epa(1,l1),ll,mmax,mxprj,rr,uua,qq, &
+      &                    irc(l1),qcut(l1),qmsbf(l1),ncon(l1),nbas(l1),nproj(l1), &
+      &                    pswf(1,1,l1),vp(1,l1),vkb(1,1,l1),vfull,cvgplt(1,1,1,l1))
 
- end do !l1
+   end do  !l1
 
 ! construct Vanderbilt / Kleinman-Bylander projectors
 
- write(6,'(/a,a)') 'Construct Vanderbilt / Kleinmman-Bylander projectors'
+   write(6,'(/a,a)') 'Construct Vanderbilt / Kleinmman-Bylander projectors'
 
- call run_vkb(lmax,lloc,lpopt,dvloc0,irc,nproj,rr,mmax,mxprj,pswf,vfull,vp, &
-&             evkb,vkb,nlim,vr)
+   call run_vkb(lmax,lloc,lpopt,dvloc0,irc,nproj,rr,mmax,mxprj,pswf,vfull,vp, &
+   &             evkb,vkb,nlim,vr)
 
 !restore this to its proper value
- nproj(lloc+1)=0
+   nproj(lloc+1)=0
 
- deallocate(uua,upa)
+   deallocate(uua,upa)
 
 ! accumulate charge and eigenvalues
 ! pseudo wave functions are calculated with VKB projectors for
@@ -466,208 +466,208 @@
 ! charge densities
 
 ! null charge and eigenvalue accumulators
- uupsa(:,:)=0.0d0
- eeig=0.0d0
- zval=0.0d0
- rho(:)=0.0d0
- nodes(:)=0
- rhotae(:)=0.0d0
- irps=0
- do kk=1,nv
+   uupsa(:,:)=0.0d0
+   eeig=0.0d0
+   zval=0.0d0
+   rho(:)=0.0d0
+   nodes(:)=0
+   rhotae(:)=0.0d0
+   irps=0
+   do kk=1,nv
 
-   et=ea(nc+kk)
-   ll=la(nc+kk)
-   l1=ll+1
-   call lschfb(na(nc+kk),ll,ierr,et, &
-&                rr,vfull,uu,up,zz,mmax,mch,srel)
-   if(ierr /= 0) then
-     write(6,'(/a,3i4)') 'oncvpsp-461: lschfb convergence ERROR n,l,iter=', &
-&     na(ii),la(ii),it
-     stop
-   end if
+      et=ea(nc+kk)
+      ll=la(nc+kk)
+      l1=ll+1
+      call lschfb(na(nc+kk),ll,ierr,et, &
+      &                rr,vfull,uu,up,zz,mmax,mch,srel)
+      if(ierr /= 0) then
+         write(6,'(/a,3i4)') 'oncvpsp-461: lschfb convergence ERROR n,l,iter=', &
+         &     na(ii),la(ii),it
+         stop
+      end if
 
-   rhoae(:,kk)=(uu(:)/rr(:))**2
+      rhoae(:,kk)=(uu(:)/rr(:))**2
 
-   rhotae(:)=rhotae(:) + fa(nc+kk)*rhoae(:,kk)
+      rhotae(:)=rhotae(:) + fa(nc+kk)*rhoae(:,kk)
 
-   emax=0.75d0*et
-   emin=1.25d0*et
+      emax=0.75d0*et
+      emin=1.25d0*et
 
-   call lschvkbb(ll+nodes(l1)+1,ll,nproj(l1),ierr,et,emin,emax, &
-&                rr,vp(1,lloc+1),vkb(1,1,l1),evkb(1,l1), &
-&                uu,up,mmax,mch)
+      call lschvkbb(ll+nodes(l1)+1,ll,nproj(l1),ierr,et,emin,emax, &
+      &                rr,vp(1,lloc+1),vkb(1,1,l1),evkb(1,l1), &
+      &                uu,up,mmax,mch)
 
-   if(ierr/=0) then 
-     write(6,'(a,3i4)') 'oncvpsp: lschvkbb ERROR',ll+nodes(l1)+1,ll,ierr
-     flush(6)
-     stop
-   end if
+      if(ierr/=0) then
+         write(6,'(a,3i4)') 'oncvpsp: lschvkbb ERROR',ll+nodes(l1)+1,ll,ierr
+         flush(6)
+         stop
+      end if
 
 ! save valence pseudo wave functions for upfout
-   uupsa(:,kk)=uu(:)
+      uupsa(:,kk)=uu(:)
 
-   rhops(:,kk)=(uu(:)/rr(:))**2
-   rho(:)=rho(:)+fa(nc+kk)*rhops(:,kk)
-   eeig=eeig+fa(nc+kk)*et
+      rhops(:,kk)=(uu(:)/rr(:))**2
+      rho(:)=rho(:)+fa(nc+kk)*rhops(:,kk)
+      eeig=eeig+fa(nc+kk)*et
 
-   zval=zval+fa(nc+kk)
-   nodes(l1)=nodes(l1)+1
-   irps=max(irps,irc(l1))
- end do !kk
+      zval=zval+fa(nc+kk)
+      nodes(l1)=nodes(l1)+1
+      irps=max(irps,irc(l1))
+   end do  !kk
 
- allocate(rhomod(mmax,5))
+   allocate(rhomod(mmax,5))
 
- rhomod(:,:)=0.0d0
+   rhomod(:,:)=0.0d0
 
 ! construct model core charge based on monotonic polynomial fit
 ! or Teter function fit
 
- if(icmod==1) then
-   call modcore(icmod,rhops,rho,rhoc,rhoae,rhotae,rhomod, &
-&               fcfact,rcfact,irps,mmax,rr,nc,nv,la,zion,iexc)
+   if(icmod==1) then
+      call modcore(icmod,rhops,rho,rhoc,rhoae,rhotae,rhomod, &
+      &               fcfact,rcfact,irps,mmax,rr,nc,nv,la,zion,iexc)
 
- else if(icmod==2) then
-   call modcore2(icmod,rhops,rho,rhoc,rhoae,rhotae,rhomod, &
-&               fcfact,rcfact,irps,mmax,rr,nc,nv,la,zion,iexc)
+   else if(icmod==2) then
+      call modcore2(icmod,rhops,rho,rhoc,rhoae,rhotae,rhomod, &
+      &               fcfact,rcfact,irps,mmax,rr,nc,nv,la,zion,iexc)
 
- else if(icmod>=3) then
-   call modcore3(icmod,rhops,rho,rhoc,rhoae,rhotae,rhomod, &
-&               fcfact,rcfact,irps,mmax,rr,nc,nv,la,zion,iexc)
+   else if(icmod>=3) then
+      call modcore3(icmod,rhops,rho,rhoc,rhoae,rhotae,rhomod, &
+      &               fcfact,rcfact,irps,mmax,rr,nc,nv,la,zion,iexc)
 
- end if
+   end if
 
 ! screening potential for pseudocharge
 
- call vout(1,rho,rhomod(1,1),vo,vxc,zval,eeel,eexc,rr,mmax,iexc)
+   call vout(1,rho,rhomod(1,1),vo,vxc,zval,eeel,eexc,rr,mmax,iexc)
 
 ! total energy output
 
- epstot= eeig + eexc - 0.5d0*eeel
- write(6,'(/a,f12.6/)') 'Pseudoatom total energy', epstot
+   epstot= eeig + eexc - 0.5d0*eeel
+   write(6,'(/a,f12.6/)') 'Pseudoatom total energy', epstot
 
- call run_diag(lmax,npa,epa,lloc,irc, &
-&                    vkb,evkb,nproj,rr,vfull,vp,zz,mmax,mxprj,srel)
+   call run_diag(lmax,npa,epa,lloc,irc, &
+   &                    vkb,evkb,nproj,rr,vfull,vp,zz,mmax,mxprj,srel)
 
- call run_ghosts(lmax,la,ea,nc,nv,lloc,irc,qmsbf, &
-&                    vkb,evkb,nproj,rr,vp,mmax,mxprj)
+   call run_ghosts(lmax,la,ea,nc,nv,lloc,irc,qmsbf, &
+   &                    vkb,evkb,nproj,rr,vp,mmax,mxprj)
 
 ! unscreen semi-local potentials
 
- do l1=1,max(lmax+1,lloc+1)
-   vpuns(:,l1)=vp(:,l1)-vo(:)
- end do
+   do l1=1,max(lmax+1,lloc+1)
+      vpuns(:,l1)=vp(:,l1)-vo(:)
+   end do
 
 !fix unscreening error due to greater range of all-electron charge
- do ii=mmax,1,-1
-   if(rho(ii)==0.0d0) then 
-     do l1=1,max(lmax+1,lloc+1)
-       vpuns(ii,l1)=-zion/rr(ii)
-     end do
-   else
-     exit
-   end if
- end do
+   do ii=mmax,1,-1
+      if(rho(ii)==0.0d0) then
+         do l1=1,max(lmax+1,lloc+1)
+            vpuns(ii,l1)=-zion/rr(ii)
+         end do
+      else
+         exit
+      end if
+   end do
 
 
 ! loop over reference plus test atom configurations
 !if(.false.) then
 
 !ncnf=0
- rhot(:)=rho(:)
- do jj=1,ncnf+1
+   rhot(:)=rho(:)
+   do jj=1,ncnf+1
 
-   write(6,'(/a,i2)') 'Test configuration',jj-1
+      write(6,'(/a,i2)') 'Test configuration',jj-1
 
 ! charge density is initialized to that of reference configuration
 
-   rhot(:)=rho(:)
+      rhot(:)=rho(:)
 
-   call run_config(jj,nacnf,lacnf,facnf,nc,nvcnf,rhot,rhomod,rr,zz, &
-&                  rcmax,mmax,mxprj,iexc,ea,etot,epstot,nproj,vpuns, &
-&                  lloc,vkb,evkb,srel)
+      call run_config(jj,nacnf,lacnf,facnf,nc,nvcnf,rhot,rhomod,rr,zz, &
+      &                  rcmax,mmax,mxprj,iexc,ea,etot,epstot,nproj,vpuns, &
+      &                  lloc,vkb,evkb,srel)
 
- end do !jj
+   end do  !jj
 
- call run_plot(lmax,npa,epa,lloc,irc, &
-&                    vkb,evkb,nproj,rr,vfull,vp,vpuns,zz,mmax,mxprj,drl,nrl, &
-&                    rho,rhoc,rhomod,srel,cvgplt)
-
-
-
- call run_phsft(lmax,lloc,nproj,epa,epsh1,epsh2,depsh,vkb,evkb, &
-&               rr,vfull,vp,zz,mmax,mxprj,irc,srel)
- 
- call gnu_script(epa,evkb,lmax,lloc,mxprj,nproj)
-
- if(trim(psfile)=='psp8' .or. trim(psfile)=='both') then
+   call run_plot(lmax,npa,epa,lloc,irc, &
+   &                    vkb,evkb,nproj,rr,vfull,vp,vpuns,zz,mmax,mxprj,drl,nrl, &
+   &                    rho,rhoc,rhomod,srel,cvgplt)
 
 
-  call linout(lmax,lloc,rc,vkb,evkb,nproj,rr,vpuns,rho,rhomod, &
-&             rhotae,rhoc,zz,zion,mmax,mxprj,iexc,icmod,nrl,drl,atsym, &
-&             na,la,ncon,nbas,nvcnf,nacnf,lacnf,nc,nv,lpopt,ncnf, &
-&             fa,rc0,ep,qcut,debl,facnf,dvloc0,fcfact,rcfact, &
-&             epsh1,epsh2,depsh,rlmax,psfile)
- end if
 
- if(trim(psfile)=='upf' .or. trim(psfile)=='both') then
-  call upfout(lmax,lloc,rc,vkb,evkb,nproj,rr,vpuns,rho,rhomod, &
-&             zz,zion,mmax,mxprj,iexc,icmod,nrl,drl,atsym,epstot, &
-&             na,la,ncon,nbas,nvcnf,nacnf,lacnf,nc,nv,lpopt,ncnf, &
-&             fa,rc0,ep,qcut,debl,facnf,dvloc0,fcfact,rcfact, &
-&             epsh1,epsh2,depsh,rlmax,psfile,uupsa,ea)
- end if
+   call run_phsft(lmax,lloc,nproj,epa,epsh1,epsh2,depsh,vkb,evkb, &
+   &               rr,vfull,vp,zz,mmax,mxprj,irc,srel)
 
- if(trim(psfile)=='psml' .or. trim(psfile)=='both') then
+   call gnu_script(epa,evkb,lmax,lloc,mxprj,nproj)
+
+   if(trim(psfile)=='psp8' .or. trim(psfile)=='both') then
+
+
+      call linout(lmax,lloc,rc,vkb,evkb,nproj,rr,vpuns,rho,rhomod, &
+      &             rhotae,rhoc,zz,zion,mmax,mxprj,iexc,icmod,nrl,drl,atsym, &
+      &             na,la,ncon,nbas,nvcnf,nacnf,lacnf,nc,nv,lpopt,ncnf, &
+      &             fa,rc0,ep,qcut,debl,facnf,dvloc0,fcfact,rcfact, &
+      &             epsh1,epsh2,depsh,rlmax,psfile)
+   end if
+
+   if(trim(psfile)=='upf' .or. trim(psfile)=='both') then
+      call upfout(lmax,lloc,rc,vkb,evkb,nproj,rr,vpuns,rho,rhomod, &
+      &             zz,zion,mmax,mxprj,iexc,icmod,nrl,drl,atsym,epstot, &
+      &             na,la,ncon,nbas,nvcnf,nacnf,lacnf,nc,nv,lpopt,ncnf, &
+      &             fa,rc0,ep,qcut,debl,facnf,dvloc0,fcfact,rcfact, &
+      &             epsh1,epsh2,depsh,rlmax,psfile,uupsa,ea)
+   end if
+
+   if(trim(psfile)=='psml' .or. trim(psfile)=='both') then
 !
 ! Write info for PSML format
 !
-   print *, 'calling psmlout'
-   call psmlout(lmax,lloc,rc,vkb,evkb,nproj,rr,vpuns,rho,rhomod, &
-&             irct, srel, &
-&             zz,zion,mmax,iexc,icmod,nrl,drl,atsym,epstot, &
-&             na,la,ncon,nbas,nvcnf,nacnf,lacnf,nc,nv,lpopt,ncnf, &
-&             fa,rc0,ep,qcut,debl,facnf,dvloc0,fcfact, &
-&             epsh1,epsh2,depsh,rlmax,psfile)
- end if
+      print *, 'calling psmlout'
+      call psmlout(lmax,lloc,rc,vkb,evkb,nproj,rr,vpuns,rho,rhomod, &
+      &             irct, srel, &
+      &             zz,zion,mmax,iexc,icmod,nrl,drl,atsym,epstot, &
+      &             na,la,ncon,nbas,nvcnf,nacnf,lacnf,nc,nv,lpopt,ncnf, &
+      &             fa,rc0,ep,qcut,debl,facnf,dvloc0,fcfact, &
+      &             epsh1,epsh2,depsh,rlmax,psfile)
+   end if
 
- stop
- end program oncvpsp
+   stop
+end program oncvpsp
 
 
- subroutine cmtskp(inline)
+subroutine cmtskp(inline)
 ! skips lines of standard input (file 5) whose first character is #
- implicit none
+   implicit none
 
 !In/Out variable
- integer :: inline
+   integer :: inline
 
 !Local variable
- character*1 tst
+   character(len=1) :: tst
 
- tst='#'
- do while (tst=='#')
-  read(5,*) tst
-  inline=inline+1
- end do
- backspace(5)
- inline=inline-1
+   tst='#'
+   do while (tst=='#')
+      read(5,*) tst
+      inline=inline+1
+   end do
+   backspace(5)
+   inline=inline-1
 
- return
- end subroutine cmtskp
+   return
+end subroutine cmtskp
 
- subroutine read_error(ios,inline)
+subroutine read_error(ios,inline)
 ! report data read error and stop
- implicit none
+   implicit none
 
 !Input variables
- integer :: ios,inline
+   integer :: ios,inline
 
- inline=inline+1
- if(ios/=0) then
-  write(6,'(a,i4)') 'Read ERROR, input data file line',inline
-  write(6,'(a)') 'Program will stop'
-  stop
- end if
+   inline=inline+1
+   if(ios/=0) then
+      write(6,'(a,i4)') 'Read ERROR, input data file line',inline
+      write(6,'(a)') 'Program will stop'
+      stop
+   end if
 
- return
- end subroutine read_error
+   return
+end subroutine read_error

--- a/src/oncvpsp_r.f90
+++ b/src/oncvpsp_r.f90
@@ -2,21 +2,21 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- program oncvpsp_r
+program oncvpsp_r
 !
 ! Creates and tests optimized norm-conserving Vanderbilt or Kleinman-Bylander
 ! pseudopotentials based on D. R. Hamann, Phys. Rev. B 88, 085117 (2013)
@@ -32,772 +32,772 @@
 !
 !   Output format for ABINIT pspcod=8 and upf format for quantumespresso
 !
- use m_psmlout, only: psmlout_r
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   use m_psmlout, only: psmlout_r
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !
- integer :: ii,ierr,iexc,iexct,ios,iprint,irps,it,icmod,lpopt
- integer :: jj,kk,ll,l1,lloc,lmax,lt,inline
- integer :: mch,mchf,mmax,n1,n2,nc,nlim,nlloc,nlmax,irpsh,nrl
- integer :: nv,irct,ncnf,nvt
- integer :: ikap,kap,mkap
- integer :: iprj,mxprj
- integer,allocatable :: npa(:,:)
+   integer :: ii,ierr,iexc,iexct,ios,iprint,irps,it,icmod,lpopt
+   integer :: jj,kk,ll,l1,lloc,lmax,lt,inline
+   integer :: mch,mchf,mmax,n1,n2,nc,nlim,nlloc,nlmax,irpsh,nrl
+   integer :: nv,irct,ncnf,nvt
+   integer :: ikap,kap,mkap
+   integer :: iprj,mxprj
+   integer,allocatable :: npa(:,:)
 !
- integer :: dtime(8),na(30),la(30),np(6)
- integer :: nacnf(30,5),lacnf(30,5),nvcnf(5)
- integer :: nat(30),lat(30)
- integer :: irc(6),nodes(4)
- integer :: nproj(6)
- integer :: ncon(6),nbas(6)
+   integer :: dtime(8),na(30),la(30),np(6)
+   integer :: nacnf(30,5),lacnf(30,5),nvcnf(5)
+   integer :: nat(30),lat(30)
+   integer :: irc(6),nodes(4)
+   integer :: nproj(6)
+   integer :: ncon(6),nbas(6)
 
- real(dp) :: al,amesh,csc,csc1,depsh,depsht,drl,eeel,fj
- real(dp) :: eeig,eexc
- real(dp) :: emax,epsh1,epsh1t,epsh2,epsh2t
- real(dp) :: et,etest,emin,sls
- real(dp) :: fcfact,rcfact,dvloc0,soscale
- real(dp) :: rr1,rcion,rciont,rcmax,rct,rlmax,rpkt
- real(dp) :: sf,zz,zion,zval,etot
- real(dp) :: cnorm,ebar,eprmin
- real(dp) :: xdummy
+   real(dp) :: al,amesh,csc,csc1,depsh,depsht,drl,eeel,fj
+   real(dp) :: eeig,eexc
+   real(dp) :: emax,epsh1,epsh1t,epsh2,epsh2t
+   real(dp) :: et,etest,emin,sls
+   real(dp) :: fcfact,rcfact,dvloc0,soscale
+   real(dp) :: rr1,rcion,rciont,rcmax,rct,rlmax,rpkt
+   real(dp) :: sf,zz,zion,zval,etot
+   real(dp) :: cnorm,ebar,eprmin
+   real(dp) :: xdummy
 !
- real(dp) :: cl(6),debl(6),ea(30,2),eacopy(30,2),ep(6,2),fa(30),facnf(30,5)
- real(dp) :: qcut(6),qmsbf(6),rc(6),rc0(6)
- real(dp) :: rpk(30,2)
- real(dp) :: epstot,eps_srso
- real(dp), parameter :: eps=1.0d-8
+   real(dp) :: cl(6),debl(6),ea(30,2),eacopy(30,2),ep(6,2),fa(30),facnf(30,5)
+   real(dp) :: qcut(6),qmsbf(6),rc(6),rc0(6)
+   real(dp) :: rpk(30,2)
+   real(dp) :: epstot,eps_srso
+   real(dp), parameter :: eps=1.0d-8
 
- real(dp), allocatable :: evkb(:,:,:),cvgplt(:,:,:,:,:),qq(:,:)
- real(dp), allocatable :: rr(:)
- real(dp), allocatable :: rho(:),rhoc(:),rhot(:)
- real(dp), allocatable :: uu(:,:),up(:,:)
- real(dp), allocatable :: vp(:,:,:),vfull(:),vkb(:,:,:,:),pswf(:,:,:,:)
- real(dp), allocatable :: vwell(:,:)
- real(dp), allocatable :: vpuns(:,:)
- real(dp), allocatable :: vo(:),vxc(:)
- real(dp), allocatable :: rhomod(:,:),rhoae(:,:),rhops(:,:),rhotae(:)
- real(dp), allocatable :: uupsa(:,:,:) !pseudo-atomic orbitals array
- real(dp), allocatable :: epa(:,:,:),fpa(:,:,:)
- real(dp), allocatable :: uua(:,:,:),upa(:,:,:)
- real(dp), allocatable :: vsr(:,:,:),vso(:,:,:),esr(:,:),eso(:,:)
- real(dp), allocatable :: vpsml(:,:,:)
- real(dp), allocatable :: vr(:,:,:,:)
+   real(dp), allocatable :: evkb(:,:,:),cvgplt(:,:,:,:,:),qq(:,:)
+   real(dp), allocatable :: rr(:)
+   real(dp), allocatable :: rho(:),rhoc(:),rhot(:)
+   real(dp), allocatable :: uu(:,:),up(:,:)
+   real(dp), allocatable :: vp(:,:,:),vfull(:),vkb(:,:,:,:),pswf(:,:,:,:)
+   real(dp), allocatable :: vwell(:,:)
+   real(dp), allocatable :: vpuns(:,:)
+   real(dp), allocatable :: vo(:),vxc(:)
+   real(dp), allocatable :: rhomod(:,:),rhoae(:,:),rhops(:,:),rhotae(:)
+   real(dp), allocatable :: uupsa(:,:,:)  !pseudo-atomic orbitals array
+   real(dp), allocatable :: epa(:,:,:),fpa(:,:,:)
+   real(dp), allocatable :: uua(:,:,:),upa(:,:,:)
+   real(dp), allocatable :: vsr(:,:,:),vso(:,:,:),esr(:,:),eso(:,:)
+   real(dp), allocatable :: vpsml(:,:,:)
+   real(dp), allocatable :: vr(:,:,:,:)
 
- character*2 :: atsym
- character*4 :: psfile
+   character(len=2) :: atsym
+   character(len=4) :: psfile
 
- logical :: srel,cset
+   logical :: srel,cset
 
- write(6,'(a/a//)') &
-&      'ONCVPSP  (Optimized Norm-Conservinng Vanderbilt PSeudopotential)', &
-&      'relativistic version 4.0.1 03/01/2019'
+   write(6,'(a/a//)') &
+   &      'ONCVPSP  (Optimized Norm-Conservinng Vanderbilt PSeudopotential)', &
+   &      'relativistic version 4.0.1 03/01/2019'
 
- write(6,'(a/a/a//)') &
-&      'While it is not required under the terms of the GNU GPL, it is',&
-&      'suggested that you cite D. R. Hamann, Phys. Rev. B 88, 085117 (2013)', &
-&      'in any publication utilizing these pseudopotentials.'
+   write(6,'(a/a/a//)') &
+   &      'While it is not required under the terms of the GNU GPL, it is',&
+   &      'suggested that you cite D. R. Hamann, Phys. Rev. B 88, 085117 (2013)', &
+   &      'in any publication utilizing these pseudopotentials.'
 
- srel=.true.
+   srel=.true.
 !srel=.false.
 
- nproj(:)=0
- fcfact=0.0d0
- rcfact=0.0d0
- rc(:)=0.0d0
- ep(:,:)=0.0d0
+   nproj(:)=0
+   fcfact=0.0d0
+   rcfact=0.0d0
+   rc(:)=0.0d0
+   ep(:,:)=0.0d0
 
 ! read input data
- inline=0
+   inline=0
 
 ! atom and reference configuration
- call cmtskp(inline)
- read(5,*,iostat=ios) atsym,zz,nc,nv,iexc,psfile
- call read_error(ios,inline)
-
- call cmtskp(inline)
- do ii=1,nc+nv
-   read(5,*,iostat=ios) na(ii),la(ii),fa(ii)
+   call cmtskp(inline)
+   read(5,*,iostat=ios) atsym,zz,nc,nv,iexc,psfile
    call read_error(ios,inline)
- end do
+
+   call cmtskp(inline)
+   do ii=1,nc+nv
+      read(5,*,iostat=ios) na(ii),la(ii),fa(ii)
+      call read_error(ios,inline)
+   end do
 
 ! pseudopotential and optimization
- call cmtskp(inline)
- read(5,*,iostat=ios) lmax
- call read_error(ios,inline)
-
- call cmtskp(inline)
- do l1=1,lmax+1
-   read(5,*,iostat=ios) lt,rc(l1),ep(l1,1),ncon(l1),nbas(l1),qcut(l1)
-   if(lt/=l1-1) ios=999
+   call cmtskp(inline)
+   read(5,*,iostat=ios) lmax
    call read_error(ios,inline)
-   ep(l1,2)=ep(l1,1)
- end do
+
+   call cmtskp(inline)
+   do l1=1,lmax+1
+      read(5,*,iostat=ios) lt,rc(l1),ep(l1,1),ncon(l1),nbas(l1),qcut(l1)
+      if(lt/=l1-1) ios=999
+      call read_error(ios,inline)
+      ep(l1,2)=ep(l1,1)
+   end do
 
 ! local potential
- call cmtskp(inline)
- read(5,*, iostat=ios) lloc,lpopt,rc(5),dvloc0
- call read_error(ios,inline)
+   call cmtskp(inline)
+   read(5,*, iostat=ios) lloc,lpopt,rc(5),dvloc0
+   call read_error(ios,inline)
 
 ! Vanderbilt-Kleinman-Bylander projectors
- call cmtskp(inline)
- do l1=1,lmax+1
-   read(5,*,iostat=ios) lt,nproj(l1),debl(l1)
-   if(lt/=l1-1) ios=999
-   call read_error(ios,inline)
- end do
+   call cmtskp(inline)
+   do l1=1,lmax+1
+      read(5,*,iostat=ios) lt,nproj(l1),debl(l1)
+      if(lt/=l1-1) ios=999
+      call read_error(ios,inline)
+   end do
 
 ! model core charge
- call cmtskp(inline)
- read(5,*, iostat=ios) icmod, fcfact
- if(ios==0 .and. icmod==3) then
-  backspace(5)
-  read(5,*, iostat=ios) icmod, fcfact, rcfact
- end if
- call read_error(ios,inline)
+   call cmtskp(inline)
+   read(5,*, iostat=ios) icmod, fcfact
+   if(ios==0 .and. icmod==3) then
+      backspace(5)
+      read(5,*, iostat=ios) icmod, fcfact, rcfact
+   end if
+   call read_error(ios,inline)
 
 ! log derivative analysis
- call cmtskp(inline)
- read(5,*,iostat=ios) epsh1, epsh2, depsh
- call read_error(ios,inline)
+   call cmtskp(inline)
+   read(5,*,iostat=ios) epsh1, epsh2, depsh
+   call read_error(ios,inline)
 
 ! output grid
- call cmtskp(inline)
- read(5,*,iostat=ios) rlmax,drl
- call read_error(ios,inline)
+   call cmtskp(inline)
+   read(5,*,iostat=ios) rlmax,drl
+   call read_error(ios,inline)
 
 ! test configurations
- call cmtskp(inline)
- read(5,*,iostat=ios) ncnf
- call read_error(ios,inline)
-
- do jj=2,ncnf+1
    call cmtskp(inline)
-   read(5,*,iostat=ios) nvcnf(jj)
+   read(5,*,iostat=ios) ncnf
    call read_error(ios,inline)
-   do ii=nc+1,nc+nvcnf(jj)
-     call cmtskp(inline)
-     read(5,*,iostat=ios) nacnf(ii,jj),lacnf(ii,jj),facnf(ii,jj)
-     call read_error(ios,inline)
+
+   do jj=2,ncnf+1
+      call cmtskp(inline)
+      read(5,*,iostat=ios) nvcnf(jj)
+      call read_error(ios,inline)
+      do ii=nc+1,nc+nvcnf(jj)
+         call cmtskp(inline)
+         read(5,*,iostat=ios) nacnf(ii,jj),lacnf(ii,jj),facnf(ii,jj)
+         call read_error(ios,inline)
+      end do
    end do
- end do
 
 ! end of reading input data
 
- nvcnf(1)=nv
- do ii=1,nc+nv
-   nacnf(ii,1)=na(ii)
-   lacnf(ii,1)=la(ii)
-   facnf(ii,1)=fa(ii)
- end do
-
- do jj=2,ncnf+1
-   do ii=1,nc
-     nacnf(ii,jj)=na(ii)
-     lacnf(ii,jj)=la(ii)
-     facnf(ii,jj)=fa(ii)
+   nvcnf(1)=nv
+   do ii=1,nc+nv
+      nacnf(ii,1)=na(ii)
+      lacnf(ii,1)=la(ii)
+      facnf(ii,1)=fa(ii)
    end do
- end do
 
- if(icmod==0) then
-   fcfact=0.0d0
- end if
+   do jj=2,ncnf+1
+      do ii=1,nc
+         nacnf(ii,jj)=na(ii)
+         lacnf(ii,jj)=la(ii)
+         facnf(ii,jj)=fa(ii)
+      end do
+   end do
 
- call check_data(atsym,zz,fcfact,rcfact,epsh1,epsh2,depsh,rlmax,drl,fa,facnf, &
-&                rc,ep,qcut,debl,nc,nv,iexc,lmax,lloc,lpopt,icmod, &
-&                ncnf,na,la,nvcnf,nacnf,lacnf,ncon,nbas,nproj,psfile)
+   if(icmod==0) then
+      fcfact=0.0d0
+   end if
 
- nrl=int((rlmax/drl)-0.5d0)+1
+   call check_data(atsym,zz,fcfact,rcfact,epsh1,epsh2,depsh,rlmax,drl,fa,facnf, &
+   &                rc,ep,qcut,debl,nc,nv,iexc,lmax,lloc,lpopt,icmod, &
+   &                ncnf,na,la,nvcnf,nacnf,lacnf,ncon,nbas,nproj,psfile)
+
+   nrl=int((rlmax/drl)-0.5d0)+1
 
 !amesh=1.012d0
- amesh=1.006d0
+   amesh=1.006d0
 !amesh=1.003d0
 !amesh=1.0015d0
 
- al=dlog(amesh)
- rr1=.0005d0/zz
- rr1=0.0005d0/zz
- mmax=dlog(45.0d0 /rr1)/al
+   al=dlog(amesh)
+   rr1=.0005d0/zz
+   rr1=0.0005d0/zz
+   mmax=dlog(45.0d0 /rr1)/al
 
 !calculate zion for output
- zion=zz
- do ii=1,nc
-  zion=zion-fa(ii)
- end do
+   zion=zz
+   do ii=1,nc
+      zion=zion-fa(ii)
+   end do
 
 !temporary test
- mxprj=5
+   mxprj=5
 !mxprj=2
 
- allocate(rr(mmax))
- allocate(rho(mmax),rhoc(mmax),rhot(mmax))
- allocate(uu(mmax,2),up(mmax,2),uupsa(mmax,2,nv))
- allocate(evkb(mxprj,4,2), cvgplt(2,7,mxprj,4,2),qq(mxprj,mxprj))
- allocate(vp(mmax,5,2),vfull(mmax),vkb(mmax,mxprj,4,2),pswf(mmax,mxprj,4,2))
- allocate(vwell(mmax,mxprj))
- allocate(vpuns(mmax,5))
- allocate(vo(mmax),vxc(mmax))
- allocate(rhoae(mmax,nv),rhops(mmax,nv),rhotae(mmax))
- allocate(npa(mxprj,6))
- allocate(epa(mxprj,6,2),fpa(mxprj,6,2))
- allocate(uua(mmax,mxprj,2),upa(mmax,mxprj,2))
- allocate(vsr(mmax,2*mxprj,4),vso(mmax,2*mxprj,4))
- allocate(esr(2*mxprj,4),eso(2*mxprj,4))
- allocate(vr(mmax,mxprj,6,2))
+   allocate(rr(mmax))
+   allocate(rho(mmax),rhoc(mmax),rhot(mmax))
+   allocate(uu(mmax,2),up(mmax,2),uupsa(mmax,2,nv))
+   allocate(evkb(mxprj,4,2), cvgplt(2,7,mxprj,4,2),qq(mxprj,mxprj))
+   allocate(vp(mmax,5,2),vfull(mmax),vkb(mmax,mxprj,4,2),pswf(mmax,mxprj,4,2))
+   allocate(vwell(mmax,mxprj))
+   allocate(vpuns(mmax,5))
+   allocate(vo(mmax),vxc(mmax))
+   allocate(rhoae(mmax,nv),rhops(mmax,nv),rhotae(mmax))
+   allocate(npa(mxprj,6))
+   allocate(epa(mxprj,6,2),fpa(mxprj,6,2))
+   allocate(uua(mmax,mxprj,2),upa(mmax,mxprj,2))
+   allocate(vsr(mmax,2*mxprj,4),vso(mmax,2*mxprj,4))
+   allocate(esr(2*mxprj,4),eso(2*mxprj,4))
+   allocate(vr(mmax,mxprj,6,2))
 
- vp(:,:,:)=0.0d0
- vkb(:,:,:,:)=0.0d0
- epa(:,:,:)=0.0d0
+   vp(:,:,:)=0.0d0
+   vkb(:,:,:,:)=0.0d0
+   epa(:,:,:)=0.0d0
 
- do ii=1,mmax
-  rr(ii)=rr1*exp(al*(ii-1))
- end do
+   do ii=1,mmax
+      rr(ii)=rr1*exp(al*(ii-1))
+   end do
 
 !
 ! full potential atom solution
 !
    call relatom(na,la,ea,fa,rpk,nc,nc+nv,it,rhoc,rho, &
-&              rr,vfull,zz,mmax,iexc,etot,ierr)
+   &              rr,vfull,zz,mmax,iexc,etot,ierr)
 
 !
 !
 
 ! Drop digits beyond 5 decimals for input rcs before making any use of them
- do l1=1,max(lmax+1,lloc+1)
-    jj=int(rc(l1)*10.0d5)
-    rc(l1)=jj/10.0d5
- end do
+   do l1=1,max(lmax+1,lloc+1)
+      jj=int(rc(l1)*10.0d5)
+      rc(l1)=jj/10.0d5
+   end do
 
- rcmax=0.0d0
- do l1=1,lmax+1
-   rcmax=dmax1(rcmax,rc(l1))
- end do
- do l1=1,lmax+1
-   if(rc(l1)==0.0d0) then
-     rc(l1)=rcmax
-   end if
- end do
+   rcmax=0.0d0
+   do l1=1,lmax+1
+      rcmax=dmax1(rcmax,rc(l1))
+   end do
+   do l1=1,lmax+1
+      if(rc(l1)==0.0d0) then
+         rc(l1)=rcmax
+      end if
+   end do
 
- nproj(lloc+1)=0
- rc0(:)=rc(:)
+   nproj(lloc+1)=0
+   rc0(:)=rc(:)
 
 ! output printing (echos input data, with all-electron eigenvalues added)
 
- write(6,'(a)') '# ATOM AND REFERENCE CONFIGURATION'
- write(6,'(a)') '# atsym  z   nc   nv     iexc    psfile'
- write(6,'(a,a,f6.2,2i5,i8,2a)') '  ',trim(atsym),zz,nc,nv,iexc, &
-&      '      ',psfile
- write(6,'(a/a)') '#','#   n    l    f        energy (Ha)'
- do ii=1,nc+nv
-  if(la(ii)==0) then
-   write(6,'(2i5,f8.2,1p,d18.7)') na(ii),la(ii),fa(ii),ea(ii,1)
-   ea(ii,2)=ea(ii,1)
-  else
-   write(6,'(2i5,f8.2,1p,2d18.7)') na(ii),la(ii),fa(ii),ea(ii,1),ea(ii,2)
-  end if
+   write(6,'(a)') '# ATOM AND REFERENCE CONFIGURATION'
+   write(6,'(a)') '# atsym  z   nc   nv     iexc    psfile'
+   write(6,'(a,a,f6.2,2i5,i8,2a)') '  ',trim(atsym),zz,nc,nv,iexc, &
+   &      '      ',psfile
+   write(6,'(a/a)') '#','#   n    l    f        energy (Ha)'
+   do ii=1,nc+nv
+      if(la(ii)==0) then
+         write(6,'(2i5,f8.2,1p,d18.7)') na(ii),la(ii),fa(ii),ea(ii,1)
+         ea(ii,2)=ea(ii,1)
+      else
+         write(6,'(2i5,f8.2,1p,2d18.7)') na(ii),la(ii),fa(ii),ea(ii,1),ea(ii,2)
+      end if
 
- end do
-
- write(6,'(a/a/a)') '#','# PSEUDOPOTENTIAL AND OPTIMIZATION','# lmax'
- write(6,'(i5)')  lmax
- write(6,'(a/a)') '#','#   l,   rc,      ep,       ncon, nbas, qcut'
- do l1=1,lmax+1
-   write(6,'(i5,2f10.5,2i5,f10.5)') l1-1,rc(l1),ep(l1,1),ncon(l1),&
-&        nbas(l1),qcut(l1)
- end do
-
- write(6,'(a/a/a,a)') '#','# LOCAL POTENTIAL','# lloc, lpopt,  rc(5),', &
-&      '   dvloc0'
- write(6,'(2i5,f10.5,a,f10.5)') lloc,lpopt,rc(5),'   ',dvloc0
-
- write(6,'(a/a/a)') '#','# VANDERBILT-KLEINMAN-BYLANDER PROJECTORs', &
-&      '# l, nproj, debl'
- do l1=1,lmax+1
-   write(6,'(2i5,f10.5)') l1-1,nproj(l1),debl(l1)
- end do
-
- write(6,'(a/a/a)') '#','# MODEL CORE CHARGE', &
-&      '# icmod, fcfact, rcfact'
- write(6,'(i5,2f10.5)') icmod,fcfact,rcfact
-
- write(6,'(a/a/a)') '#','# LOG DERIVATIVE ANALYSIS', &
-&      '# epsh1, epsh2, depsh'
- write(6,'(3f8.2)') epsh1,epsh2,depsh
-
- write(6,'(a/a/a)') '#','# OUTPUT GRID','# rlmax, drl'
- write(6,'(2f8.4)') rlmax,drl
-
- write(6,'(a/a/a)') '#','# TEST CONFIGURATIONS','# ncnf'
- write(6,'(i5)') ncnf
- write(6,'(a/a)') '# nvcnf','#   n    l    f'
- do jj=2,ncnf+1
-   write(6,'(i5)') nvcnf(jj)
-   do ii=nc+1,nc+nvcnf(jj)
-     write(6,'(2i5,f8.2)') nacnf(ii,jj),lacnf(ii,jj),facnf(ii,jj)
    end do
-   write(6,'(a)') '#'
- end do
 
- write(6,'(//a)') 'Reference configufation results'
- write(6,'(a,i6)') '  iterations',it
- if(it .ge. 100) then
-  write(6,'(a)') 'oncvpsp_r: ERROR all-electron reference atom not converged'
-  stop
- end if
- write(6,'(a,1p,d18.8)') '  all-electron total energy (Ha)',etot
+   write(6,'(a/a/a)') '#','# PSEUDOPOTENTIAL AND OPTIMIZATION','# lmax'
+   write(6,'(i5)')  lmax
+   write(6,'(a/a)') '#','#   l,   rc,      ep,       ncon, nbas, qcut'
+   do l1=1,lmax+1
+      write(6,'(i5,2f10.5,2i5,f10.5)') l1-1,rc(l1),ep(l1,1),ncon(l1),&
+      &        nbas(l1),qcut(l1)
+   end do
+
+   write(6,'(a/a/a,a)') '#','# LOCAL POTENTIAL','# lloc, lpopt,  rc(5),', &
+   &      '   dvloc0'
+   write(6,'(2i5,f10.5,a,f10.5)') lloc,lpopt,rc(5),'   ',dvloc0
+
+   write(6,'(a/a/a)') '#','# VANDERBILT-KLEINMAN-BYLANDER PROJECTORs', &
+   &      '# l, nproj, debl'
+   do l1=1,lmax+1
+      write(6,'(2i5,f10.5)') l1-1,nproj(l1),debl(l1)
+   end do
+
+   write(6,'(a/a/a)') '#','# MODEL CORE CHARGE', &
+   &      '# icmod, fcfact, rcfact'
+   write(6,'(i5,2f10.5)') icmod,fcfact,rcfact
+
+   write(6,'(a/a/a)') '#','# LOG DERIVATIVE ANALYSIS', &
+   &      '# epsh1, epsh2, depsh'
+   write(6,'(3f8.2)') epsh1,epsh2,depsh
+
+   write(6,'(a/a/a)') '#','# OUTPUT GRID','# rlmax, drl'
+   write(6,'(2f8.4)') rlmax,drl
+
+   write(6,'(a/a/a)') '#','# TEST CONFIGURATIONS','# ncnf'
+   write(6,'(i5)') ncnf
+   write(6,'(a/a)') '# nvcnf','#   n    l    f'
+   do jj=2,ncnf+1
+      write(6,'(i5)') nvcnf(jj)
+      do ii=nc+1,nc+nvcnf(jj)
+         write(6,'(2i5,f8.2)') nacnf(ii,jj),lacnf(ii,jj),facnf(ii,jj)
+      end do
+      write(6,'(a)') '#'
+   end do
+
+   write(6,'(//a)') 'Reference configufation results'
+   write(6,'(a,i6)') '  iterations',it
+   if(it >= 100) then
+      write(6,'(a)') 'oncvpsp_r: ERROR all-electron reference atom not converged'
+      stop
+   end if
+   write(6,'(a,1p,d18.8)') '  all-electron total energy (Ha)',etot
 
 !find log mesh point nearest input rc
- rcmax=0.0d0
- irc(:)=0
- do l1=1,max(lmax+1,lloc+1)
-  rct=rc(l1)
-  irc(l1)=0
-  do ii=2,mmax
-   if(rr(ii)>rct) then
-    irc(l1)=ii
-    rc(l1)=rr(ii)
-    exit
-   end if
-  end do
-  rcmax=dmax1(rcmax,rc(l1))
- end do
+   rcmax=0.0d0
+   irc(:)=0
+   do l1=1,max(lmax+1,lloc+1)
+      rct=rc(l1)
+      irc(l1)=0
+      do ii=2,mmax
+         if(rr(ii)>rct) then
+            irc(l1)=ii
+            rc(l1)=rr(ii)
+            exit
+         end if
+      end do
+      rcmax=dmax1(rcmax,rc(l1))
+   end do
 
 !
- cvgplt(:,:,:,:,:)=0.0d0
+   cvgplt(:,:,:,:,:)=0.0d0
 !
 ! loop to construct pseudopotentials for all angular momenta
 !
- write(6,'(/a/a)') 'Begin loop to  construct optimized pseudo wave functions',&
-&      'and semi-local pseudopoentials for all angular momenta'
+   write(6,'(/a/a)') 'Begin loop to  construct optimized pseudo wave functions',&
+   &      'and semi-local pseudopoentials for all angular momenta'
 
 !temporarily set this to 1 so that the pseudo wave function needed for the
 !local potential will be generated.  Reset before psp output.
- npa(:,:)=0
- nproj(lloc+1)=1
- do l1=1,lmax+1
-   vwell(:,:)=0.0d0
-   ll=l1-1
-  if(ll==0) then
-    mkap=1
-  else
-   mkap=2
-  end if
-  do ikap=1,mkap
-   if(ikap==1) then
-     kap=-(ll+1)
-     fj=dble(ll+1)/dble(2*ll+1)
-   else
-     kap=  ll
-     fj=dble(ll)/dble(2*ll+1)
-   end if
+   npa(:,:)=0
+   nproj(lloc+1)=1
+   do l1=1,lmax+1
+      vwell(:,:)=0.0d0
+      ll=l1-1
+      if(ll==0) then
+         mkap=1
+      else
+         mkap=2
+      end if
+      do ikap=1,mkap
+         if(ikap==1) then
+            kap=-(ll+1)
+            fj=dble(ll+1)/dble(2*ll+1)
+         else
+            kap=  ll
+            fj=dble(ll)/dble(2*ll+1)
+         end if
 
-   uu(:,:)=0.0d0; qq(:,:)=0.0d0
-   iprj=0
+         uu(:,:)=0.0d0; qq(:,:)=0.0d0
+         iprj=0
 
 !get principal quantum number for the highest core state for this l
-   npa(1,l1)=l1
-   if(nc>0) then
-     do kk=1,nc
-       if(la(kk)==l1-1) npa(1,l1)=na(kk)+1
-     end do !kk
-   end if
-   
-!get all-electron bound states for projectors
-   if(nv/=0) then
-     do kk=nc+1,nc+nv
-       if(la(kk)==l1-1) then
-         iprj=iprj+1
-         if(ll==0) then
-           ebar=ea(kk,1)
-         else
-           ebar=(l1*ea(kk,1)+(l1-1)*ea(kk,2))/dble(2*l1-1)
-         end if
-         et=ea(kk,ikap)
-         call ldiracfb(na(kk),ll,kap,ierr,et, &
-&                rr,zz,vfull,uu,up,mmax,mch)
-         if(ierr /= 0) then
-           write(6,'(a,i2,a,i2,a,i2)') &
-&                'oncvpsp_r 409: ldiracfb convergence ERROR, n=',&
-&                 np(l1),'  l=',ll, 'kap-',kap
-           stop
+         npa(1,l1)=l1
+         if(nc>0) then
+            do kk=1,nc
+               if(la(kk)==l1-1) npa(1,l1)=na(kk)+1
+            end do  !kk
          end if
 
-         epa(iprj,l1,ikap)=ea(kk,ikap)
-         npa(iprj,l1)=na(kk)
-         call renorm_r(uu,rr,ll,kap,zz,mmax,cnorm)
-         uua(:,iprj,ikap)=uu(:,1)
-         upa(:,iprj,ikap)=cnorm*up(:,1)
-       end if !la(kk)==l1-1
-       if(iprj==nproj(l1)) exit
-     end do !kk
-   end if !nv/=0
+!get all-electron bound states for projectors
+         if(nv/=0) then
+            do kk=nc+1,nc+nv
+               if(la(kk)==l1-1) then
+                  iprj=iprj+1
+                  if(ll==0) then
+                     ebar=ea(kk,1)
+                  else
+                     ebar=(l1*ea(kk,1)+(l1-1)*ea(kk,2))/dble(2*l1-1)
+                  end if
+                  et=ea(kk,ikap)
+                  call ldiracfb(na(kk),ll,kap,ierr,et, &
+                  &                rr,zz,vfull,uu,up,mmax,mch)
+                  if(ierr /= 0) then
+                     write(6,'(a,i2,a,i2,a,i2)') &
+                     &                'oncvpsp_r 409: ldiracfb convergence ERROR, n=',&
+                     &                 np(l1),'  l=',ll, 'kap-',kap
+                     stop
+                  end if
+
+                  epa(iprj,l1,ikap)=ea(kk,ikap)
+                  npa(iprj,l1)=na(kk)
+                  call renorm_r(uu,rr,ll,kap,zz,mmax,cnorm)
+                  uua(:,iprj,ikap)=uu(:,1)
+                  upa(:,iprj,ikap)=cnorm*up(:,1)
+               end if  !la(kk)==l1-1
+               if(iprj==nproj(l1)) exit
+            end do  !kk
+         end if  !nv/=0
 
 !get all-electron well states for projectors
 !if there were no valence states, use ep from input data for 1st well state
 !otherwise shift up by input debl
 
-   if(iprj==0) epa(1,l1,ikap)=ep(l1,ikap)
-   if(iprj<nproj(l1))then
-     do kk=1,nproj(l1)-iprj
-       iprj=iprj+1
-       if(iprj>1 .and.debl(l1)<=0.0d0) then
-         write(6,'(a,f8.3,a/a)') 'oncvpsp: ERROR debl =',debl, 'for l=', &
-&              ' not allowed with 2 or more scattering states', &
-&              'program will stop'
-         stop
-       end if
+         if(iprj==0) epa(1,l1,ikap)=ep(l1,ikap)
+         if(iprj<nproj(l1))then
+            do kk=1,nproj(l1)-iprj
+               iprj=iprj+1
+               if(iprj>1 .and.debl(l1)<=0.0d0) then
+                  write(6,'(a,f8.3,a/a)') 'oncvpsp: ERROR debl =',debl, 'for l=', &
+                  &              ' not allowed with 2 or more scattering states', &
+                  &              'program will stop'
+                  stop
+               end if
 
 ! npa is not reset for ikap=2 to retain same node count for consistency with
 ! keeping same well potential as for ikap=1.  Note that it may have been
 ! reset by wellstate which is only now called foerer ikap1.
-       if(iprj>1) then
-         epa(iprj,l1,ikap)=epa(iprj-1,l1,ikap)+debl(l1)
-         if(ikap==1) then
-           npa(iprj,l1)=npa(iprj-1,l1)+1
-         end if
-       end if
+               if(iprj>1) then
+                  epa(iprj,l1,ikap)=epa(iprj-1,l1,ikap)+debl(l1)
+                  if(ikap==1) then
+                     npa(iprj,l1)=npa(iprj-1,l1)+1
+                  end if
+               end if
 
 ! since new wellstate can change npa, well potential is calculated for
 ! less-bound ikap=1 state and kept for ikap=2, which is more deeply
 ! bound and shoould always have a bound state for this combination of
 ! npa and vwell
-       if(ikap==1) then
-         call wellstate_r(npa(iprj,l1),ll,kap,irc(l1),epa(iprj,l1,ikap), &
-&                         rr,vfull,vwell(1,iprj),uu,up,zz,mmax,mch)
-       else
-         et=epa(iprj,l1,ikap)
-         call ldiracfb(npa(iprj,l1),ll,kap,ierr,epa(iprj,l1,ikap), &
-&                         rr,zz,vwell(1,iprj),uu,up,mmax,mch)
+               if(ikap==1) then
+                  call wellstate_r(npa(iprj,l1),ll,kap,irc(l1),epa(iprj,l1,ikap), &
+                  &                         rr,vfull,vwell(1,iprj),uu,up,zz,mmax,mch)
+               else
+                  et=epa(iprj,l1,ikap)
+                  call ldiracfb(npa(iprj,l1),ll,kap,ierr,epa(iprj,l1,ikap), &
+                  &                         rr,zz,vwell(1,iprj),uu,up,mmax,mch)
 
-          if(ierr /= 0) then
-            write(6,'(a,i2,a,i2,a,i3,a,f12.6)') &
-&                 'oncvpsp_r 474: ldiracfb convergence ERROR, n=',&
-&                  npa(iprj,l1),'  l=',ll, 'kap=',kap, ' epa=', &
-&                  epa(iprj,l1,ikap)
+                  if(ierr /= 0) then
+                     write(6,'(a,i2,a,i2,a,i3,a,f12.6)') &
+                     &                 'oncvpsp_r 474: ldiracfb convergence ERROR, n=',&
+                     &                  npa(iprj,l1),'  l=',ll, 'kap=',kap, ' epa=', &
+                     &                  epa(iprj,l1,ikap)
 
-            stop
-          end if
+                     stop
+                  end if
 
-          write(6,'(/a,i3,a,i3,a,i3/a,f8.4)') &
-&                  '   Wellstate for l =',ll,'  n =',npa(iprj,l1),' kap=',kap, &
-&                  '     eigenvalue = ',et
-       end if
+                  write(6,'(/a,i3,a,i3,a,i3/a,f8.4)') &
+                  &                  '   Wellstate for l =',ll,'  n =',npa(iprj,l1),' kap=',kap, &
+                  &                  '     eigenvalue = ',et
+               end if
 
-       call renorm_r(uu,rr,ll,kap,zz,mmax,cnorm)
-       uua(:,iprj,ikap)=uu(:,1)
-       upa(:,iprj,ikap)=cnorm*up(:,1)
-     end do !kk
-   end if !iprj<nproj(l1)
+               call renorm_r(uu,rr,ll,kap,zz,mmax,cnorm)
+               uua(:,iprj,ikap)=uu(:,1)
+               upa(:,iprj,ikap)=cnorm*up(:,1)
+            end do  !kk
+         end if  !iprj<nproj(l1)
 
-   do iprj=1,nproj(l1)
+         do iprj=1,nproj(l1)
 
-     call vrel(ll,epa(iprj,l1,ikap),rr,vfull,vr(1,iprj,l1,ikap), &
-&              uua(1,iprj,ikap),upa(1,iprj,ikap), &
-&              zz,mmax,irc(l1),srel)
-   end do
+            call vrel(ll,epa(iprj,l1,ikap),rr,vfull,vr(1,iprj,l1,ikap), &
+            &              uua(1,iprj,ikap),upa(1,iprj,ikap), &
+            &              zz,mmax,irc(l1),srel)
+         end do
 
 
 !get all-electron overlap matrix
-   do jj=1,nproj(l1)
-     do ii=1,jj
+         do jj=1,nproj(l1)
+            do ii=1,jj
 !      call fpovlp_r(uua(1,ii,ikap),uua(1,jj,ikap),irc(l1),ll,zz, &
-       call fpovlp(uua(1,ii,ikap),uua(1,jj,ikap),irc(l1),ll,zz, &
-&                  qq(ii,jj),rr,srel)
-       qq(jj,ii)=qq(ii,jj)
-     end do
-   end do
-   call run_optimize(epa(1,l1,ikap),ll,mmax,mxprj,rr,uua(1,1,ikap),qq, &
-&                    irc(l1),qcut(l1),qmsbf(l1),ncon(l1),nbas(l1),nproj(l1), &
-&                    pswf(1,1,l1,ikap),vp(1,l1,ikap),vkb(1,1,l1,ikap), &
-&                    vfull,cvgplt(1,1,1,l1,ikap))
+               call fpovlp(uua(1,ii,ikap),uua(1,jj,ikap),irc(l1),ll,zz, &
+               &                  qq(ii,jj),rr,srel)
+               qq(jj,ii)=qq(ii,jj)
+            end do
+         end do
+         call run_optimize(epa(1,l1,ikap),ll,mmax,mxprj,rr,uua(1,1,ikap),qq, &
+         &                    irc(l1),qcut(l1),qmsbf(l1),ncon(l1),nbas(l1),nproj(l1), &
+         &                    pswf(1,1,l1,ikap),vp(1,l1,ikap),vkb(1,1,l1,ikap), &
+         &                    vfull,cvgplt(1,1,1,l1,ikap))
 
-  end do !ikap
- end do !l1
+      end do  !ikap
+   end do  !l1
 
- deallocate(uua,upa)
+   deallocate(uua,upa)
 
 !restore this temporay reset
-  nproj(lloc+1)=0
+   nproj(lloc+1)=0
 
 ! construct Vanderbilt / Kleinman-Bylander projectors
 
- write(6,'(/a,a)') 'Construct Vanderbilt / Kleinmman-Bylander projectors'
+   write(6,'(/a,a)') 'Construct Vanderbilt / Kleinmman-Bylander projectors'
 
- call run_vkb_r(lmax,lloc,lpopt,dvloc0,irc,nproj,rr,mmax,mxprj,pswf,vfull,vp, &
-&             evkb,vkb,nlim,vr)
+   call run_vkb_r(lmax,lloc,lpopt,dvloc0,irc,nproj,rr,mmax,mxprj,pswf,vfull,vp, &
+   &             evkb,vkb,nlim,vr)
 
 ! accumulate charge and eigenvalues
 ! pseudo wave functions are calculated with VKB projectors for
 ! maximum consistency of unscreening
- allocate(uua(mmax,30,2))
+   allocate(uua(mmax,30,2))
 ! get all-electron and pseudopotential valence-state by valence-state
 ! charge densities
 
 ! null charge and eigenvalue accumulators
- uupsa(:,:,:)=0.0d0
- eeig=0.0d0
- zval=0.0d0
- rhops(:,:)=0.0d0
- rho(:)=0.0d0
- nodes(:)=0
- rhoae(:,:)=0.0d0
- rhotae(:)=0.0d0
- irps=0
- do kk=1,nv
-  ll=la(nc+kk)
-  l1=ll+1
+   uupsa(:,:,:)=0.0d0
+   eeig=0.0d0
+   zval=0.0d0
+   rhops(:,:)=0.0d0
+   rho(:)=0.0d0
+   nodes(:)=0
+   rhoae(:,:)=0.0d0
+   rhotae(:)=0.0d0
+   irps=0
+   do kk=1,nv
+      ll=la(nc+kk)
+      l1=ll+1
 
-  if(ll==0) then
-    mkap=1
-  else
-   mkap=2
-  end if
-  do ikap=1,mkap
-   if(ikap==1) then
-     kap=-(ll+1)
-     fj=dble(ll+1)/dble(2*ll+1)
-   else
-     kap=  ll
-     fj=dble(ll)/dble(2*ll+1)
-   end if
+      if(ll==0) then
+         mkap=1
+      else
+         mkap=2
+      end if
+      do ikap=1,mkap
+         if(ikap==1) then
+            kap=-(ll+1)
+            fj=dble(ll+1)/dble(2*ll+1)
+         else
+            kap=  ll
+            fj=dble(ll)/dble(2*ll+1)
+         end if
 
-   et=ea(nc+kk,ikap)
+         et=ea(nc+kk,ikap)
 
-   call ldiracfb(na(nc+kk),ll,kap,ierr,et, &
-&                rr,zz,vfull,uu,up,mmax,mch)
-    if(ierr /= 0) then
-      write(6,'(a,i2,a,i2,a,i2,a,i4)') &
-&           'oncvpsp_r 541: ldiracfb convergence ERROR, n=',&
-&            np(l1),'  l=',ll, '  kap-',kap,'  ierr=',ierr
-      stop
-    end if
+         call ldiracfb(na(nc+kk),ll,kap,ierr,et, &
+         &                rr,zz,vfull,uu,up,mmax,mch)
+         if(ierr /= 0) then
+            write(6,'(a,i2,a,i2,a,i2,a,i4)') &
+            &           'oncvpsp_r 541: ldiracfb convergence ERROR, n=',&
+            &            np(l1),'  l=',ll, '  kap-',kap,'  ierr=',ierr
+            stop
+         end if
 
-   rhoae(:,kk)=rhoae(:,kk)+fj*((uu(:,1)/rr(:))**2 + (uu(:,2)/rr(:))**2)
-   rhotae(:)=rhotae(:)+fa(nc+kk)*rhoae(:,kk)
+         rhoae(:,kk)=rhoae(:,kk)+fj*((uu(:,1)/rr(:))**2 + (uu(:,2)/rr(:))**2)
+         rhotae(:)=rhotae(:)+fa(nc+kk)*rhoae(:,kk)
 
-   emax=0.90d0*et
-   emin=1.10d0*et
+         emax=0.90d0*et
+         emin=1.10d0*et
 
-   call lschvkbb(ll+nodes(l1)+1,ll,nproj(l1),ierr,et,emin,emax, &
-&                rr,vp(1,lloc+1,ikap),vkb(1,1,l1,ikap),evkb(1,l1,ikap), &
-&                uu(1,1),up(1,1),mmax,mch)
-   if(ierr .ne. 0) then
-     write(6,'(a,i2,a,i2)') 'oncvpsp_r: lschvkbb convergence ERROR, n=',&
-&     ll+1,'  l=',ll
-     stop
-   end if
+         call lschvkbb(ll+nodes(l1)+1,ll,nproj(l1),ierr,et,emin,emax, &
+         &                rr,vp(1,lloc+1,ikap),vkb(1,1,l1,ikap),evkb(1,l1,ikap), &
+         &                uu(1,1),up(1,1),mmax,mch)
+         if(ierr /= 0) then
+            write(6,'(a,i2,a,i2)') 'oncvpsp_r: lschvkbb convergence ERROR, n=',&
+            &     ll+1,'  l=',ll
+            stop
+         end if
 
 ! save valence pseudo wave functions for uprout
-   uupsa(:,ikap,kk)=uu(:,1)
+         uupsa(:,ikap,kk)=uu(:,1)
 
-   rhops(:,kk)=rhops(:,kk)+fj*(uu(:,1)/rr(:))**2
-   eeig=eeig+fa(nc+kk)*fj*et
+         rhops(:,kk)=rhops(:,kk)+fj*(uu(:,1)/rr(:))**2
+         eeig=eeig+fa(nc+kk)*fj*et
 
-  end do !ikap
-  rho(:)=rho(:)+fa(nc+kk)*rhops(:,kk)
-  zval=zval+fa(nc+kk)
-  nodes(l1)=nodes(l1)+1
-  irps=max(irps,irc(l1))
- end do !kk
+      end do  !ikap
+      rho(:)=rho(:)+fa(nc+kk)*rhops(:,kk)
+      zval=zval+fa(nc+kk)
+      nodes(l1)=nodes(l1)+1
+      irps=max(irps,irc(l1))
+   end do  !kk
 
 ! decomposition into scalar-relativistic and spin-orbit projectors
 
-  call sr_so_r(lmax,irc,nproj,rr,mmax,mxprj,evkb,vkb, &
-&              vsr,esr,vso,eso)
+   call sr_so_r(lmax,irc,nproj,rr,mmax,mxprj,evkb,vkb, &
+   &              vsr,esr,vso,eso)
 
 ! set smallest components to zero (will be dropped in psp8 output)
-  eps_srso=1.0d-3
-  do l1=1,lmax+1
-    if(nproj(l1)>0) then
-      do iprj=2,2*nproj(l1)
-        if(abs(esr(iprj,l1))<eps_srso*abs(esr(1,l1))) esr(iprj,l1)=0.0d0
-        if(l1==1) cycle
-        if(abs(eso(iprj,l1))<eps_srso*abs(eso(1,l1))) eso(iprj,l1)=0.0d0
-      end do
-    end if
-  end do
+   eps_srso=1.0d-3
+   do l1=1,lmax+1
+      if(nproj(l1)>0) then
+         do iprj=2,2*nproj(l1)
+            if(abs(esr(iprj,l1))<eps_srso*abs(esr(1,l1))) esr(iprj,l1)=0.0d0
+            if(l1==1) cycle
+            if(abs(eso(iprj,l1))<eps_srso*abs(eso(1,l1))) eso(iprj,l1)=0.0d0
+         end do
+      end if
+   end do
 
- allocate(rhomod(mmax,5))
+   allocate(rhomod(mmax,5))
 
- rhomod(:,:)=0.0d0
+   rhomod(:,:)=0.0d0
 
 ! construct model core charge based on monotonic polynomial fit
 ! or Teter function fit
 
- if(icmod==1) then
-   call modcore(icmod,rhops,rho,rhoc,rhoae,rhotae,rhomod, &
-&               fcfact,rcfact,irps,mmax,rr,nc,nv,la,zion,iexc)
+   if(icmod==1) then
+      call modcore(icmod,rhops,rho,rhoc,rhoae,rhotae,rhomod, &
+      &               fcfact,rcfact,irps,mmax,rr,nc,nv,la,zion,iexc)
 
- else if(icmod==2) then
-   call modcore2(icmod,rhops,rho,rhoc,rhoae,rhotae,rhomod, &
-&               fcfact,rcfact,irps,mmax,rr,nc,nv,la,zion,iexc)
+   else if(icmod==2) then
+      call modcore2(icmod,rhops,rho,rhoc,rhoae,rhotae,rhomod, &
+      &               fcfact,rcfact,irps,mmax,rr,nc,nv,la,zion,iexc)
 
- else if(icmod>=3) then
-   call modcore3(icmod,rhops,rho,rhoc,rhoae,rhotae,rhomod, &
-&               fcfact,rcfact,irps,mmax,rr,nc,nv,la,zion,iexc)
+   else if(icmod>=3) then
+      call modcore3(icmod,rhops,rho,rhoc,rhoae,rhotae,rhomod, &
+      &               fcfact,rcfact,irps,mmax,rr,nc,nv,la,zion,iexc)
 
- end if
+   end if
 
 ! screening potential for pseudocharge
 
- call vout(1,rho,rhomod(1,1),vo,vxc,zval,eeel,eexc,rr,mmax,iexc)
+   call vout(1,rho,rhomod(1,1),vo,vxc,zval,eeel,eexc,rr,mmax,iexc)
 
 ! total energy output
 
- epstot= eeig + eexc - 0.5d0*eeel
- write(6,'(/a,f12.6/)') 'Pseudoatom total energy', epstot
+   epstot= eeig + eexc - 0.5d0*eeel
+   write(6,'(/a,f12.6/)') 'Pseudoatom total energy', epstot
 
- ! diagnostics
+   ! diagnostics
 
- call run_diag_r(lmax,npa,epa,lloc,irc, &
-&                vkb,evkb,nproj,rr,vfull,vp,zz,mmax,mxprj)
+   call run_diag_r(lmax,npa,epa,lloc,irc, &
+   &                vkb,evkb,nproj,rr,vfull,vp,zz,mmax,mxprj)
 
-  call run_diag_sr_so_r(lmax,npa,epa,lloc,irc, &
-&                       vsr,esr,vso,eso,nproj,rr,vfull,vp,zz,mmax,mxprj)
+   call run_diag_sr_so_r(lmax,npa,epa,lloc,irc, &
+   &                       vsr,esr,vso,eso,nproj,rr,vfull,vp,zz,mmax,mxprj)
 
-! save full info for psml 
- allocate(vpsml(mmax,5,2))
- do l1=1,max(lmax+1,lloc+1)
-    ll=l1-1
-    vpsml(:,l1,1) = vp(:,l1,1) - vo(:)
-    vpsml(:,l1,2) = vp(:,l1,2) - vo(:)
- end do
+! save full info for psml
+   allocate(vpsml(mmax,5,2))
+   do l1=1,max(lmax+1,lloc+1)
+      ll=l1-1
+      vpsml(:,l1,1) = vp(:,l1,1) - vo(:)
+      vpsml(:,l1,2) = vp(:,l1,2) - vo(:)
+   end do
 
 
 
 ! ghost testing
 
- write(6,'(/a)') 'Ghost test for J = L + 1/2'
- call run_ghosts(lmax,la,ea(1,1),nc,nv,lloc,irc,qmsbf, &
-&                vkb(1,1,1,1),evkb(1,1,1),nproj,rr,vp,mmax,mxprj)
+   write(6,'(/a)') 'Ghost test for J = L + 1/2'
+   call run_ghosts(lmax,la,ea(1,1),nc,nv,lloc,irc,qmsbf, &
+   &                vkb(1,1,1,1),evkb(1,1,1),nproj,rr,vp,mmax,mxprj)
 
- write(6,'(/a)') 'Ghost test for J = L - 1/2'
- vkb(:,:,1,2)=vkb(:,:,1,1)
- evkb(:,1,2)=evkb(:,1,1)
- call run_ghosts(lmax,la,ea(1,2),nc,nv,lloc,irc,qmsbf, &
-&                vkb(1,1,1,2),evkb(1,1,2),nproj,rr,vp,mmax,mxprj)
- vkb(:,:,1,2)=0.0d0
- evkb(:,1,2)=0.0d0
+   write(6,'(/a)') 'Ghost test for J = L - 1/2'
+   vkb(:,:,1,2)=vkb(:,:,1,1)
+   evkb(:,1,2)=evkb(:,1,1)
+   call run_ghosts(lmax,la,ea(1,2),nc,nv,lloc,irc,qmsbf, &
+   &                vkb(1,1,1,2),evkb(1,1,2),nproj,rr,vp,mmax,mxprj)
+   vkb(:,:,1,2)=0.0d0
+   evkb(:,1,2)=0.0d0
 
 ! unscreen semi-local potentials taking scalar-relativistic average
 
- do l1=1,max(lmax+1,lloc+1)
-   ll=l1-1
-   if(ll==0  .or. ll==4) then
-     vpuns(:,l1)=vp(:,l1,1)-vo(:)
-   else
-     vpuns(:,l1)=(dble(ll+1)*vp(:,l1,1)+ dble(ll)*vp(:,l1,2))/dble(2*ll+1) &
-&                -vo(:)
-   end if
- end do
+   do l1=1,max(lmax+1,lloc+1)
+      ll=l1-1
+      if(ll==0  .or. ll==4) then
+         vpuns(:,l1)=vp(:,l1,1)-vo(:)
+      else
+         vpuns(:,l1)=(dble(ll+1)*vp(:,l1,1)+ dble(ll)*vp(:,l1,2))/dble(2*ll+1) &
+         &                -vo(:)
+      end if
+   end do
 
 ! fix unscreening error due to greater range of all-electron charge
- do ii=mmax,1,-1
- if(rho(ii)==0.0d0) then 
-     do l1=1,max(lmax+1,lloc+1)
-       vpuns(ii,l1)=-zion/rr(ii)
-     end do
-   else
-     exit
-   end if
- end do
+   do ii=mmax,1,-1
+      if(rho(ii)==0.0d0) then
+         do l1=1,max(lmax+1,lloc+1)
+            vpuns(ii,l1)=-zion/rr(ii)
+         end do
+      else
+         exit
+      end if
+   end do
 
 
 ! loop over reference plus test atom configurations
- do jj=1,ncnf+1
+   do jj=1,ncnf+1
 
-   write(6,'(/a,i2)') 'Test configuration',jj-1
+      write(6,'(/a,i2)') 'Test configuration',jj-1
 
 ! For first (reference) configuration, charge is initialized as previously-
 ! calculated pseudocharge is saved
 
-   rhot(:)=rho(:)
+      rhot(:)=rho(:)
 
-   call run_config_r(jj,nacnf,lacnf,facnf,nc,nvcnf,rhot,rhomod,rr,zz, &
-&                  rcmax,mmax,mxprj,iexc,ea,etot,epstot,nproj,vpuns, &
-&                  lloc,vkb,evkb)
+      call run_config_r(jj,nacnf,lacnf,facnf,nc,nvcnf,rhot,rhomod,rr,zz, &
+      &                  rcmax,mmax,mxprj,iexc,ea,etot,epstot,nproj,vpuns, &
+      &                  lloc,vkb,evkb)
 
- end do !jj
+   end do  !jj
 
- call run_plot_r(lmax,npa,epa,lloc,irc, &
-&                    vkb,evkb,nproj,rr,vfull,vp,vpuns,zz,mmax,mxprj,drl,nrl, &
-&                    rho,rhoc,rhomod,cvgplt)
+   call run_plot_r(lmax,npa,epa,lloc,irc, &
+   &                    vkb,evkb,nproj,rr,vfull,vp,vpuns,zz,mmax,mxprj,drl,nrl, &
+   &                    rho,rhoc,rhomod,cvgplt)
 
- call run_phsft_r(lmax,lloc,nproj,ep,epsh1,epsh2,depsh,vkb,evkb, &
-&               rr,vfull,vp,zz,mmax,mxprj,irc)
+   call run_phsft_r(lmax,lloc,nproj,ep,epsh1,epsh2,depsh,vkb,evkb, &
+   &               rr,vfull,vp,zz,mmax,mxprj,irc)
 
- call gnu_script_r(epa,evkb,lmax,lloc,mxprj,nproj)
+   call gnu_script_r(epa,evkb,lmax,lloc,mxprj,nproj)
 
- if(trim(psfile)=='psp8' .or. trim(psfile)=='both') then
+   if(trim(psfile)=='psp8' .or. trim(psfile)=='both') then
 
- soscale=1.0d0
- call linout_r(lmax,lloc,rc,vsr,esr,vso,eso,nproj,rr,vpuns,rho,rhomod, &
-&             rhotae,rhoc,zz,zion,mmax,mxprj,iexc,icmod,nrl,drl,atsym,soscale, &
-&             na,la,ncon,nbas,nvcnf,nacnf,lacnf,nc,nv,lpopt,ncnf, &
-&             fa,rc0,ep,qcut,debl,facnf,dvloc0,fcfact,rcfact, &
-&             epsh1,epsh2,depsh,rlmax,psfile)
+      soscale=1.0d0
+      call linout_r(lmax,lloc,rc,vsr,esr,vso,eso,nproj,rr,vpuns,rho,rhomod, &
+      &             rhotae,rhoc,zz,zion,mmax,mxprj,iexc,icmod,nrl,drl,atsym,soscale, &
+      &             na,la,ncon,nbas,nvcnf,nacnf,lacnf,nc,nv,lpopt,ncnf, &
+      &             fa,rc0,ep,qcut,debl,facnf,dvloc0,fcfact,rcfact, &
+      &             epsh1,epsh2,depsh,rlmax,psfile)
 
- end if
+   end if
 
- if(trim(psfile)=='upf' .or. trim(psfile)=='both') then
+   if(trim(psfile)=='upf' .or. trim(psfile)=='both') then
 
- call upfout_r(lmax,lloc,rc,vkb,evkb,nproj,rr,vpuns,rho,rhomod, &
-&              zz,zion,mmax,mxprj,iexc,icmod,nrl,drl,atsym,epstot, &
-&              na,la,ncon,nbas,nvcnf,nacnf,lacnf,nc,nv,lpopt,ncnf, &
-&              fa,rc0,ep,qcut,debl,facnf,dvloc0,fcfact,rcfact, &
-&              epsh1,epsh2,depsh,rlmax,psfile,uupsa,ea)
+      call upfout_r(lmax,lloc,rc,vkb,evkb,nproj,rr,vpuns,rho,rhomod, &
+      &              zz,zion,mmax,mxprj,iexc,icmod,nrl,drl,atsym,epstot, &
+      &              na,la,ncon,nbas,nvcnf,nacnf,lacnf,nc,nv,lpopt,ncnf, &
+      &              fa,rc0,ep,qcut,debl,facnf,dvloc0,fcfact,rcfact, &
+      &              epsh1,epsh2,depsh,rlmax,psfile,uupsa,ea)
 
- end if
+   end if
 
- if(trim(psfile)=='psml' .or. trim(psfile)=='both') then
-   print *, 'calling psmlout'
-   call psmlout_r(lmax,lloc,rc,vkb,evkb,nproj,rr,vpsml,rho,rhomod, &
-&             irct, &
-&             vsr,esr,vso,eso, &
-&             zz,zion,mmax,iexc,icmod,nrl,drl,atsym,epstot, &
-&             na,la,ncon,nbas,nvcnf,nacnf,lacnf,nc,nv,lpopt,ncnf, &
-&             fa,rc0,ep,qcut,debl,facnf,dvloc0,fcfact, &
-&             epsh1,epsh2,depsh,rlmax,psfile)
- end if
+   if(trim(psfile)=='psml' .or. trim(psfile)=='both') then
+      print *, 'calling psmlout'
+      call psmlout_r(lmax,lloc,rc,vkb,evkb,nproj,rr,vpsml,rho,rhomod, &
+      &             irct, &
+      &             vsr,esr,vso,eso, &
+      &             zz,zion,mmax,iexc,icmod,nrl,drl,atsym,epstot, &
+      &             na,la,ncon,nbas,nvcnf,nacnf,lacnf,nc,nv,lpopt,ncnf, &
+      &             fa,rc0,ep,qcut,debl,facnf,dvloc0,fcfact, &
+      &             epsh1,epsh2,depsh,rlmax,psfile)
+   end if
 
- stop
- end program oncvpsp_r
+   stop
+end program oncvpsp_r
 
 
- subroutine cmtskp(inline)
+subroutine cmtskp(inline)
 ! skips lines of standard input (file 5) whose first character is #
- implicit none
+   implicit none
 
 !In/Out variable
- integer :: inline
+   integer :: inline
 
 !Local variable
- character*1 tst
+   character(len=1) :: tst
 
- tst='#'
- do while (tst=='#')
-  read(5,*) tst
-  inline=inline+1
- end do
- backspace(5)
- inline=inline-1
+   tst='#'
+   do while (tst=='#')
+      read(5,*) tst
+      inline=inline+1
+   end do
+   backspace(5)
+   inline=inline-1
 
- return
- end subroutine cmtskp
+   return
+end subroutine cmtskp
 
- subroutine read_error(ios,inline)
+subroutine read_error(ios,inline)
 ! report data read error and stop
- implicit none
+   implicit none
 
 !Input variables
- integer :: ios,inline
+   integer :: ios,inline
 
- inline=inline+1
- if(ios/=0) then
-  write(6,'(a,i4)') 'Read error, input data file line',inline
-  write(6,'(a)') 'Program will stop'
-  stop
- end if
+   inline=inline+1
+   if(ios/=0) then
+      write(6,'(a,i4)') 'Read error, input data file line',inline
+      write(6,'(a)') 'Program will stop'
+      stop
+   end if
 
- return
- end subroutine read_error
+   return
+end subroutine read_error

--- a/src/optimize.f90
+++ b/src/optimize.f90
@@ -2,31 +2,31 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
 ! calculates convergence-optimized pseudo-wave-function coefficients
 ! in orthonormal and spherical Bessel function bases
 
- subroutine optimize(nnull,nbas,pswf0_sb,pswf0_or,nqout,qout,&
+subroutine optimize(nnull,nbas,pswf0_sb,pswf0_or,nqout,qout,&
 &                    eresid0,eresiddot,eresidmat,&
 &                    pswfnull_sb,pswfnull_or,uunorm,ps0norm,eresidmin,&
 &                    pswfopt_sb,pswfopt_or,ekin_anal,eresq)
 
 !nnull  number of unconstrained basis vectors for residual minimization
 !nbas  number of sbf basis functions
-!pswf0_sb(nbas)  sbf basis  coefficients for constrained part of pseudo 
+!pswf0_sb(nbas)  sbf basis  coefficients for constrained part of pseudo
 !                    wave function
 !pswf0_or(nbas)  or basis  coefficients
 !nqout  number of q values in [0,qmax] for which results are to be saved
@@ -44,71 +44,71 @@
 !ekin_anal  total pswf kinetic energy calculated analytically from E_resid
 !eresq(nqout)  E_resid for optimized pswf as a function of cutoff
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !Input variables
- integer :: nnull,nbas,nqout
- real(dp) :: pswf0_sb(nbas),pswfnull_sb(nbas,nnull)
- real(dp) :: pswf0_or(nbas),pswfnull_or(nbas,nnull)
- real(dp) :: eresid0(nqout),eresiddot(nnull,nqout),eresidmat(nnull,nnull,nqout)
- real(dp) :: orbasis_it(nbas,nbas)
- real(dp) :: qout(nqout),eresq(nqout)
- real(dp) :: uunorm,ps0norm
+   integer :: nnull,nbas,nqout
+   real(dp) :: pswf0_sb(nbas),pswfnull_sb(nbas,nnull)
+   real(dp) :: pswf0_or(nbas),pswfnull_or(nbas,nnull)
+   real(dp) :: eresid0(nqout),eresiddot(nnull,nqout),eresidmat(nnull,nnull,nqout)
+   real(dp) :: orbasis_it(nbas,nbas)
+   real(dp) :: qout(nqout),eresq(nqout)
+   real(dp) :: uunorm,ps0norm
 
 !Output variables
- real(dp) :: eresidmin,ekin_anal
- real(dp) :: pswfopt_sb(nbas),pswfopt_or(nbas)
- real(dp) :: eres(nqout)
+   real(dp) :: eresidmin,ekin_anal
+   real(dp) :: pswfopt_sb(nbas),pswfopt_or(nbas)
+   real(dp) :: eres(nqout)
 
 !Local variables
- real(dp) :: yy,tt,emin,rtsgn,sn
- real(dp) :: emin0,emin1,x1,x1min,x1max
- real(dp), allocatable :: work(:),wmat(:,:),wev(:),wvec(:)
- real(dp), allocatable :: eresidevec_nu(:,:)
- real(dp), allocatable :: pswfopt(:),pswfopt_nu(:)
- real(dp), allocatable :: eresiddot_ev(:),eresideval(:)
- real(dp), parameter :: eps=1.d-10
- integer :: ii,iter,jj,kk,ll,nn,info
- integer, parameter :: niter=100
- logical :: converged
+   real(dp) :: yy,tt,emin,rtsgn,sn
+   real(dp) :: emin0,emin1,x1,x1min,x1max
+   real(dp), allocatable :: work(:),wmat(:,:),wev(:),wvec(:)
+   real(dp), allocatable :: eresidevec_nu(:,:)
+   real(dp), allocatable :: pswfopt(:),pswfopt_nu(:)
+   real(dp), allocatable :: eresiddot_ev(:),eresideval(:)
+   real(dp), parameter :: eps=1.d-10
+   integer :: ii,iter,jj,kk,ll,nn,info
+   integer, parameter :: niter=100
+   logical :: converged
 
 !find eigenvalues and eigenvectors of saved E_resid matrix for qout(1)
 !which is meant to be the cutoff used for optimization
 
- allocate(work(5*nnull),wmat(nnull,nnull),wev(nnull),wvec(nnull))
- allocate(eresidevec_nu(nnull,nnull),eresideval(nnull))
- allocate(eresiddot_ev(nnull))
+   allocate(work(5*nnull),wmat(nnull,nnull),wev(nnull),wvec(nnull))
+   allocate(eresidevec_nu(nnull,nnull),eresideval(nnull))
+   allocate(eresiddot_ev(nnull))
 
 !      SUBROUTINE DSYEV( JOBZ, UPLO, N, A, LDA, W, WORK, LWORK, INFO )
 
- wmat(:,:)=eresidmat(:,:,1)
+   wmat(:,:)=eresidmat(:,:,1)
 
- call dsyev( 'V', 'U', nnull, wmat, nnull, wev, work, 5*nnull, info )
- if(info .ne. 0) then
-  write(6,'(a,i4)') 'optimize: residual-energy eigenvalue ERROR, info=',info
-  stop
- end if
+   call dsyev( 'V', 'U', nnull, wmat, nnull, wev, work, 5*nnull, info )
+   if(info /= 0) then
+      write(6,'(a,i4)') 'optimize: residual-energy eigenvalue ERROR, info=',info
+      stop
+   end if
 
 !convert <ps0| E_resid |psnull> vector from the null-space representation
 !to the eigenvector representation
 
- wvec(:)=eresiddot(:,1)
- eresiddot_ev(:)=0.0d0
- do jj=1,nnull
-  do kk=1,nnull
-   eresiddot_ev(jj)=eresiddot_ev(jj)+wvec(kk)*wmat(kk,jj)
-  end do
- end do
+   wvec(:)=eresiddot(:,1)
+   eresiddot_ev(:)=0.0d0
+   do jj=1,nnull
+      do kk=1,nnull
+         eresiddot_ev(jj)=eresiddot_ev(jj)+wvec(kk)*wmat(kk,jj)
+      end do
+   end do
 
 !write(6,'(/a,1p,4d14.4)') 'eresideval',wev(:)
 !write(6,'(/a,1p,4d14.4)') 'eresiddot_ev',eresiddot_ev(:)
 !write(6,'(/a,1p,4d14.4)') 'eresid0',eresid0(1)
 
- eresideval(:)=wev(:)
- eresidevec_nu(:,:)=wmat(:,:)
+   eresideval(:)=wev(:)
+   eresidevec_nu(:,:)=wmat(:,:)
 
- deallocate(work,wmat,wev,wvec)
+   deallocate(work,wmat,wev,wvec)
 
 !find coefficients of E_resid eigenvectors which must be added to pswf0
 !to minimize E_resid
@@ -117,9 +117,9 @@
 !consisting of a constant plus as sum of linear and quadratic terms in each of
 !these coefficients
 
- allocate(pswfopt(nnull),pswfopt_nu(nnull))
- pswfopt(:)=0.d0
- pswfopt_nu(:)=0.d0
+   allocate(pswfopt(nnull),pswfopt_nu(nnull))
+   pswfopt(:)=0.d0
+   pswfopt_nu(:)=0.d0
 
 !write(6,'(/a,1p,3d16.6)') 'initial emin, final, diff',emin0,emin,emin0-emin
 
@@ -146,88 +146,87 @@
 !   N-M = nnull
 
 
- rtsgn=-sign(1.0d0, eresiddot_ev(1))
- if(ps0norm>uunorm) then
-   write(6,'(/a)') 'optimize: ERROR ps0norm > uunorm, code will stop'
-   stop
- end if
- yy=sqrt((uunorm-ps0norm))
+   rtsgn=-sign(1.0d0, eresiddot_ev(1))
+   if(ps0norm>uunorm) then
+      write(6,'(/a)') 'optimize: ERROR ps0norm > uunorm, code will stop'
+      stop
+   end if
+   yy=sqrt((uunorm-ps0norm))
 
- x1min=0.0d0
- x1max=yy
- converged=.false.
-  
- do iter=1,niter
+   x1min=0.0d0
+   x1max=yy
+   converged=.false.
 
-  x1=0.5d0*(x1max+x1min)
+   do iter=1,niter
 
-  tt=x1**2-yy**2
-  do ii=2,nnull
-   pswfopt(ii)=-eresiddot_ev(ii)/(eresideval(ii)-eresideval(1) &
-&               +abs(eresiddot_ev(1))/x1)
-   tt=tt+pswfopt(ii)**2 
-  end do
+      x1=0.5d0*(x1max+x1min)
 
-  if(x1max-x1min<eps) then
-   pswfopt(1)=rtsgn*x1
-   converged=.true.
-   exit
-  end if
+      tt=x1**2-yy**2
+      do ii=2,nnull
+         pswfopt(ii)=-eresiddot_ev(ii)/(eresideval(ii)-eresideval(1) &
+         &               +abs(eresiddot_ev(1))/x1)
+         tt=tt+pswfopt(ii)**2
+      end do
 
-  if(tt<0.0d0) then
-   x1min=x1
-  else
-   x1max=x1
-  end if
- end do
+      if(x1max-x1min<eps) then
+         pswfopt(1)=rtsgn*x1
+         converged=.true.
+         exit
+      end if
 
- if(converged .eqv. .false.) then
-  write(6,'(/a)') 'optimize: ERROR interval-halving search not converged'
-  stop
- end if
+      if(tt<0.0d0) then
+         x1min=x1
+      else
+         x1max=x1
+      end if
+   end do
 
- emin=eresid0(1)
- do ii=1,nnull
-  emin=emin+(2.0d0*eresiddot_ev(ii)*pswfopt(ii) &
-&            +eresideval(ii)*pswfopt(ii)**2)
- end do
- eresidmin=emin
+   if(converged .eqv. .false.) then
+      write(6,'(/a)') 'optimize: ERROR interval-halving search not converged'
+      stop
+   end if
 
- ekin_anal=0.0d0
+   emin=eresid0(1)
+   do ii=1,nnull
+      emin=emin+(2.0d0*eresiddot_ev(ii)*pswfopt(ii) &
+      &            +eresideval(ii)*pswfopt(ii)**2)
+   end do
+   eresidmin=emin
+
+   ekin_anal=0.0d0
 !find cutoff-dependence of E_resid for optimized pswf
 !must transform pswfopt to the null basis representation to be
-!consistent with the input dot product and 
- allocate(work(nnull))
- do ii=1,nnull
-  pswfopt_nu(ii)=0.0d0
-  do jj=1,nnull
-   pswfopt_nu(ii)=pswfopt_nu(ii)+eresidevec_nu(ii,jj)*pswfopt(jj)
-  end do
- end do
+!consistent with the input dot product and
+   allocate(work(nnull))
+   do ii=1,nnull
+      pswfopt_nu(ii)=0.0d0
+      do jj=1,nnull
+         pswfopt_nu(ii)=pswfopt_nu(ii)+eresidevec_nu(ii,jj)*pswfopt(jj)
+      end do
+   end do
 
- do kk=1,nqout
-  emin=eresid0(kk)
-  work(:)=0.0d0
-  do ii=1,nnull
-   emin=emin+2.0d0*eresiddot(ii,kk)*pswfopt_nu(ii)
-   work(:)=work(:)+eresidmat(:,ii,kk)*pswfopt_nu(ii)
-  end do
-  do ii=1,nnull
-   emin=emin+pswfopt_nu(ii)*work(ii)
-  end do
-  eresq(kk)=emin
-  if(qout(kk)==0.0d0) ekin_anal=emin
- end do
- 
+   do kk=1,nqout
+      emin=eresid0(kk)
+      work(:)=0.0d0
+      do ii=1,nnull
+         emin=emin+2.0d0*eresiddot(ii,kk)*pswfopt_nu(ii)
+         work(:)=work(:)+eresidmat(:,ii,kk)*pswfopt_nu(ii)
+      end do
+      do ii=1,nnull
+         emin=emin+pswfopt_nu(ii)*work(ii)
+      end do
+      eresq(kk)=emin
+      if(qout(kk)==0.0d0) ekin_anal=emin
+   end do
+
 !calculate optimized pswf in sbf representation
- pswfopt_sb(:)=pswf0_sb(:)
- pswfopt_or(:)=pswf0_or(:)
- do ii=1,nnull
-  pswfopt_sb(:)=pswfopt_sb(:)+pswfopt_nu(ii)*pswfnull_sb(:,ii)
-  pswfopt_or(:)=pswfopt_or(:)+pswfopt_nu(ii)*pswfnull_or(:,ii)
- end do
+   pswfopt_sb(:)=pswf0_sb(:)
+   pswfopt_or(:)=pswf0_or(:)
+   do ii=1,nnull
+      pswfopt_sb(:)=pswfopt_sb(:)+pswfopt_nu(ii)*pswfnull_sb(:,ii)
+      pswfopt_or(:)=pswfopt_or(:)+pswfopt_nu(ii)*pswfnull_or(:,ii)
+   end do
 
- deallocate(pswfopt,pswfopt_nu)
- return
- end subroutine optimize
-
+   deallocate(pswfopt,pswfopt_nu)
+   return
+end subroutine optimize

--- a/src/psatom.f90
+++ b/src/psatom.f90
@@ -2,23 +2,23 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
 ! self-consistent pseudoatom calculation
 
- subroutine psatom(na,la,ea,fat,nv,it,rhoc,rho, &
+subroutine psatom(na,la,ea,fat,nv,it,rhoc,rho, &
 &           rr,rcmax,mmax,mxprj,iexc,etot,nproj,vpuns,lloc,vkb,evkb,ierr)
 
 !na  principal quantum number array, dimension nv
@@ -41,72 +41,72 @@
 !evkb VKB projector coefficients
 !uua Array of pseudo-atomic orbitals (output)
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !Input variables
- 
- integer :: mmax,mxprj,iexc,nv,lloc,okb
- integer :: na(nv),la(nv),nproj(5)
- real(dp) :: rcmax
- real(dp) :: fat(30,2),rr(mmax)
- real(dp) :: vpuns(mmax,5),vkb(mmax,mxprj,4),evkb(mxprj,4)
+
+   integer :: mmax,mxprj,iexc,nv,lloc,okb
+   integer :: na(nv),la(nv),nproj(5)
+   real(dp) :: rcmax
+   real(dp) :: fat(30,2),rr(mmax)
+   real(dp) :: vpuns(mmax,5),vkb(mmax,mxprj,4),evkb(mxprj,4)
 
 !Output variables
- integer :: it
- real(dp) :: etot
- real(dp) :: ea(nv)
- real(dp) :: rho(mmax),rhoc(mmax),vi(mmax)
- real(dp) :: uua(mmax,nv)
+   integer :: it
+   real(dp) :: etot
+   real(dp) :: ea(nv)
+   real(dp) :: rho(mmax),rhoc(mmax),vi(mmax)
+   real(dp) :: uua(mmax,nv)
 
 !Local variables
- integer :: nin,mch
- real(dp) :: amesh,al
- real(dp) :: dr,eeel,eexc,et,emin,emax,rl,rl1,sd,sn,sls,eeig
- real(dp) :: thl,vn,zval,dfa
- real(dp) :: fa(30)
- integer :: ii,jj,l1,ierr,icx,nprj
- logical :: convg
+   integer :: nin,mch
+   real(dp) :: amesh,al
+   real(dp) :: dr,eeel,eexc,et,emin,emax,rl,rl1,sd,sn,sls,eeig
+   real(dp) :: thl,vn,zval,dfa
+   real(dp) :: fa(30)
+   integer :: ii,jj,l1,ierr,icx,nprj
+   logical :: convg
 
- real(dp), allocatable :: uu(:),up(:)
- real(dp), allocatable :: vo(:),vi1(:),vo1(:),vxc(:),vp(:)
- real(dp), allocatable :: vtot(:)
+   real(dp), allocatable :: uu(:),up(:)
+   real(dp), allocatable :: vo(:),vi1(:),vo1(:),vxc(:),vp(:)
+   real(dp), allocatable :: vtot(:)
 
 
 ! blend parameter for Anderson iterative potential mixing
- real(dp), parameter ::  bl=0.5d0
+   real(dp), parameter ::  bl=0.5d0
 
- allocate(uu(mmax),up(mmax))
- allocate(vo(mmax),vi1(mmax),vo1(mmax),vxc(mmax),vp(mmax))
- allocate(vtot(mmax))
+   allocate(uu(mmax),up(mmax))
+   allocate(vo(mmax),vi1(mmax),vo1(mmax),vxc(mmax),vp(mmax))
+   allocate(vtot(mmax))
 
 ! this seems necessary in sratom, so I might as well do it  here too
 ! don't ask why!
- uu(:)=0.d0; up(:)=0.d0
- vo(:)=0.d0; vi1(:)=0.d0; vo1(:)=0.d0; vxc(:)=0.d0; vp(:)=0.d0
- vtot(:)=0.d0
- dr=0.d0; eeel=0.d0; eexc=0.d0; et=0.d0; emin=0.d0; emax=0.d0;
- rl=0.d0; rl1=0.d0; sd=0.d0; sn=0.d0; sls=0.d0; eeig=0.d0; 
- thl=0.d0; vn=0.d0; zval=0.d0; 
- nin=0; mch=0 
+   uu(:)=0.d0; up(:)=0.d0
+   vo(:)=0.d0; vi1(:)=0.d0; vo1(:)=0.d0; vxc(:)=0.d0; vp(:)=0.d0
+   vtot(:)=0.d0
+   dr=0.d0; eeel=0.d0; eexc=0.d0; et=0.d0; emin=0.d0; emax=0.d0;
+   rl=0.d0; rl1=0.d0; sd=0.d0; sn=0.d0; sls=0.d0; eeig=0.d0;
+   thl=0.d0; vn=0.d0; zval=0.d0;
+   nin=0; mch=0
 
- al = 0.01d0 * dlog(rr(101) / rr(1))
- amesh = dexp(al)
+   al = 0.01d0 * dlog(rr(101) / rr(1))
+   amesh = dexp(al)
 
- nprj=0
- do l1=1,4
-   nprj=max(nprj,nproj(l1))
- end do
+   nprj=0
+   do l1=1,4
+      nprj=max(nprj,nproj(l1))
+   end do
 
 ! total valence charge, initial config
- zval=0.0d0
- do ii=1,nv
-   fa(ii)=fat(ii,1)
-   zval=zval+fa(ii)
- end do
+   zval=0.0d0
+   do ii=1,nv
+      fa(ii)=fat(ii,1)
+      zval=zval+fa(ii)
+   end do
 
-! test if new states are added 
- icx=50
+! test if new states are added
+   icx=50
 !do ii=1,nv
 !  if(fat(ii,2)>fat(ii,1)) icx=100
 !end do
@@ -116,128 +116,128 @@
 ! which shouldn''t be a bad approximation for a starting screened
 ! potential
 
- call vout(1,rho,rhoc,vi,vxc,zval,eeel,eexc,rr,mmax,iexc)
+   call vout(1,rho,rhoc,vi,vxc,zval,eeel,eexc,rr,mmax,iexc)
 
 
 ! big self  self-consietency loop
- do it=1,100
+   do it=1,100
 
 ! convergence is only to be considered if we are fully in  the target
 ! configurtion
 
-  if(it>2) then
-    convg=.true.
-  else
-    convg=.false.
-  end if
+      if(it>2) then
+         convg=.true.
+      else
+         convg=.false.
+      end if
 
 ! solve for bound states in turn
 
-   eeig=0.0d0
+      eeig=0.0d0
 
-   vtot(:)=vpuns(:,lloc+1)+vi(:)
+      vtot(:)=vpuns(:,lloc+1)+vi(:)
 
-   rho(:)=0.0d0
+      rho(:)=0.0d0
 
-   do ii=1,nv
+      do ii=1,nv
 
-     if(fa(ii)==0.0d0) then
-       cycle
-     end if
-     et=ea(ii)
-     ierr = 0
-     l1=la(ii)+1
+         if(fa(ii)==0.0d0) then
+            cycle
+         end if
+         et=ea(ii)
+         ierr = 0
+         l1=la(ii)+1
 
-     emin=1.10d0*ea(ii)
-     emax=0.90d0*ea(ii)
-     call lschvkbb(na(ii),la(ii),nproj(l1),ierr,et,emin,emax, &
-&                 rr,vtot,vkb(1,1,l1),evkb(1,l1),uu,up,mmax,mch)
-     
-     if(ierr .ne. 0) then
-       write(6,'(/a,3i4)') 'psatom: WARNING lschvkbb convergence error n,l,iter=', &
-&       na(ii),la(ii),it
-       write(6,'(a,1p,4e14.6)') 'ea(ii),et,emin,emax',ea(ii),et,emin,emax
-       exit
-     end if
+         emin=1.10d0*ea(ii)
+         emax=0.90d0*ea(ii)
+         call lschvkbb(na(ii),la(ii),nproj(l1),ierr,et,emin,emax, &
+         &                 rr,vtot,vkb(1,1,l1),evkb(1,l1),uu,up,mmax,mch)
+
+         if(ierr /= 0) then
+            write(6,'(/a,3i4)') 'psatom: WARNING lschvkbb convergence error n,l,iter=', &
+            &       na(ii),la(ii),it
+            write(6,'(a,1p,4e14.6)') 'ea(ii),et,emin,emax',ea(ii),et,emin,emax
+            exit
+         end if
 
 ! overall convergence criterion based on eps within lschf*
-     if(ea(ii)/= et) convg=.false.
-     ea(ii)=et
+         if(ea(ii)/= et) convg=.false.
+         ea(ii)=et
 
 ! accumulate charge and eigenvalues
-     eeig = eeig + fa(ii) * ea(ii)
-     rho(:)=rho(:) + fa(ii)*(uu(:)/rr(:))**2
+         eeig = eeig + fa(ii) * ea(ii)
+         rho(:)=rho(:) + fa(ii)*(uu(:)/rr(:))**2
 
-   end do !ii
+      end do  !ii
 
-   if(ierr/=0) exit
+      if(ierr/=0) exit
 
 ! total valence charge
-   zval=0.0d0
-   do ii=1,nv
-     zval=zval+fa(ii)
-   end do
+      zval=0.0d0
+      do ii=1,nv
+         zval=zval+fa(ii)
+      end do
 
 ! output potential
-   call vout(1,rho,rhoc,vo,vxc,zval,eeel,eexc,rr,mmax,iexc)
+      call vout(1,rho,rhoc,vo,vxc,zval,eeel,eexc,rr,mmax,iexc)
 
 ! generate next iteration using d. g. anderson''s
 ! method
-   thl=0.0d0
-   if(it>icx+1) then
-     sn=0.0d0
-     sd=0.0d0
-     do ii=1,mmax
-       rl=vo(ii)-vi(ii)
-       rl1=vo1(ii)-vi1(ii)
-       dr=rl-rl1
-       sn=sn + rl*dr*rr(ii)**2
-       sd=sd + dr*dr*rr(ii)**2
-     end do
-     thl=sn/sd
-   end if
+      thl=0.0d0
+      if(it>icx+1) then
+         sn=0.0d0
+         sd=0.0d0
+         do ii=1,mmax
+            rl=vo(ii)-vi(ii)
+            rl1=vo1(ii)-vi1(ii)
+            dr=rl-rl1
+            sn=sn + rl*dr*rr(ii)**2
+            sd=sd + dr*dr*rr(ii)**2
+         end do
+         thl=sn/sd
+      end if
 
-   do ii=1,mmax
-     vn=(1.0d0-bl)*((1.0d0-thl)*vi(ii) + thl*vi1(ii)) &
-  &   + bl*((1.0d0-thl)*vo(ii) + thl*vo1(ii))
-     vi1(ii)=vi(ii)
-     vo1(ii)=vo(ii)
-     vi(ii)=vn
-   end do
+      do ii=1,mmax
+         vn=(1.0d0-bl)*((1.0d0-thl)*vi(ii) + thl*vi1(ii)) &
+         &   + bl*((1.0d0-thl)*vo(ii) + thl*vo1(ii))
+         vi1(ii)=vi(ii)
+         vo1(ii)=vo(ii)
+         vi(ii)=vn
+      end do
 
-   if(convg) exit
+      if(convg) exit
 
-   if(it==400 .and. .not. convg) then
-     write(6,'(/a)') 'psatom: potential failed to converge'
-     ierr=101
-   end if
+      if(it==400 .and. .not. convg) then
+         write(6,'(/a)') 'psatom: potential failed to converge'
+         ierr=101
+      end if
 
 ! switch from reference to new configuration
 ! new or increased occupancy added in second stage
-   do ii=1,nv
-     dfa=0.02d0*(fat(ii,2)-fat(ii,1))
-     if(it<=50) then
-       fa(ii)=0.02d0*(50-it)*fat(ii,1) + 0.02d0*it*fat(ii,2)
-     else 
-       fa(ii)=fat(ii,2)
-     end if
-   end do
+      do ii=1,nv
+         dfa=0.02d0*(fat(ii,2)-fat(ii,1))
+         if(it<=50) then
+            fa(ii)=0.02d0*(50-it)*fat(ii,1) + 0.02d0*it*fat(ii,2)
+         else
+            fa(ii)=fat(ii,2)
+         end if
+      end do
 
 
- end do !it
- 
+   end do  !it
+
 ! total energy output
 
 ! output potential for e-e interactions
 
- call vout(1,rho,rhoc,vo,vxc,zval,eeel,eexc, &
-&          rr,mmax,iexc)
+   call vout(1,rho,rhoc,vo,vxc,zval,eeel,eexc, &
+   &          rr,mmax,iexc)
 
- etot =  eeig + eexc - 0.5d0*eeel
+   etot =  eeig + eexc - 0.5d0*eeel
 
- deallocate(uu,up)
- deallocate(vo,vi1,vo1,vxc,vp)
- deallocate(vtot)
- return
+   deallocate(uu,up)
+   deallocate(vo,vi1,vo1,vxc,vp)
+   deallocate(vtot)
+   return
 
- end subroutine psatom
+end subroutine psatom

--- a/src/psatom_r.f90
+++ b/src/psatom_r.f90
@@ -2,23 +2,23 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
 ! self-consistent pseudoatom calculation
 
- subroutine psatom_r(na,la,ea,fat,nv,it,rhoc,rho, &
+subroutine psatom_r(na,la,ea,fat,nv,it,rhoc,rho, &
 &           rr,rcmax,mmax,mxprj,iexc,etot,nproj,vpuns,lloc,vkb,evkb,ierr)
 
 !na  principal quantum number array, dimension nv
@@ -40,83 +40,83 @@
 !vkb   Vanderbilt-Kleinman-Bylander projectors
 !evkb VKB projector coefficients
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !Input variables
- 
- integer :: mmax,mxprj,iexc,nv,lloc,okb
- integer :: na(30),la(30),nproj(5)
- real(dp) :: rcmax
- real(dp) :: fat(30,2),rr(mmax)
- real(dp) :: vpuns(mmax,5),vkb(mmax,mxprj,4,2),evkb(mxprj,4,2)
+
+   integer :: mmax,mxprj,iexc,nv,lloc,okb
+   integer :: na(30),la(30),nproj(5)
+   real(dp) :: rcmax
+   real(dp) :: fat(30,2),rr(mmax)
+   real(dp) :: vpuns(mmax,5),vkb(mmax,mxprj,4,2),evkb(mxprj,4,2)
 
 !Output variables
- integer :: it
- real(dp) :: etot
- real(dp) :: ea(30,2)
- real(dp) :: rho(mmax),rhoc(mmax),vi(mmax)
+   integer :: it
+   real(dp) :: etot
+   real(dp) :: ea(30,2)
+   real(dp) :: rho(mmax),rhoc(mmax),vi(mmax)
 
 !Local variables
- integer :: nin,mch
- real(dp) :: amesh,al
- real(dp) :: dr,eeel,eexc,et,emin,emax,rl,rl1,sd,sn,sls,eeig
- real(dp) :: thl,vn,zval,dfa,fj
- real(dp) :: fa(30)
- integer :: ii,jj,l1,ierr,icx,nprj
- integer :: ikap,kap,ll,mkap
- logical :: convg
+   integer :: nin,mch
+   real(dp) :: amesh,al
+   real(dp) :: dr,eeel,eexc,et,emin,emax,rl,rl1,sd,sn,sls,eeig
+   real(dp) :: thl,vn,zval,dfa,fj
+   real(dp) :: fa(30)
+   integer :: ii,jj,l1,ierr,icx,nprj
+   integer :: ikap,kap,ll,mkap
+   logical :: convg
 
- real(dp), allocatable :: uu(:),up(:)
- real(dp), allocatable :: vo(:),vi1(:),vo1(:),vxc(:),vp(:)
- real(dp), allocatable :: vtot(:)
+   real(dp), allocatable :: uu(:),up(:)
+   real(dp), allocatable :: vo(:),vi1(:),vo1(:),vxc(:),vp(:)
+   real(dp), allocatable :: vtot(:)
 
 
 ! blend parameter for Anderson iterative potential mixing
- real(dp), parameter ::  bl=0.5d0
+   real(dp), parameter ::  bl=0.5d0
 
- allocate(uu(mmax),up(mmax))
- allocate(vo(mmax),vi1(mmax),vo1(mmax),vxc(mmax),vp(mmax))
- allocate(vtot(mmax))
+   allocate(uu(mmax),up(mmax))
+   allocate(vo(mmax),vi1(mmax),vo1(mmax),vxc(mmax),vp(mmax))
+   allocate(vtot(mmax))
 
 ! this seems necessary in sratom, so I might as well do it  here too
 ! don't ask why!
- uu(:)=0.d0; up(:)=0.d0
- vo(:)=0.d0; vi1(:)=0.d0; vo1(:)=0.d0; vxc(:)=0.d0; vp(:)=0.d0
- vtot(:)=0.d0
- dr=0.d0; eeel=0.d0; eexc=0.d0; et=0.d0; emin=0.d0; emax=0.d0;
- rl=0.d0; rl1=0.d0; sd=0.d0; sn=0.d0; sls=0.d0; eeig=0.d0; 
- thl=0.d0; vn=0.d0; zval=0.d0; 
- nin=0; mch=0 
+   uu(:)=0.d0; up(:)=0.d0
+   vo(:)=0.d0; vi1(:)=0.d0; vo1(:)=0.d0; vxc(:)=0.d0; vp(:)=0.d0
+   vtot(:)=0.d0
+   dr=0.d0; eeel=0.d0; eexc=0.d0; et=0.d0; emin=0.d0; emax=0.d0;
+   rl=0.d0; rl1=0.d0; sd=0.d0; sn=0.d0; sls=0.d0; eeig=0.d0;
+   thl=0.d0; vn=0.d0; zval=0.d0;
+   nin=0; mch=0
 
- al = 0.01d0 * dlog(rr(101) / rr(1))
- amesh = dexp(al)
+   al = 0.01d0 * dlog(rr(101) / rr(1))
+   amesh = dexp(al)
 
- nprj=0
- do l1=1,4
-   nprj=max(nprj,nproj(l1))
- end do
+   nprj=0
+   do l1=1,4
+      nprj=max(nprj,nproj(l1))
+   end do
 
 ! total valence charge, initial config
- zval=0.0d0
- do ii=1,nv
-   fa(ii)=fat(ii,1)
-   zval=zval+fa(ii)
- end do
+   zval=0.0d0
+   do ii=1,nv
+      fa(ii)=fat(ii,1)
+      zval=zval+fa(ii)
+   end do
 
-! test if new states are added 
- icx=50
+! test if new states are added
+   icx=50
 
 ! screening potential for pseudocharge
 ! input rho is assumed to be valence rho from all-electron calculation
 ! which shouldn''t be a bad approximation for a starting screened
 ! potential
 
- call vout(1,rho,rhoc,vi,vxc,zval,eeel,eexc,rr,mmax,iexc)
+   call vout(1,rho,rhoc,vi,vxc,zval,eeel,eexc,rr,mmax,iexc)
 
 
 ! big self  self-consietency loop
- do it=1,100
+   do it=1,100
 
 
 ! add well do deal with initially unbound states which may arise from
@@ -126,136 +126,136 @@
 
 ! convergence is only to be considered if we are fully in  the target
 ! configurtion
-  if(it>2) then
-    convg=.true.
-  else
-    convg=.false.
-  end if
+      if(it>2) then
+         convg=.true.
+      else
+         convg=.false.
+      end if
 
 ! solve for bound states in turn
 
-   eeig=0.0d0
+      eeig=0.0d0
 
-   vtot(:)=vpuns(:,lloc+1)+vi(:)
+      vtot(:)=vpuns(:,lloc+1)+vi(:)
 
-   rho(:)=0.0d0
+      rho(:)=0.0d0
 
-   do ii=1,nv
+      do ii=1,nv
 
-     if(fa(ii)==0.0d0) then
-       cycle
-     end if
+         if(fa(ii)==0.0d0) then
+            cycle
+         end if
 
-     ierr = 0
-     l1=la(ii)+1
-     ll=la(ii)
-     if(ll==0) then
-      mkap=1
-     else
-      mkap=2
-     end if
+         ierr = 0
+         l1=la(ii)+1
+         ll=la(ii)
+         if(ll==0) then
+            mkap=1
+         else
+            mkap=2
+         end if
 ! loop on J = ll +/- 1/2
-      do ikap=1,mkap
-        if(ikap==1) then
-          kap=-(ll+1)
-          fj=dble(ll+1)*fa(ii)/dble(2*ll+1)
-        else
-          kap=  ll
-          fj=dble(ll)*fa(ii)/dble(2*ll+1)
-        end if
-        et=ea(ii,ikap)
+         do ikap=1,mkap
+            if(ikap==1) then
+               kap=-(ll+1)
+               fj=dble(ll+1)*fa(ii)/dble(2*ll+1)
+            else
+               kap=  ll
+               fj=dble(ll)*fa(ii)/dble(2*ll+1)
+            end if
+            et=ea(ii,ikap)
 
-       emin=1.10d0*ea(ii,ikap)
-       emax=0.90d0*ea(ii,ikap)
-       call lschvkbb(na(ii),la(ii),nproj(l1),ierr,et,emin,emax, &
-&                   rr,vtot,vkb(1,1,l1,ikap),evkb(1,l1,ikap),uu,up,mmax,mch)
-       
-       if(ierr .ne. 0) then
-         write(6,'(/a,3i4)') &
-&              'psatom_r: WARNING lschvkbb convergence error n,l,kap,iter=', &
-&               na(ii),la(ii),kap,it
-         write(6,'(a,1p,4e14.6)') 'ea(ii),et,emin,emax',ea(ii,ikap),et,emin,emax
-          exit
-       end if
+            emin=1.10d0*ea(ii,ikap)
+            emax=0.90d0*ea(ii,ikap)
+            call lschvkbb(na(ii),la(ii),nproj(l1),ierr,et,emin,emax, &
+            &                   rr,vtot,vkb(1,1,l1,ikap),evkb(1,l1,ikap),uu,up,mmax,mch)
+
+            if(ierr /= 0) then
+               write(6,'(/a,3i4)') &
+               &              'psatom_r: WARNING lschvkbb convergence error n,l,kap,iter=', &
+               &               na(ii),la(ii),kap,it
+               write(6,'(a,1p,4e14.6)') 'ea(ii),et,emin,emax',ea(ii,ikap),et,emin,emax
+               exit
+            end if
 
 !   overall convergence criterion based on eps within lschf*
-       if(ea(ii,ikap)/= et) convg=.false.
-       ea(ii,ikap)=et
+            if(ea(ii,ikap)/= et) convg=.false.
+            ea(ii,ikap)=et
 
 ! accumulate charge and eigenvalues
-       eeig = eeig + fj*ea(ii,ikap)
-       rho(:)=rho(:) + fj*(uu(:)/rr(:))**2
-     end do !ikap
-   end do !ii
+            eeig = eeig + fj*ea(ii,ikap)
+            rho(:)=rho(:) + fj*(uu(:)/rr(:))**2
+         end do  !ikap
+      end do  !ii
 
-   if(ierr/=0) exit
+      if(ierr/=0) exit
 
 ! total valence charge
-   zval=0.0d0
-   do ii=1,nv
-     zval=zval+fa(ii)
-   end do
+      zval=0.0d0
+      do ii=1,nv
+         zval=zval+fa(ii)
+      end do
 
 ! output potential
-   call vout(1,rho,rhoc,vo,vxc,zval,eeel,eexc,rr,mmax,iexc)
+      call vout(1,rho,rhoc,vo,vxc,zval,eeel,eexc,rr,mmax,iexc)
 
 ! generate next iteration using d. g. anderson''s
 ! method
-   thl=0.0d0
-   if(it>icx+1) then
-     sn=0.0d0
-     sd=0.0d0
-     do ii=1,mmax
-       rl=vo(ii)-vi(ii)
-       rl1=vo1(ii)-vi1(ii)
-       dr=rl-rl1
-       sn=sn + rl*dr*rr(ii)**2
-       sd=sd + dr*dr*rr(ii)**2
-     end do
-     thl=sn/sd
-   end if
+      thl=0.0d0
+      if(it>icx+1) then
+         sn=0.0d0
+         sd=0.0d0
+         do ii=1,mmax
+            rl=vo(ii)-vi(ii)
+            rl1=vo1(ii)-vi1(ii)
+            dr=rl-rl1
+            sn=sn + rl*dr*rr(ii)**2
+            sd=sd + dr*dr*rr(ii)**2
+         end do
+         thl=sn/sd
+      end if
 
-   do ii=1,mmax
-     vn=(1.0d0-bl)*((1.0d0-thl)*vi(ii) + thl*vi1(ii)) &
-  &   + bl*((1.0d0-thl)*vo(ii) + thl*vo1(ii))
-     vi1(ii)=vi(ii)
-     vo1(ii)=vo(ii)
-     vi(ii)=vn
-   end do
+      do ii=1,mmax
+         vn=(1.0d0-bl)*((1.0d0-thl)*vi(ii) + thl*vi1(ii)) &
+         &   + bl*((1.0d0-thl)*vo(ii) + thl*vo1(ii))
+         vi1(ii)=vi(ii)
+         vo1(ii)=vo(ii)
+         vi(ii)=vn
+      end do
 
-   if(convg) exit
+      if(convg) exit
 
-   if(it==100 .and. .not. convg) then
-     write(6,'(/a)') 'psatom_r: WARNING potential failed to converge'
-     ierr=101
-   end if
+      if(it==100 .and. .not. convg) then
+         write(6,'(/a)') 'psatom_r: WARNING potential failed to converge'
+         ierr=101
+      end if
 
 ! switch from reference to new configuration
 ! new or increased occupancy added in second stage
-   do ii=1,nv
-     dfa=0.02d0*(fat(ii,2)-fat(ii,1))
-     if(it<=50) then
-       fa(ii)=0.02d0*(50-it)*fat(ii,1) + 0.02d0*it*fat(ii,2)
-     else 
-       fa(ii)=fat(ii,2)
-     end if
-   end do
+      do ii=1,nv
+         dfa=0.02d0*(fat(ii,2)-fat(ii,1))
+         if(it<=50) then
+            fa(ii)=0.02d0*(50-it)*fat(ii,1) + 0.02d0*it*fat(ii,2)
+         else
+            fa(ii)=fat(ii,2)
+         end if
+      end do
 
 
- end do !it
- 
+   end do  !it
+
 
 ! total energy output
 ! output potential for e-e interactions
 
- call vout(1,rho,rhoc,vo,vxc,zval,eeel,eexc, &
-&          rr,mmax,iexc)
+   call vout(1,rho,rhoc,vo,vxc,zval,eeel,eexc, &
+   &          rr,mmax,iexc)
 
- etot =  eeig + eexc - 0.5d0*eeel
+   etot =  eeig + eexc - 0.5d0*eeel
 
- deallocate(uu,up)
- deallocate(vo,vi1,vo1,vxc,vp)
- deallocate(vtot)
- return
+   deallocate(uu,up)
+   deallocate(vo,vi1,vo1,vxc,vp)
+   deallocate(vtot)
+   return
 
- end subroutine psatom_r
+end subroutine psatom_r

--- a/src/pspot.f90
+++ b/src/pspot.f90
@@ -2,28 +2,28 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- subroutine pspot(ipr,ll,rr,irc,mmax,al,nbas,qroot,eig,uu,pswfopt_sb, &
+subroutine pspot(ipr,ll,rr,irc,mmax,al,nbas,qroot,eig,uu,pswfopt_sb, &
 &           psopt,vae,vpsp,vkb,ekin_num)
 
 !calculates optimized pseudopotential from coefficients of optimized
 !pseudo wave function and all-electron wave function
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !INPUT
 !ipr 1 for first projector, 2 for second which usually has a node
@@ -46,39 +46,39 @@
 !ekin_num  total radial kinetic energy
 
 !Input variables
- integer :: ipr,ll,irc,mmax,nbas
- real(dp) :: rr(mmax),qroot(nbas),uu(mmax),pswfopt_sb(nbas),vae(mmax)
- real(dp) :: al,eig
+   integer :: ipr,ll,irc,mmax,nbas
+   real(dp) :: rr(mmax),qroot(nbas),uu(mmax),pswfopt_sb(nbas),vae(mmax)
+   real(dp) :: al,eig
 
 !Output variables
- real(dp) :: psopt(mmax)
- real(dp) :: vpsp(mmax),vkb(mmax)
- real(dp) :: ekin_num
+   real(dp) :: psopt(mmax)
+   real(dp) :: vpsp(mmax),vkb(mmax)
+   real(dp) :: ekin_num
 
 !Local variables
- real(dp), allocatable :: work(:,:)
- real(dp) :: sbfder(5)
- real(dp) :: amesh,tt,ddt,ske,ro
- integer :: ii,jj,kk,ll1
- integer :: ixp(4)
+   real(dp), allocatable :: work(:,:)
+   real(dp) :: sbfder(5)
+   real(dp) :: amesh,tt,ddt,ske,ro
+   integer :: ii,jj,kk,ll1
+   integer :: ixp(4)
 
- allocate(work(mmax,5))
- work(:,:)=0.0d0
+   allocate(work(mmax,5))
+   work(:,:)=0.0d0
 
 
- ll1=ll+1
- ixp(1)=2
- ixp(2)=4
- ixp(3)=6
- ixp(4)=8
+   ll1=ll+1
+   ixp(1)=2
+   ixp(2)=4
+   ixp(3)=6
+   ixp(4)=8
 
- do ii=1,mmax
-  work(ii,1)=uu(ii)
- end do
+   do ii=1,mmax
+      work(ii,1)=uu(ii)
+   end do
 
 !numerical derivatives of all-electron wave function
 !note that we are taking derivatives of uu here, not uu/rr as for sbf matching
- do jj=2,3
+   do jj=2,3
 
 ! 5-point numerical first derivatives applied successively
 !  do ii=1+2*jj,mmax-2*jj
@@ -87,73 +87,73 @@
 !&     /(24.d0*al*rr(ii))
 
 ! 7-point numerical first derivatives applied successively
-  do ii=1+3*jj,mmax-3*jj
-     work(ii,jj)=(-work(ii-3,jj-1)+ 9.d0*work(ii-2,jj-1)&
-&     -45.d0*work(ii-1,jj-1)+45.d0*work(ii+1,jj-1)&
-&     -9.d0*work(ii+2,jj-1)+work(ii+3,jj-1))&
-&     /(60.d0*al*rr(ii))
-  end do
- end do
+      do ii=1+3*jj,mmax-3*jj
+         work(ii,jj)=(-work(ii-3,jj-1)+ 9.d0*work(ii-2,jj-1)&
+         &     -45.d0*work(ii-1,jj-1)+45.d0*work(ii+1,jj-1)&
+         &     -9.d0*work(ii+2,jj-1)+work(ii+3,jj-1))&
+         &     /(60.d0*al*rr(ii))
+      end do
+   end do
 
 !fill [0, rc] with rr * analytic pswf and 2nd derivatives
- do ii=1,irc
-  tt=0.0d0
-  ddt=0.0d0
-  do jj=1,nbas
-   call sbf_rc_der(ll,qroot(jj),rr(ii),sbfder)
-   tt=tt+pswfopt_sb(jj)*rr(ii)*sbfder(1)
-   ddt=ddt+pswfopt_sb(jj)*(rr(ii)*sbfder(3)+2.0d0*sbfder(2))
-  end do
-  work(ii,1)=tt
-  work(ii,3)=ddt
- end do
+   do ii=1,irc
+      tt=0.0d0
+      ddt=0.0d0
+      do jj=1,nbas
+         call sbf_rc_der(ll,qroot(jj),rr(ii),sbfder)
+         tt=tt+pswfopt_sb(jj)*rr(ii)*sbfder(1)
+         ddt=ddt+pswfopt_sb(jj)*(rr(ii)*sbfder(3)+2.0d0*sbfder(2))
+      end do
+      work(ii,1)=tt
+      work(ii,3)=ddt
+   end do
 
- do ii=1,mmax
-  psopt(ii)=work(ii,1)
- end do
+   do ii=1,mmax
+      psopt(ii)=work(ii,1)
+   end do
 
 !integration for radial kinetic energy
 
- amesh = exp(al)
- ro=rr(5)/sqrt(amesh)
+   amesh = exp(al)
+   ro=rr(5)/sqrt(amesh)
 
 !kinetic operator on psopt including centrifugal term
- work(:,4)=0.5d0*(ll*ll1*work(:,1)/rr(:)**2-work(:,3))
+   work(:,4)=0.5d0*(ll*ll1*work(:,1)/rr(:)**2-work(:,3))
 
 
 !pseudopotential and node test
- do ii=1,irc
-  if(abs(work(ii,1))>0.0d0) then
-   if(ipr<=1 .and. work(ii,1)*work(ii+1,1)<0.0d0) then
-    write(6,'(a)') ' ERROR pspot:  first pseudo wave function has node, &
-&         program will stop'
-    write(6,'(a)') ' ERROR pspot: try changing psp parameters for this l'
-    stop
-   end if
-   vpsp(ii)=-work(ii,4)/work(ii,1) + eig
-   vkb(ii)=-work(ii,4) + eig*work(ii,1)
-  else
-   vpsp(ii)=0.0d0
-  end if
- end do
+   do ii=1,irc
+      if(abs(work(ii,1))>0.0d0) then
+         if(ipr<=1 .and. work(ii,1)*work(ii+1,1)<0.0d0) then
+            write(6,'(a)') ' ERROR pspot:  first pseudo wave function has node, &
+            &         program will stop'
+            write(6,'(a)') ' ERROR pspot: try changing psp parameters for this l'
+            stop
+         end if
+         vpsp(ii)=-work(ii,4)/work(ii,1) + eig
+         vkb(ii)=-work(ii,4) + eig*work(ii,1)
+      else
+         vpsp(ii)=0.0d0
+      end if
+   end do
 
- do ii=irc+1,mmax
-   vpsp(ii)=vae(ii)
-   vkb(ii)=vae(ii)*work(ii,1)
- end do
+   do ii=irc+1,mmax
+      vpsp(ii)=vae(ii)
+      vkb(ii)=vae(ii)*work(ii,1)
+   end do
 
 !kinetic energy integrand
- work(:,5)=work(:,1)*work(:,4)
+   work(:,5)=work(:,1)*work(:,4)
 
- ro=rr(5)/sqrt(amesh)
- ske=((work(5,5))/rr(5)**ixp(ll1)) * ro**ixp(ll1)/ixp(ll1)
+   ro=rr(5)/sqrt(amesh)
+   ske=((work(5,5))/rr(5)**ixp(ll1)) * ro**ixp(ll1)/ixp(ll1)
 
- do ii=5,mmax-9
-  ske=ske+al*rr(ii)*work(ii,5)
- end do
+   do ii=5,mmax-9
+      ske=ske+al*rr(ii)*work(ii,5)
+   end do
 
- ekin_num=ske
+   ekin_num=ske
 
- deallocate(work)
- return
- end subroutine pspot
+   deallocate(work)
+   return
+end subroutine pspot

--- a/src/qroots.f90
+++ b/src/qroots.f90
@@ -2,21 +2,21 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- subroutine qroots(ll,rc,ulgd,nroot,dltq,qmax,qroot)
+subroutine qroots(ll,rc,ulgd,nroot,dltq,qmax,qroot)
 
 !calculate q values for spherical Bessel function orthogonal basis inside r_c
 !all having specified log derivative ulgd at rc
@@ -24,8 +24,8 @@
 !0.5 times the first matching root, and the average of the 1st and second
 !matching roots
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !INPUT
 !ll  angular momentum
@@ -41,73 +41,73 @@
 
 
 !Arguments
- integer :: ll,nroot
- real(dp) :: rc,ulgd,dltq,qmax
- real(dp) :: qroot(nroot)
+   integer :: ll,nroot
+   real(dp) :: rc,ulgd,dltq,qmax
+   real(dp) :: qroot(nroot)
 
 !Local variables
- real(dp), parameter :: eps=1.0d-12
+   real(dp), parameter :: eps=1.0d-12
 
- real(dp) :: sbfd(5)
- real(dp) al,qq,dlgd,dlgd_last,qhi,qlow,qt
- integer :: ii,jj,ll1,lmax,mmax,iroot,nq
- logical :: found_root
+   real(dp) :: sbfd(5)
+   real(dp) :: al,qq,dlgd,dlgd_last,qhi,qlow,qt
+   integer :: ii,jj,ll1,lmax,mmax,iroot,nq
+   logical :: found_root
 
- nq=int(qmax/dltq)+1
+   nq=int(qmax/dltq)+1
 
- qroot(:)=0.0d0
- iroot=2
- do ii=1,nq
-  qq=dltq*ii
-  call sbf_rc_der(ll,qq,rc,sbfd)
-  dlgd=ulgd - sbfd(2)/sbfd(1)
-  found_root=.false.
-!interval halving to find root
-  if(ii>1 .and. dlgd*dlgd_last < 0.0d0 .and. &
-&         abs(dlgd*dlgd_last)<1.0d0) then
-    if(dlgd>0.0d0) then
-      qhi=qq
-      qlow=dltq*(ii-1)
-    else
-      qhi=dltq*(ii-1)
-      qlow=qq
-    end if
-
-    do jj=1,100
-      qt=0.5d0*(qhi+qlow)
-      call sbf_rc_der(ll,qt,rc,sbfd)
+   qroot(:)=0.0d0
+   iroot=2
+   do ii=1,nq
+      qq=dltq*ii
+      call sbf_rc_der(ll,qq,rc,sbfd)
       dlgd=ulgd - sbfd(2)/sbfd(1)
-      if(abs(dlgd)<eps) then
-        iroot=iroot+1
-        qroot(iroot)=qt
-        found_root=.true.
-        exit
+      found_root=.false.
+!interval halving to find root
+      if(ii>1 .and. dlgd*dlgd_last < 0.0d0 .and. &
+      &         abs(dlgd*dlgd_last)<1.0d0) then
+         if(dlgd>0.0d0) then
+            qhi=qq
+            qlow=dltq*(ii-1)
+         else
+            qhi=dltq*(ii-1)
+            qlow=qq
+         end if
+
+         do jj=1,100
+            qt=0.5d0*(qhi+qlow)
+            call sbf_rc_der(ll,qt,rc,sbfd)
+            dlgd=ulgd - sbfd(2)/sbfd(1)
+            if(abs(dlgd)<eps) then
+               iroot=iroot+1
+               qroot(iroot)=qt
+               found_root=.true.
+               exit
+            end if
+            if(dlgd>0.0d0) then
+               qhi=qt
+            else
+               qlow=qt
+            end if
+         end do
+         found_root=.true.
+         if(.not. found_root) then
+            write(6,'(a)') 'qroots: ERROR - failed to find root'
+            stop
+         end if
       end if
-      if(dlgd>0.0d0) then
-        qhi=qt
-      else
-        qlow=qt
-      end if
-    end do
-    found_root=.true.
-    if(.not. found_root) then
-      write(6,'(a)') 'qroots: ERROR - failed to find root'
+      if(iroot == nroot) exit
+      dlgd_last=dlgd
+   end do
+   if(.not. found_root) then
+      write(6,'(a)') 'qroots: ERROR - failed to find nroot roots'
       stop
-    end if
-  end if
-  if(iroot .eq. nroot) exit
-  dlgd_last=dlgd
- end do
- if(.not. found_root) then
-   write(6,'(a)') 'qroots: ERROR - failed to find nroot roots'
-   stop
- end if
+   end if
 
 !extra q values for needed flexibility to satisfy constraints
- qroot(1)=0.5d0*qroot(3)
- qt=0.5d0*(qroot(3)+qroot(4))
- qroot(2)=qroot(3)
- qroot(3)=qt
+   qroot(1)=0.5d0*qroot(3)
+   qt=0.5d0*(qroot(3)+qroot(4))
+   qroot(2)=qroot(3)
+   qroot(3)=qt
 
- return
- end subroutine qroots
+   return
+end subroutine qroots

--- a/src/relatom.f90
+++ b/src/relatom.f90
@@ -2,21 +2,21 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- subroutine relatom(na,la,ea,fa,rpk,nc,ncv,it,rhoc,rho, &
+subroutine relatom(na,la,ea,fa,rpk,nc,ncv,it,rhoc,rho, &
 &           rr,vi,zz,mmax,iexc,etot,ierr)
 
 ! self-consistent fully-relativistic all-electron atom
@@ -40,183 +40,183 @@
 !ierr  error flag
 !srel  .true. for scalar-relativistic, .false. for non-relativistic
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !Input variables
- 
- integer :: mmax,iexc,nc,ncv
- integer :: na(ncv),la(ncv)
- real(dp) :: zz
- real(dp) :: fa(ncv),rr(mmax)
+
+   integer :: mmax,iexc,nc,ncv
+   integer :: na(ncv),la(ncv)
+   real(dp) :: zz
+   real(dp) :: fa(ncv),rr(mmax)
 
 !Output variables
- integer :: it,ierr
- real(dp) :: etot
- real(dp) :: ea(30,2),rpk(30,2)
- real(dp) :: rho(mmax),rhoc(mmax),vi(mmax)
+   integer :: it,ierr
+   real(dp) :: etot
+   real(dp) :: ea(30,2),rpk(30,2)
+   real(dp) :: rho(mmax),rhoc(mmax),vi(mmax)
 
 !Local function
- real(dp) :: tfapot
+   real(dp) :: tfapot
 
 !Local variables
- integer :: nin,mch
- real(dp) :: amesh,al
- real(dp) :: dr,eeel,eexc,et,rl,rl1,sd,sf,sn,eeig
- real(dp) :: thl,vn,zion,fj
- integer :: ii,jj,ll,ikap,kap,mkap
- logical :: convg
+   integer :: nin,mch
+   real(dp) :: amesh,al
+   real(dp) :: dr,eeel,eexc,et,rl,rl1,sd,sf,sn,eeig
+   real(dp) :: thl,vn,zion,fj
+   integer :: ii,jj,ll,ikap,kap,mkap
+   logical :: convg
 
- real(dp), allocatable :: uu(:,:),up(:,:)
- real(dp), allocatable :: vo(:),vi1(:),vo1(:),vxc(:)
+   real(dp), allocatable :: uu(:,:),up(:,:)
+   real(dp), allocatable :: vo(:),vi1(:),vo1(:),vxc(:)
 
 ! blend parameter for Anderson iterative potential mixing
- real(dp), parameter ::  bl=0.5d0
+   real(dp), parameter ::  bl=0.5d0
 
- allocate(uu(mmax,2),up(mmax,2))
- allocate(vo(mmax),vi1(mmax),vo1(mmax),vxc(mmax))
+   allocate(uu(mmax,2),up(mmax,2))
+   allocate(vo(mmax),vi1(mmax),vo1(mmax),vxc(mmax))
 
 ! why all this is necessary is unclear, but it seems to be
- uu(:,:)=0.d0; up(:,:)=0.d0; vo(:)=0.d0; vi1(:)=0.d0; vo1(:)=0.d0; vxc(:)=0.d0
- dr=0.d0; eeel=0.d0; eexc=0.d0; et=0.d0; rl=0.d0; rl1=0.d0
- sd=0.d0; sf=0.d0; sn=0.d0; eeig=0.d0; thl=0.d0; vn=0.d0; zion=0.d0 
- nin=0; mch=0
+   uu(:,:)=0.d0; up(:,:)=0.d0; vo(:)=0.d0; vi1(:)=0.d0; vo1(:)=0.d0; vxc(:)=0.d0
+   dr=0.d0; eeel=0.d0; eexc=0.d0; et=0.d0; rl=0.d0; rl1=0.d0
+   sd=0.d0; sf=0.d0; sn=0.d0; eeig=0.d0; thl=0.d0; vn=0.d0; zion=0.d0
+   nin=0; mch=0
 
- al = 0.01d0 * dlog(rr(101) / rr(1))
- amesh = dexp(al)
+   al = 0.01d0 * dlog(rr(101) / rr(1))
+   amesh = dexp(al)
 
- do ii=1,mmax
-  vi(ii)=tfapot(rr(ii),zz)
- end do
+   do ii=1,mmax
+      vi(ii)=tfapot(rr(ii),zz)
+   end do
 
 ! starting approximation for energies
- sf=0.0d0
- do ii=1,ncv
-   sf=sf+fa(ii)
-   zion=zz+1.0d0-sf
-   do ikap=1,2
-     ea(ii,ikap)=-0.5d0*(zion/na(ii))**2
-     if(ea(ii,ikap)>vi(mmax)) ea(ii,ikap)=2.0d0*vi(mmax)
+   sf=0.0d0
+   do ii=1,ncv
+      sf=sf+fa(ii)
+      zion=zz+1.0d0-sf
+      do ikap=1,2
+         ea(ii,ikap)=-0.5d0*(zion/na(ii))**2
+         if(ea(ii,ikap)>vi(mmax)) ea(ii,ikap)=2.0d0*vi(mmax)
+      end do
+      if(la(ii)==0) ea(ii,2)=0.0d0
    end do
-   if(la(ii)==0) ea(ii,2)=0.0d0
- end do
 
 ! big self  self-consietency loop
 
- do it=1,100
-   convg=.true.
+   do it=1,100
+      convg=.true.
 
-   rhoc(:) = 0.0d0
-   rho(:)=0.0d0
+      rhoc(:) = 0.0d0
+      rho(:)=0.0d0
 
 ! solve for bound states in turn
-   eeig=0.0d0
-   do ii=1,ncv
-    ll = la(ii)
-    if(ll==0) then
-     mkap=1
-    else
-     mkap=2
-    end if
+      eeig=0.0d0
+      do ii=1,ncv
+         ll = la(ii)
+         if(ll==0) then
+            mkap=1
+         else
+            mkap=2
+         end if
 ! loop on J = ll +/- 1/2
-    do ikap=1,mkap
-     if(ikap==1) then
-       kap=-(ll+1)
-       fj=dble(ll+1)*fa(ii)/dble(2*ll+1)
-     else
-       kap=  ll
-       fj=dble(ll)*fa(ii)/dble(2*ll+1)
-     end if
-     et=ea(ii,ikap)
-     ierr = 0
+         do ikap=1,mkap
+            if(ikap==1) then
+               kap=-(ll+1)
+               fj=dble(ll+1)*fa(ii)/dble(2*ll+1)
+            else
+               kap=  ll
+               fj=dble(ll)*fa(ii)/dble(2*ll+1)
+            end if
+            et=ea(ii,ikap)
+            ierr = 0
 
-     call ldiracfb(na(ii),ll,kap,ierr,et, &
-&                rr,zz,vi,uu,up,mmax,mch)
+            call ldiracfb(na(ii),ll,kap,ierr,et, &
+            &                rr,zz,vi,uu,up,mmax,mch)
 
-     if(ierr .ne. 0) then
-       write(6,'(/2a,5i4)') 'relatom: ldiracfb convergence ERROR', &
-&           ' n,l,kap,iter,ierr=',na(ii),ll,kap,it,ierr
-       stop
-     end if
+            if(ierr /= 0) then
+               write(6,'(/2a,5i4)') 'relatom: ldiracfb convergence ERROR', &
+               &           ' n,l,kap,iter,ierr=',na(ii),ll,kap,it,ierr
+               stop
+            end if
 
 ! overall convergence criterion based on eps within lschfb
-     if(ea(ii,ikap)/= et) convg=.false.
-     ea(ii,ikap)=et
+            if(ea(ii,ikap)/= et) convg=.false.
+            ea(ii,ikap)=et
 
 ! accumulate charge and eigenvalues
-     eeig = eeig + fj*ea(ii,ikap)
-     rho(:)=rho(:) + fj*((uu(:,1)/rr(:))**2 + (uu(:,2)/rr(:))**2)
-     if(ii<=nc) then
-      rhoc(:)=rhoc(:) + fj*((uu(:,1)/rr(:))**2 + (uu(:,2)/rr(:))**2)
-     end if
+            eeig = eeig + fj*ea(ii,ikap)
+            rho(:)=rho(:) + fj*((uu(:,1)/rr(:))**2 + (uu(:,2)/rr(:))**2)
+            if(ii<=nc) then
+               rhoc(:)=rhoc(:) + fj*((uu(:,1)/rr(:))**2 + (uu(:,2)/rr(:))**2)
+            end if
 
 
 ! find outermost peak of wavefunction
-     do jj=mch-1,1,-1
-       if(up(jj,1)*up(jj+1,1)<0.0d0) then
-         rpk(ii,ikap)=rr(jj)
-         exit
-       end if
-     end do
-    end do
-   end do
+            do jj=mch-1,1,-1
+               if(up(jj,1)*up(jj+1,1)<0.0d0) then
+                  rpk(ii,ikap)=rr(jj)
+                  exit
+               end if
+            end do
+         end do
+      end do
 
-   if(ierr/=0) then
-    exit
-   end if
+      if(ierr/=0) then
+         exit
+      end if
 
 
 ! output potential
-   call vout(0,rho,rhoc,vo,vxc,sf-zz,eeel,eexc, &
-&            rr,mmax,iexc)
+      call vout(0,rho,rhoc,vo,vxc,sf-zz,eeel,eexc, &
+      &            rr,mmax,iexc)
 
 ! generate next iteration using d. g. anderson''s
 ! method
-   thl=0.0d0
-   if(it>1) then
-     sn=0.0d0
-     sd=0.0d0
-     do ii=1,mmax
-       rl=vo(ii)-vi(ii)
-       rl1=vo1(ii)-vi1(ii)
-       dr=rl-rl1
-       sn=sn + rl*dr*rr(ii)**2
-       sd=sd + dr*dr*rr(ii)**2
-     end do
-     thl=sn/sd
+      thl=0.0d0
+      if(it>1) then
+         sn=0.0d0
+         sd=0.0d0
+         do ii=1,mmax
+            rl=vo(ii)-vi(ii)
+            rl1=vo1(ii)-vi1(ii)
+            dr=rl-rl1
+            sn=sn + rl*dr*rr(ii)**2
+            sd=sd + dr*dr*rr(ii)**2
+         end do
+         thl=sn/sd
+      end if
+
+      do ii=1,mmax
+         vn=(1.0d0-bl)*((1.0d0-thl)*vi(ii) + thl*vi1(ii)) &
+         &   + bl*((1.0d0-thl)*vo(ii) + thl*vo1(ii))
+         vi1(ii)=vi(ii)
+         vo1(ii)=vo(ii)
+         vi(ii)=vn
+      end do
+
+      if(convg) exit
+
+      if(it==100 .and. .not. convg) then
+         write(6,'(/a)') 'relatom: WARNING failed to converge'
+      end if
+
+   end do  !it
+
+   if(.not. convg .and. ierr==0) then
+      ierr=100
    end if
-
-   do ii=1,mmax
-     vn=(1.0d0-bl)*((1.0d0-thl)*vi(ii) + thl*vi1(ii)) &
-  &   + bl*((1.0d0-thl)*vo(ii) + thl*vo1(ii))
-     vi1(ii)=vi(ii)
-     vo1(ii)=vo(ii)
-     vi(ii)=vn
-   end do
-
-   if(convg) exit
-
-   if(it==100 .and. .not. convg) then
-     write(6,'(/a)') 'relatom: WARNING failed to converge'
-   end if
-
- end do !it
-
- if(.not. convg .and. ierr==0) then
-   ierr=100
- end if
 
 ! total energy output
 
 ! output potential for e-e interactions
 
- call vout(0,rho,rhoc,vo,vxc,sf,eeel,eexc, &
-&          rr,mmax,iexc)
+   call vout(0,rho,rhoc,vo,vxc,sf,eeel,eexc, &
+   &          rr,mmax,iexc)
 
- etot =  eeig + eexc - 0.5d0*eeel
+   etot =  eeig + eexc - 0.5d0*eeel
 
- deallocate(uu,up)
- deallocate(vo,vi1,vo1,vxc)
- return
+   deallocate(uu,up)
+   deallocate(vo,vi1,vo1,vxc)
+   return
 
- end subroutine relatom
+end subroutine relatom

--- a/src/renorm_r.f90
+++ b/src/renorm_r.f90
@@ -2,21 +2,21 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- subroutine renorm_r(uu,rr,ll,kap,zz,mmax,cnorm)
+subroutine renorm_r(uu,rr,ll,kap,zz,mmax,cnorm)
 
 ! renormalize Dirac wave function so that large component is normalized
 
@@ -28,57 +28,57 @@
 !mmax  size of radial grid
 !cnorm  renormalization coefficient
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !Input variables
- real(dp) :: rr(mmax)
- real(dp) :: zz
- integer :: ll,kap,mmax
+   real(dp) :: rr(mmax)
+   real(dp) :: zz
+   integer :: ll,kap,mmax
 
 !Output variable
- real(dp) :: cnorm
+   real(dp) :: cnorm
 
 !Input/Output variable
- real(dp) :: uu(mmax,2)
+   real(dp) :: uu(mmax,2)
 
 !Local variables
- real(dp) :: sn
- real(dp) :: al,amesh
- real(dp) :: r0,gam,cc,cci
- integer :: ii,nin
+   real(dp) :: sn
+   real(dp) :: al,amesh
+   real(dp) :: r0,gam,cc,cci
+   integer :: ii,nin
 
- al = 0.01d0 * dlog(rr(101)/rr(1))
- amesh = exp(al)
+   al = 0.01d0 * dlog(rr(101)/rr(1))
+   amesh = exp(al)
 
- cc=137.036d0
- cci=1.0d0/cc
+   cc=137.036d0
+   cci=1.0d0/cc
 
- gam=sqrt(kap**2-(zz*cci)**2)
+   gam=sqrt(kap**2-(zz*cci)**2)
 
- do ii=mmax,1,-1
-   if(dabs(uu(ii,1))>0.0d0) then
-     nin=ii
-     exit
-   end if
- end do
+   do ii=mmax,1,-1
+      if(dabs(uu(ii,1))>0.0d0) then
+         nin=ii
+         exit
+      end if
+   end do
 
- r0=rr(1)/dsqrt(amesh)
- sn=r0**(2.0d0*gam+1.0d0)/(2.d0*gam+1.0d0)
- sn=sn*(uu(1,1)**2)/rr(1)**(2.d0*gam)
+   r0=rr(1)/dsqrt(amesh)
+   sn=r0**(2.0d0*gam+1.0d0)/(2.d0*gam+1.0d0)
+   sn=sn*(uu(1,1)**2)/rr(1)**(2.d0*gam)
 
- do ii=1,nin-3
-   sn=sn+al*rr(ii)*uu(ii,1)**2
- end do
-  
- sn=sn + al*(23.0d0*rr(nin-2)*uu(nin-2,1)**2 &
-&          + 28.0d0*rr(nin-1)*uu(nin-1,1)**2 &
-&          +  9.0d0*rr(nin  )*uu(nin  ,1)**2)/24.0d0
+   do ii=1,nin-3
+      sn=sn+al*rr(ii)*uu(ii,1)**2
+   end do
+
+   sn=sn + al*(23.0d0*rr(nin-2)*uu(nin-2,1)**2 &
+   &          + 28.0d0*rr(nin-1)*uu(nin-1,1)**2 &
+   &          +  9.0d0*rr(nin  )*uu(nin  ,1)**2)/24.0d0
 
 
- cnorm=sqrt(1.0d0/sn)
+   cnorm=sqrt(1.0d0/sn)
 
- uu(:,:)=cnorm*uu(:,:)
+   uu(:,:)=cnorm*uu(:,:)
 
- return
- end subroutine renorm_r
+   return
+end subroutine renorm_r

--- a/src/run_config.f90
+++ b/src/run_config.f90
@@ -2,17 +2,17 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
@@ -20,7 +20,7 @@
 ! compared for reference and tests atomic configurations
 
 
-  subroutine run_config(jj,nacnf,lacnf,facnf,nc,nvcnf,rhov,rhomod,rr,zz, &
+subroutine run_config(jj,nacnf,lacnf,facnf,nc,nvcnf,rhov,rhomod,rr,zz, &
 &                  rcmax,mmax,mxprj,iexc,ea,etot,epstot,nproj,vpuns, &
 &                  lloc,vkb,evkb,srel)
 
@@ -47,55 +47,55 @@
 !evkb VKB projector coefficients
 !srel .true. for scalar-relativistic, .false. for non-relativistic
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !Input variables
- 
- integer :: jj,mmax,mxprj,iexc,nc,lloc
- integer :: nacnf(30,5),lacnf(30,5),nvcnf(5),nproj(5)
- real(dp) :: etot,epstot,rcmax,zz
- real(dp) :: facnf(30,5),ea(30),rhov(mmax),rr(mmax)
- real(dp) :: vpuns(mmax,5),vkb(mmax,mxprj,4),evkb(mxprj,4),rhomod(mmax,5)
- logical :: srel
+
+   integer :: jj,mmax,mxprj,iexc,nc,lloc
+   integer :: nacnf(30,5),lacnf(30,5),nvcnf(5),nproj(5)
+   real(dp) :: etot,epstot,rcmax,zz
+   real(dp) :: facnf(30,5),ea(30),rhov(mmax),rr(mmax)
+   real(dp) :: vpuns(mmax,5),vkb(mmax,mxprj,4),evkb(mxprj,4),rhomod(mmax,5)
+   logical :: srel
 
 !Output variables  only printing
- 
+
 !Local variables
- integer :: ii,it,kk,l1,ierr,mch,nvt
- integer :: nat(30),lat(30),natp(30),latp(30),nav(4)
- integer ::  indxr(30),indxe(30)
- real(dp) :: et,eaetst,etsttot,zval
+   integer :: ii,it,kk,l1,ierr,mch,nvt
+   integer :: nat(30),lat(30),natp(30),latp(30),nav(4)
+   integer ::  indxr(30),indxe(30)
+   real(dp) :: et,eaetst,etsttot,zval
 !real(dp) :: eat(30,2),fat(30,2),rpk(30),eatp(30),fatp(30,2)
- real(dp) :: eat(30,3),fat(30,3),rpk(30),eatp(30),fatp(30,3)
+   real(dp) :: eat(30,3),fat(30,3),rpk(30),eatp(30),fatp(30,3)
 
- real(dp),allocatable :: rho(:),rhoc(:),rhocps(:),vi(:),vfull(:)
- real(dp),allocatable :: uu(:),up(:)
+   real(dp),allocatable :: rho(:),rhoc(:),rhocps(:),vi(:),vfull(:)
+   real(dp),allocatable :: uu(:),up(:)
 
- allocate(rho(mmax),rhoc(mmax),vi(mmax),vfull(mmax),rhocps(mmax))
- allocate(uu(mmax),up(mmax))
+   allocate(rho(mmax),rhoc(mmax),vi(mmax),vfull(mmax),rhocps(mmax))
+   allocate(uu(mmax),up(mmax))
 
 ! atom tests comparing reference state and excited configuration for
 ! all-electron and pseudo atoms.  Total excitation energies and excited-
 ! -configuration eigenvalues are compared
 
-! For multi-projector potentials, the bound-state solver lschvkbb has poor 
+! For multi-projector potentials, the bound-state solver lschvkbb has poor
 ! stability, and requires a trial energy sufficiently close to the correct
 ! result for a given local potential. This appears to be due to the fact
-! that intermediate stages towards the solution of the radial Schroedinger 
-! equation with a non-local potential may not increase their node count 
+! that intermediate stages towards the solution of the radial Schroedinger
+! equation with a non-local potential may not increase their node count
 ! monotonically with increasing energy (the same phenonenon which gives
 ! rise to ghost states).
 
-! To aviod these problems, the pseudoatom calculation is started with the 
-! screened local potential and valence eigenvalues of the reference 
+! To aviod these problems, the pseudoatom calculation is started with the
+! screened local potential and valence eigenvalues of the reference
 ! configuration.  This is adiabatically changed in two steps.  In the first,
 ! the occupation numbers are changed by 2% within the potential iteration
-! loop for each of the first 50 steps to those of a maximally-ionized 
+! loop for each of the first 50 steps to those of a maximally-ionized
 ! intermediate configuration.
 
 ! The second step is started with the local potential of this maximally-
-! ionized psuedo-atom, and eigenvalues from an all-electron 
+! ionized psuedo-atom, and eigenvalues from an all-electron
 ! calculation of this configuration including unoccupied states that
 ! are to be adiabatically filled to produce the final configuration.
 ! The same 2% strategy is used filling pseudo-atom states in this step.
@@ -111,183 +111,183 @@
    indxr(:)=0
    indxe(:)=0
    do ii=1,nc+nvcnf(1)
-     do kk=1,nc+nvcnf(jj)
-       if(nacnf(kk,jj)==nacnf(ii,1) .and. &
-&         lacnf(kk,jj)==lacnf(ii,1)) then
-         indxr(ii)=kk
-         indxe(kk)=ii
-       end if
-     end do
+      do kk=1,nc+nvcnf(jj)
+         if(nacnf(kk,jj)==nacnf(ii,1) .and. &
+         &         lacnf(kk,jj)==lacnf(ii,1)) then
+            indxr(ii)=kk
+            indxe(kk)=ii
+         end if
+      end do
    end do
 
 ! set up merged list with reference levels first
 ! levels not present in one confguration or the other get zero occupancy
    eat(:,1)=0.0d0
    do ii=1,nc+nvcnf(1)
-     nat(ii)=nacnf(ii,1)
-     lat(ii)=lacnf(ii,1)
-     fat(ii,1)=facnf(ii,1)
-     eat(ii,1)=ea(ii)
-     if(indxr(ii)>0) then
-       fat(ii,2)=facnf(indxr(ii),jj)
-     else
-       fat(ii,2)=0.0d0
-     end if
-     fat(ii,3)=fat(ii,2)
+      nat(ii)=nacnf(ii,1)
+      lat(ii)=lacnf(ii,1)
+      fat(ii,1)=facnf(ii,1)
+      eat(ii,1)=ea(ii)
+      if(indxr(ii)>0) then
+         fat(ii,2)=facnf(indxr(ii),jj)
+      else
+         fat(ii,2)=0.0d0
+      end if
+      fat(ii,3)=fat(ii,2)
    end do
-  
+
    nvt=nvcnf(1)
    do kk=1,nc+nvcnf(jj)
-     if(indxe(kk)==0) then
-       nvt=nvt+1
-       nat(nc+nvt)=nacnf(kk,jj)
-       lat(nc+nvt)=lacnf(kk,jj)
-       fat(nc+nvt,1)=0.0d0
-       fat(nc+nvt,3)=facnf(kk,jj)
-     end if
+      if(indxe(kk)==0) then
+         nvt=nvt+1
+         nat(nc+nvt)=nacnf(kk,jj)
+         lat(nc+nvt)=lacnf(kk,jj)
+         fat(nc+nvt,1)=0.0d0
+         fat(nc+nvt,3)=facnf(kk,jj)
+      end if
    end do
 
 !set up array for maximally ionized intermediate state
    do kk=1,nc+nvt
-     fat(ii,2)=dmin1(fat(ii,1),fat(ii,3))
+      fat(ii,2)=dmin1(fat(ii,1),fat(ii,3))
    end do
 
 
 
- eat(:,2)=0.d0; rpk(:)=0.d0; rhoc(:)=0.d0; rho(:)=0.d0; vfull(:)=0.d0 
- eaetst=0.d0
+   eat(:,2)=0.d0; rpk(:)=0.d0; rhoc(:)=0.d0; rho(:)=0.d0; vfull(:)=0.d0
+   eaetst=0.d0
 
 !all-electron atom solution for maximally-ionized state
 
- call sratom(nat,lat,eat(1,2),fat(1,2),rpk,nc,nc+nvt,it,rhoc,rho, &
-&            rr,vfull,zz,mmax,iexc,eaetst,ierr,srel)
- if(ierr/=0) then
-  write(6,'(a/a,i2)') 'run_config: WARNING  for AE atom,', &
-&       ' WARNING no output for configuration',jj
-  if(ierr==-1) then
-    write(6,'(a,i4)') 'no classical turning point error, iteration',it
-  else
-    write(6,'(a)') 'run_config: WARNING self-consistency failed to converge'
-  end if
-  deallocate(rho,rhoc,rhocps,vi,vfull)
-  deallocate(uu,up)
-  return
- end if
+   call sratom(nat,lat,eat(1,2),fat(1,2),rpk,nc,nc+nvt,it,rhoc,rho, &
+   &            rr,vfull,zz,mmax,iexc,eaetst,ierr,srel)
+   if(ierr/=0) then
+      write(6,'(a/a,i2)') 'run_config: WARNING  for AE atom,', &
+      &       ' WARNING no output for configuration',jj
+      if(ierr==-1) then
+         write(6,'(a,i4)') 'no classical turning point error, iteration',it
+      else
+         write(6,'(a)') 'run_config: WARNING self-consistency failed to converge'
+      end if
+      deallocate(rho,rhoc,rhocps,vi,vfull)
+      deallocate(uu,up)
+      return
+   end if
 
 !fill in energies for empty levels of maximally ionized state
 
- do kk=1,nc+nvt
-   if(eat(kk,2)==0.0d0) then
-     et=0.0d0
-     call lschfb(nat(kk),lat(kk),ierr,et, &
-&                rr,vfull,uu,up,zz,mmax,mch,srel)
-     if(ierr .ne. 0) then
-       write(6,'(/a,3i4)') & 
-&            'runconfig: WARNING lschfb convergence ERROR n,l,iter=', &
-&            nat(kk),lat(kk),it
-       deallocate(rho,rhoc,rhocps,vi,vfull)
-       deallocate(uu,up)
-       return
-     end if
-     eat(kk,2)=et
-   end if
- end do
+   do kk=1,nc+nvt
+      if(eat(kk,2)==0.0d0) then
+         et=0.0d0
+         call lschfb(nat(kk),lat(kk),ierr,et, &
+         &                rr,vfull,uu,up,zz,mmax,mch,srel)
+         if(ierr /= 0) then
+            write(6,'(/a,3i4)') &
+            &            'runconfig: WARNING lschfb convergence ERROR n,l,iter=', &
+            &            nat(kk),lat(kk),it
+            deallocate(rho,rhoc,rhocps,vi,vfull)
+            deallocate(uu,up)
+            return
+         end if
+         eat(kk,2)=et
+      end if
+   end do
 
- eat(:,3)=0.d0; rpk(:)=0.d0; rhoc(:)=0.d0; rho(:)=0.d0; vfull(:)=0.d0 
- eaetst=0.d0
+   eat(:,3)=0.d0; rpk(:)=0.d0; rhoc(:)=0.d0; rho(:)=0.d0; vfull(:)=0.d0
+   eaetst=0.d0
 
 !all-electron atom solution for excited state
 
- call sratom(nat,lat,eat(1,3),fat(1,3),rpk,nc,nc+nvt,it,rhoc,rho, &
-&            rr,vfull,zz,mmax,iexc,eaetst,ierr,srel)
- if(ierr/=0) then
-  write(6,'(a/a,i2)') 'run_config: WARNING  for AE atom,', &
-&       ' WARNING no output for configuration',jj
-  if(ierr==-1) then
-    write(6,'(a,i4)') 'no classical turning point error, iteration',it
-  else
-    write(6,'(a)') 'run_config: WARNING self-consistency failed to converge'
-  end if
-  deallocate(rho,rhoc,rhocps,vi,vfull)
-  deallocate(uu,up)
-  return
- end if
+   call sratom(nat,lat,eat(1,3),fat(1,3),rpk,nc,nc+nvt,it,rhoc,rho, &
+   &            rr,vfull,zz,mmax,iexc,eaetst,ierr,srel)
+   if(ierr/=0) then
+      write(6,'(a/a,i2)') 'run_config: WARNING  for AE atom,', &
+      &       ' WARNING no output for configuration',jj
+      if(ierr==-1) then
+         write(6,'(a,i4)') 'no classical turning point error, iteration',it
+      else
+         write(6,'(a)') 'run_config: WARNING self-consistency failed to converge'
+      end if
+      deallocate(rho,rhoc,rhocps,vi,vfull)
+      deallocate(uu,up)
+      return
+   end if
 
 
 !first pseudoatom run from reference to maximally-ionized configuration
    do l1=1,4
-     nav(l1)=l1-1
+      nav(l1)=l1-1
    end do
 
    do kk=1,nvt
-     latp(kk)=lat(nc+kk)
-     l1=latp(kk)+1
-     nav(l1)=nav(l1)+1
-     natp(kk)=nav(l1)
-     eatp(kk)=eat(nc+kk,1)
-     fatp(kk,1)=fat(nc+kk,1)
-     fatp(kk,2)=fat(nc+kk,2)
+      latp(kk)=lat(nc+kk)
+      l1=latp(kk)+1
+      nav(l1)=nav(l1)+1
+      natp(kk)=nav(l1)
+      eatp(kk)=eat(nc+kk,1)
+      fatp(kk,1)=fat(nc+kk,1)
+      fatp(kk,2)=fat(nc+kk,2)
    end do
 
- rho(:)=rhov(:)
+   rho(:)=rhov(:)
 
- rhocps(:)=rhomod(:,1)
+   rhocps(:)=rhomod(:,1)
 
- call psatom(natp,latp,eatp,fatp,nvt,it,rhocps,rho, &
-&           rr,rcmax,mmax,mxprj,iexc,etsttot,nproj,vpuns,lloc, &
-&           vkb,evkb,ierr)
+   call psatom(natp,latp,eatp,fatp,nvt,it,rhocps,rho, &
+   &           rr,rcmax,mmax,mxprj,iexc,etsttot,nproj,vpuns,lloc, &
+   &           vkb,evkb,ierr)
 
- if(ierr/=0) then
-  write(6,'(a,a/a,i2)') 'run_config: WARNING for fully non-local PS atom,', &
-&       ' stg. 1', &
-&       ' WARNING no output for configuration',jj
-  deallocate(rho,rhoc,rhocps,vi,vfull)
-  return
- end if
+   if(ierr/=0) then
+      write(6,'(a,a/a,i2)') 'run_config: WARNING for fully non-local PS atom,', &
+      &       ' stg. 1', &
+      &       ' WARNING no output for configuration',jj
+      deallocate(rho,rhoc,rhocps,vi,vfull)
+      return
+   end if
 
 !second pseudoatom run from maximally-ionized to excited configuration
 
    do kk=1,nvt
-     eatp(kk)=eat(nc+kk,2)
-     fatp(kk,1)=fat(nc+kk,2)
-     fatp(kk,2)=fat(nc+kk,3)
+      eatp(kk)=eat(nc+kk,2)
+      fatp(kk,1)=fat(nc+kk,2)
+      fatp(kk,2)=fat(nc+kk,3)
    end do
- do ii=1,nvt
- end do
+   do ii=1,nvt
+   end do
 
- call psatom(natp,latp,eatp,fatp,nvt,it,rhocps,rho, &
-&           rr,rcmax,mmax,mxprj,iexc,etsttot,nproj,vpuns,lloc, &
-&           vkb,evkb,ierr)
+   call psatom(natp,latp,eatp,fatp,nvt,it,rhocps,rho, &
+   &           rr,rcmax,mmax,mxprj,iexc,etsttot,nproj,vpuns,lloc, &
+   &           vkb,evkb,ierr)
 
- if(ierr/=0) then
-  write(6,'(a,a/a,i2)') 'run_config: WARNING for fully non-local PS atom,', &
-&       ' stg. 2', &
-&       ' WARNING no output for configuration',jj
-  deallocate(rho,rhoc,rhocps,vi,vfull)
-  return
- end if
+   if(ierr/=0) then
+      write(6,'(a,a/a,i2)') 'run_config: WARNING for fully non-local PS atom,', &
+      &       ' stg. 2', &
+      &       ' WARNING no output for configuration',jj
+      deallocate(rho,rhoc,rhocps,vi,vfull)
+      return
+   end if
 
 
 
- write(6,'(/a)') '   n   l     f        eae           eps        diff'
- do ii=1,nc
-  write(6,'(2i4,f8.4,f14.8)') nat(ii),lat(ii),fat(ii,3),eat(ii,3)
- end do
- do ii=1,nvt
-  if(fat(ii+nc,3)==0.0d0) cycle
-  write(6,'(2i4,f8.4,2f14.8,1p,d12.2)') nat(ii+nc),lat(ii+nc),fat(ii+nc,3), &
-&  eat(ii+nc,3),eatp(ii),eatp(ii)-eat(ii+nc,3)
- end do
+   write(6,'(/a)') '   n   l     f        eae           eps        diff'
+   do ii=1,nc
+      write(6,'(2i4,f8.4,f14.8)') nat(ii),lat(ii),fat(ii,3),eat(ii,3)
+   end do
+   do ii=1,nvt
+      if(fat(ii+nc,3)==0.0d0) cycle
+      write(6,'(2i4,f8.4,2f14.8,1p,d12.2)') nat(ii+nc),lat(ii+nc),fat(ii+nc,3), &
+      &  eat(ii+nc,3),eatp(ii),eatp(ii)-eat(ii+nc,3)
+   end do
 
- write(6,'(/a)') '    Total energies and differences'
- write(6,'(a,1p,d16.8,a,d16.8,a,d10.2)') '      AE_ref=',etot, &
-& '  AE_tst=',eaetst,'  dif=',eaetst-etot
- write(6,'(a,1p,d16.8,a,d16.8,a,d10.2)') '      PS_ref=',epstot, &
-& '  PS_tst=',etsttot,'  dif=',etsttot-epstot
- write(6,'(a,1p,d10.2)') '      PSP excitation error=', &
-& eaetst-etot-etsttot+epstot
+   write(6,'(/a)') '    Total energies and differences'
+   write(6,'(a,1p,d16.8,a,d16.8,a,d10.2)') '      AE_ref=',etot, &
+   & '  AE_tst=',eaetst,'  dif=',eaetst-etot
+   write(6,'(a,1p,d16.8,a,d16.8,a,d10.2)') '      PS_ref=',epstot, &
+   & '  PS_tst=',etsttot,'  dif=',etsttot-epstot
+   write(6,'(a,1p,d10.2)') '      PSP excitation error=', &
+   & eaetst-etot-etsttot+epstot
 
- deallocate(rho,rhoc,rhocps,vi,vfull)
-  deallocate(uu,up)
- return
- end subroutine run_config
+   deallocate(rho,rhoc,rhocps,vi,vfull)
+   deallocate(uu,up)
+   return
+end subroutine run_config

--- a/src/run_config_r.f90
+++ b/src/run_config_r.f90
@@ -2,17 +2,17 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
@@ -20,7 +20,7 @@
 ! compared for reference and tests atomic configurations
 
 
-  subroutine run_config_r(jj,nacnf,lacnf,facnf,nc,nvcnf,rhov,rhomod,rr,zz, &
+subroutine run_config_r(jj,nacnf,lacnf,facnf,nc,nvcnf,rhov,rhomod,rr,zz, &
 &                  rcmax,mmax,mxprj,iexc,ea,etot,epstot,nproj,vpuns, &
 &                  lloc,vkb,evkb)
 
@@ -47,55 +47,55 @@
 !evkb VKB projector coefficients
 !srel .true. for scalar-relativistic, .false. for non-relativistic
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !Input variables
- 
- integer :: jj,mmax,mxprj,iexc,nc,lloc
- integer :: nacnf(30,5),lacnf(30,5),nvcnf(5),nproj(5)
- real(dp) :: etot,epstot,rcmax,zz
- real(dp) :: facnf(30,5),ea(30,2),rhov(mmax),rr(mmax)
- real(dp) :: vpuns(mmax,5),vkb(mmax,mxprj,4,2),evkb(mxprj,4,2),rhomod(mmax,5)
- logical :: srel
+
+   integer :: jj,mmax,mxprj,iexc,nc,lloc
+   integer :: nacnf(30,5),lacnf(30,5),nvcnf(5),nproj(5)
+   real(dp) :: etot,epstot,rcmax,zz
+   real(dp) :: facnf(30,5),ea(30,2),rhov(mmax),rr(mmax)
+   real(dp) :: vpuns(mmax,5),vkb(mmax,mxprj,4,2),evkb(mxprj,4,2),rhomod(mmax,5)
+   logical :: srel
 
 !Output variables  only printing
- 
+
 !Local variables
- integer :: ii,it,kk,ll,l1,ierr,mch,nvt
- integer :: ikap,kap,mkap
- integer :: nat(30),lat(30),natp(30),latp(30),nav(4)
- integer ::  indxr(30),indxe(30)
- real(dp) :: et,eaetst,etsttot,fj,zval
- real(dp) :: eat(30,2,3),fat(30,3),rpk(30,2),eatp(30,2),fatp(30,3)
+   integer :: ii,it,kk,ll,l1,ierr,mch,nvt
+   integer :: ikap,kap,mkap
+   integer :: nat(30),lat(30),natp(30),latp(30),nav(4)
+   integer ::  indxr(30),indxe(30)
+   real(dp) :: et,eaetst,etsttot,fj,zval
+   real(dp) :: eat(30,2,3),fat(30,3),rpk(30,2),eatp(30,2),fatp(30,3)
 
- real(dp),allocatable :: rho(:),rhoc(:),rhocps(:),vi(:),vfull(:)
- real(dp),allocatable :: uu(:,:),up(:,:)
+   real(dp),allocatable :: rho(:),rhoc(:),rhocps(:),vi(:),vfull(:)
+   real(dp),allocatable :: uu(:,:),up(:,:)
 
- allocate(rho(mmax),rhoc(mmax),vi(mmax),vfull(mmax),rhocps(mmax))
- allocate(uu(mmax,2),up(mmax,2))
+   allocate(rho(mmax),rhoc(mmax),vi(mmax),vfull(mmax),rhocps(mmax))
+   allocate(uu(mmax,2),up(mmax,2))
 
 ! atom tests comparing reference state and excited configuration for
 ! all-electron and pseudo atoms.  Total excitation energies and excited-
 ! -configuration eigenvalues are compared
 
-! For multi-projector potentials, the bound-state solver lschvkbb has poor 
+! For multi-projector potentials, the bound-state solver lschvkbb has poor
 ! stability, and requires a trial energy sufficiently close to the correct
 ! result for a given local potential. This appears to be due to the fact
-! that intermediate stages towards the solution of the radial Schroedinger 
-! equation with a non-local potential may not increase their node count 
+! that intermediate stages towards the solution of the radial Schroedinger
+! equation with a non-local potential may not increase their node count
 ! monotonically with increasing energy (the same phenonenon which gives
 ! rise to ghost states).
 
-! To aviod these problems, the pseudoatom calculation is started with the 
-! screened local potential and valence eigenvalues of the reference 
+! To aviod these problems, the pseudoatom calculation is started with the
+! screened local potential and valence eigenvalues of the reference
 ! configuration.  This is adiabatically changed in two steps.  In the first,
 ! the occupation numbers are changed by 2% within the potential iteration
-! loop for each of the first 50 steps to those of a maximally-ionized 
+! loop for each of the first 50 steps to those of a maximally-ionized
 ! intermediate configuration.
 
 ! The second step is started with the local potential of this maximally-
-! ionized psuedo-atom, and eigenvalues from an all-electron 
+! ionized psuedo-atom, and eigenvalues from an all-electron
 ! calculation of this configuration including unoccupied states that
 ! are to be adiabatically filled to produce the final configuration.
 ! The same 2% strategy is used filling pseudo-atom states in this step.
@@ -111,231 +111,231 @@
    indxr(:)=0
    indxe(:)=0
    do ii=1,nc+nvcnf(1)
-     do kk=1,nc+nvcnf(jj)
-       if(nacnf(kk,jj)==nacnf(ii,1) .and. &
-&         lacnf(kk,jj)==lacnf(ii,1)) then
-         indxr(ii)=kk
-         indxe(kk)=ii
-       end if
-     end do
+      do kk=1,nc+nvcnf(jj)
+         if(nacnf(kk,jj)==nacnf(ii,1) .and. &
+         &         lacnf(kk,jj)==lacnf(ii,1)) then
+            indxr(ii)=kk
+            indxe(kk)=ii
+         end if
+      end do
    end do
 
 ! set up merged list with reference levels first
 ! levels not present in one confguration or the other get zero occupancy
    eat(:,:,:)=0.0d0
    do ii=1,nc+nvcnf(1)
-     nat(ii)=nacnf(ii,1)
-     lat(ii)=lacnf(ii,1)
-     fat(ii,1)=facnf(ii,1)
-     eat(ii,:,1)=ea(ii,:)
-     if(indxr(ii)>0) then
-       fat(ii,2)=facnf(indxr(ii),jj)
-     else
-       fat(ii,2)=0.0d0
-     end if
-     fat(ii,3)=fat(ii,2)
+      nat(ii)=nacnf(ii,1)
+      lat(ii)=lacnf(ii,1)
+      fat(ii,1)=facnf(ii,1)
+      eat(ii,:,1)=ea(ii,:)
+      if(indxr(ii)>0) then
+         fat(ii,2)=facnf(indxr(ii),jj)
+      else
+         fat(ii,2)=0.0d0
+      end if
+      fat(ii,3)=fat(ii,2)
    end do
-  
+
    nvt=nvcnf(1)
    do kk=1,nc+nvcnf(jj)
-     if(indxe(kk)==0) then
-       nvt=nvt+1
-       nat(nc+nvt)=nacnf(kk,jj)
-       lat(nc+nvt)=lacnf(kk,jj)
-       fat(nc+nvt,1)=0.0d0
-       fat(nc+nvt,3)=facnf(kk,jj)
-     end if
+      if(indxe(kk)==0) then
+         nvt=nvt+1
+         nat(nc+nvt)=nacnf(kk,jj)
+         lat(nc+nvt)=lacnf(kk,jj)
+         fat(nc+nvt,1)=0.0d0
+         fat(nc+nvt,3)=facnf(kk,jj)
+      end if
    end do
 
 !set up array for maximally ionized intermediate state
    do kk=1,nc+nvt
-     fat(ii,2)=dmin1(fat(ii,1),fat(ii,3))
+      fat(ii,2)=dmin1(fat(ii,1),fat(ii,3))
    end do
 
 
 
- eat(:,:,2)=0.d0; rpk(:,:)=0.d0; rhoc(:)=0.d0; rho(:)=0.d0; vfull(:)=0.d0 
- eaetst=0.d0
+   eat(:,:,2)=0.d0; rpk(:,:)=0.d0; rhoc(:)=0.d0; rho(:)=0.d0; vfull(:)=0.d0
+   eaetst=0.d0
 
 !all-electron atom solution for maximally-ionized state
 
- call relatom(nat,lat,eat(1,1,2),fat(1,2),rpk,nc,nc+nvt,it,rhoc,rho, &
-&            rr,vfull,zz,mmax,iexc,eaetst,ierr)
- if(ierr/=0) then
-  write(6,'(a/a,i2)') 'run_config_r: WARNING  for AE atom,', &
-&       ' WARNING no output for configuration',jj
-  if(ierr==-1) then
-    write(6,'(a,i4)') &
-&         'run_config_r: WARNING no classical turning point error, iteration',it
-  else
-    write(6,'(a)') 'run_config_r: WARNING self-consistency failed to converge'
-  end if
-  deallocate(rho,rhoc,rhocps,vi,vfull)
-  deallocate(uu,up)
-  return
- end if
+   call relatom(nat,lat,eat(1,1,2),fat(1,2),rpk,nc,nc+nvt,it,rhoc,rho, &
+   &            rr,vfull,zz,mmax,iexc,eaetst,ierr)
+   if(ierr/=0) then
+      write(6,'(a/a,i2)') 'run_config_r: WARNING  for AE atom,', &
+      &       ' WARNING no output for configuration',jj
+      if(ierr==-1) then
+         write(6,'(a,i4)') &
+         &         'run_config_r: WARNING no classical turning point error, iteration',it
+      else
+         write(6,'(a)') 'run_config_r: WARNING self-consistency failed to converge'
+      end if
+      deallocate(rho,rhoc,rhocps,vi,vfull)
+      deallocate(uu,up)
+      return
+   end if
 
 !fill in energies for empty levels of maximally ionized state
 
- do kk=1,nc+nvt
-   if(eat(kk,1,2)==0.0d0) then
-     et=0.0d0
-     ll=lat(kk)
-     kap=ll+1
-     call ldiracfb(nat(kk),ll,kap,ierr,et, &
-&                rr,zz,vfull,uu,up,mmax,mch)
-     if(ierr .ne. 0) then
-       write(6,'(/a,4i4)') & 
-&            'runconfig: WARNING ldiracfb convergence ERROR n,l,kap,ierr=', &
-&            nat(kk),ll,kap,ierr
-       deallocate(rho,rhoc,rhocps,vi,vfull)
-       deallocate(uu,up)
-       return
-     end if
-     eat(kk,1,2)=et
-     if(ll==0) then
-       eat(kk,2,2)=et
-     else
-       kap=ll
-       call ldiracfb(nat(kk),ll,kap,ierr,et, &
-&                  rr,zz,vfull,uu,up,mmax,mch)
-       if(ierr>0) then
-         write(6,'(/a,4i4)') & 
-&              'runconfig: WARNING ldiracfb convergence ERROR n,l,kap,iter=', &
-&              nat(kk),ll,kap,it
-         deallocate(rho,rhoc,rhocps,vi,vfull)
-         deallocate(uu,up)
-         return
-       end if
-       eat(kk,2,2)=et
-     end if
-   end if
- end do
+   do kk=1,nc+nvt
+      if(eat(kk,1,2)==0.0d0) then
+         et=0.0d0
+         ll=lat(kk)
+         kap=ll+1
+         call ldiracfb(nat(kk),ll,kap,ierr,et, &
+         &                rr,zz,vfull,uu,up,mmax,mch)
+         if(ierr /= 0) then
+            write(6,'(/a,4i4)') &
+            &            'runconfig: WARNING ldiracfb convergence ERROR n,l,kap,ierr=', &
+            &            nat(kk),ll,kap,ierr
+            deallocate(rho,rhoc,rhocps,vi,vfull)
+            deallocate(uu,up)
+            return
+         end if
+         eat(kk,1,2)=et
+         if(ll==0) then
+            eat(kk,2,2)=et
+         else
+            kap=ll
+            call ldiracfb(nat(kk),ll,kap,ierr,et, &
+            &                  rr,zz,vfull,uu,up,mmax,mch)
+            if(ierr>0) then
+               write(6,'(/a,4i4)') &
+               &              'runconfig: WARNING ldiracfb convergence ERROR n,l,kap,iter=', &
+               &              nat(kk),ll,kap,it
+               deallocate(rho,rhoc,rhocps,vi,vfull)
+               deallocate(uu,up)
+               return
+            end if
+            eat(kk,2,2)=et
+         end if
+      end if
+   end do
 
- eat(:,:,3)=0.d0; rpk(:,:)=0.d0; rhoc(:)=0.d0; rho(:)=0.d0; vfull(:)=0.d0 
- eaetst=0.d0
+   eat(:,:,3)=0.d0; rpk(:,:)=0.d0; rhoc(:)=0.d0; rho(:)=0.d0; vfull(:)=0.d0
+   eaetst=0.d0
 
 !all-electron atom solution for excited state
 
- call relatom(nat,lat,eat(1,1,3),fat(1,3),rpk,nc,nc+nvt,it,rhoc,rho, &
-&            rr,vfull,zz,mmax,iexc,eaetst,ierr)
- if(ierr/=0) then
-  write(6,'(a/a,i2)') 'run_config_r: WARNING  for AE atom,', &
-&       ' WARNING no output for configuration',jj
-  if(ierr==-1) then
-    write(6,'(a,i4)') & 
-&        'run_config_r: WARNING no classical turning point error, iteration',it
-  else
-    write(6,'(a)') 'run_config_r: WARNING self-consistency failed to converge'
-  end if
-  deallocate(rho,rhoc,rhocps,vi,vfull)
-  deallocate(uu,up)
-  return
- end if
+   call relatom(nat,lat,eat(1,1,3),fat(1,3),rpk,nc,nc+nvt,it,rhoc,rho, &
+   &            rr,vfull,zz,mmax,iexc,eaetst,ierr)
+   if(ierr/=0) then
+      write(6,'(a/a,i2)') 'run_config_r: WARNING  for AE atom,', &
+      &       ' WARNING no output for configuration',jj
+      if(ierr==-1) then
+         write(6,'(a,i4)') &
+         &        'run_config_r: WARNING no classical turning point error, iteration',it
+      else
+         write(6,'(a)') 'run_config_r: WARNING self-consistency failed to converge'
+      end if
+      deallocate(rho,rhoc,rhocps,vi,vfull)
+      deallocate(uu,up)
+      return
+   end if
 
 
 !first pseudoatom run from reference to maximally-ionized configuration
    do l1=1,4
-     nav(l1)=l1-1
+      nav(l1)=l1-1
    end do
 
    do kk=1,nvt
-     latp(kk)=lat(nc+kk)
-     l1=latp(kk)+1
-     nav(l1)=nav(l1)+1
-     natp(kk)=nav(l1)
-     eatp(kk,:)=eat(nc+kk,:,1)
-     fatp(kk,1)=fat(nc+kk,1)
-     fatp(kk,2)=fat(nc+kk,2)
+      latp(kk)=lat(nc+kk)
+      l1=latp(kk)+1
+      nav(l1)=nav(l1)+1
+      natp(kk)=nav(l1)
+      eatp(kk,:)=eat(nc+kk,:,1)
+      fatp(kk,1)=fat(nc+kk,1)
+      fatp(kk,2)=fat(nc+kk,2)
    end do
 
- rho(:)=rhov(:)
+   rho(:)=rhov(:)
 
- rhocps(:)=rhomod(:,1)
+   rhocps(:)=rhomod(:,1)
 
- call psatom_r(natp,latp,eatp,fatp,nvt,it,rhocps,rho, &
-&           rr,rcmax,mmax,mxprj,iexc,etsttot,nproj,vpuns,lloc, &
-&           vkb,evkb,ierr)
+   call psatom_r(natp,latp,eatp,fatp,nvt,it,rhocps,rho, &
+   &           rr,rcmax,mmax,mxprj,iexc,etsttot,nproj,vpuns,lloc, &
+   &           vkb,evkb,ierr)
 
- if(ierr/=0) then
-  write(6,'(a/a,i2)') 'run_config_r: WARNING for fully non-local PS atom,', &
-&       ' WARNING no output for configuration',jj
-  deallocate(rho,rhoc,rhocps,vi,vfull)
-  return
- end if
+   if(ierr/=0) then
+      write(6,'(a/a,i2)') 'run_config_r: WARNING for fully non-local PS atom,', &
+      &       ' WARNING no output for configuration',jj
+      deallocate(rho,rhoc,rhocps,vi,vfull)
+      return
+   end if
 
 !second pseudoatom run from maximally-ionized to excited configuration
 
    do kk=1,nvt
-     eatp(kk,:)=eat(nc+kk,:,2)
-     fatp(kk,1)=fat(nc+kk,2)
-     fatp(kk,2)=fat(nc+kk,3)
+      eatp(kk,:)=eat(nc+kk,:,2)
+      fatp(kk,1)=fat(nc+kk,2)
+      fatp(kk,2)=fat(nc+kk,3)
    end do
 
- call psatom_r(natp,latp,eatp,fatp,nvt,it,rhocps,rho, &
-&           rr,rcmax,mmax,mxprj,iexc,etsttot,nproj,vpuns,lloc, &
-&           vkb,evkb,ierr)
+   call psatom_r(natp,latp,eatp,fatp,nvt,it,rhocps,rho, &
+   &           rr,rcmax,mmax,mxprj,iexc,etsttot,nproj,vpuns,lloc, &
+   &           vkb,evkb,ierr)
 
- if(ierr/=0) then
-  write(6,'(a/a,i2)') 'run_config_r: WARNING for fully non-local PS atom,', &
-&       ' WARNING no output for configuration',jj
-  deallocate(rho,rhoc,rhocps,vi,vfull)
-  return
- end if
-
-
- write(6,'(/a)') '   n   l kap    f        eae           eps        diff'
- do ii=1,nc
-   ll = lat(ii)
-   if(ll==0) then
-    mkap=1
-   else
-    mkap=2
+   if(ierr/=0) then
+      write(6,'(a/a,i2)') 'run_config_r: WARNING for fully non-local PS atom,', &
+      &       ' WARNING no output for configuration',jj
+      deallocate(rho,rhoc,rhocps,vi,vfull)
+      return
    end if
+
+
+   write(6,'(/a)') '   n   l kap    f        eae           eps        diff'
+   do ii=1,nc
+      ll = lat(ii)
+      if(ll==0) then
+         mkap=1
+      else
+         mkap=2
+      end if
 ! loop on J = ll +/- 1/2
-   do ikap=1,mkap
-    if(ikap==1) then
-      kap=-(ll+1)
-      fj=dble(ll+1)*fat(ii,3)/dble(2*ll+1)
-    else
-      kap=  ll
-      fj=dble(ll)*fat(ii,3)/dble(2*ll+1)
-    end if
-    write(6,'(3i4,f8.4,f14.8)') nat(ii),lat(ii),kap,fj,eat(ii,ikap,3)
+      do ikap=1,mkap
+         if(ikap==1) then
+            kap=-(ll+1)
+            fj=dble(ll+1)*fat(ii,3)/dble(2*ll+1)
+         else
+            kap=  ll
+            fj=dble(ll)*fat(ii,3)/dble(2*ll+1)
+         end if
+         write(6,'(3i4,f8.4,f14.8)') nat(ii),lat(ii),kap,fj,eat(ii,ikap,3)
+      end do
    end do
- end do
 
- do ii=1,nvt
-   ll = lat(ii+nc)
-   if(ll==0) then
-    mkap=1
-   else
-    mkap=2
-   end if
+   do ii=1,nvt
+      ll = lat(ii+nc)
+      if(ll==0) then
+         mkap=1
+      else
+         mkap=2
+      end if
 ! loop on J = ll +/- 1/2
-   do ikap=1,mkap
-    if(ikap==1) then
-      kap=-(ll+1)
-      fj=dble(ll+1)*fat(ii+nc,3)/dble(2*ll+1)
-    else
-      kap=  ll
-      fj=dble(ll)*fat(ii+nc,3)/dble(2*ll+1)
-    end if
-    write(6,'(3i4,f8.4,2f14.8,1p,e12.2)') nat(ii+nc),lat(ii+nc),kap,fj, &
-&    eat(ii+nc,ikap,3),eatp(ii,ikap),eatp(ii,ikap)-eat(ii+nc,ikap,3)
+      do ikap=1,mkap
+         if(ikap==1) then
+            kap=-(ll+1)
+            fj=dble(ll+1)*fat(ii+nc,3)/dble(2*ll+1)
+         else
+            kap=  ll
+            fj=dble(ll)*fat(ii+nc,3)/dble(2*ll+1)
+         end if
+         write(6,'(3i4,f8.4,2f14.8,1p,e12.2)') nat(ii+nc),lat(ii+nc),kap,fj, &
+         &    eat(ii+nc,ikap,3),eatp(ii,ikap),eatp(ii,ikap)-eat(ii+nc,ikap,3)
+      end do
    end do
- end do
 
 
- write(6,'(/a)') '    Total energies and differences'
- write(6,'(a,1p,e16.8,a,e16.8,a,e10.2)') '      AE_ref=',etot, &
-& '  AE_tst=',eaetst,'  dif=',eaetst-etot
- write(6,'(a,1p,e16.8,a,e16.8,a,e10.2)') '      PS_ref=',epstot, &
-& '  PS_tst=',etsttot,'  dif=',etsttot-epstot
- write(6,'(a,1p,e10.2)') '      PSP excitation error=', &
-& eaetst-etot-etsttot+epstot
+   write(6,'(/a)') '    Total energies and differences'
+   write(6,'(a,1p,e16.8,a,e16.8,a,e10.2)') '      AE_ref=',etot, &
+   & '  AE_tst=',eaetst,'  dif=',eaetst-etot
+   write(6,'(a,1p,e16.8,a,e16.8,a,e10.2)') '      PS_ref=',epstot, &
+   & '  PS_tst=',etsttot,'  dif=',etsttot-epstot
+   write(6,'(a,1p,e10.2)') '      PSP excitation error=', &
+   & eaetst-etot-etsttot+epstot
 
- deallocate(rho,rhoc,rhocps,vi,vfull)
-  deallocate(uu,up)
- return
- end subroutine run_config_r
+   deallocate(rho,rhoc,rhocps,vi,vfull)
+   deallocate(uu,up)
+   return
+end subroutine run_config_r

--- a/src/run_diag.f90
+++ b/src/run_diag.f90
@@ -2,21 +2,21 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- subroutine run_diag(lmax,npa,epa,lloc,irc, &
+subroutine run_diag(lmax,npa,epa,lloc,irc, &
 &                    vkb,evkb,nproj,rr,vfull,vp,zz,mmax,mxprj,srel)
 
 !diagnostics for semi-local and Vanderbilt-Kleinman-bylander pseudopotentials
@@ -42,112 +42,112 @@
 !mxprj  dimension of number of projectors
 !srel .true. for scalar-relativistic, .false. for non-relativistic
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !Input variables
- integer :: lmax,lloc,mmax,mxprj,nlim
- integer :: npa(mxprj,6),irc(6),nproj(6)
- real(dp) :: zz
- real(dp) :: rr(mmax),vp(mmax,5),vfull(mmax),vkb(mmax,mxprj,4)
- real(dp):: epa(mxprj,6),evkb(mxprj,4)
- logical :: srel
+   integer :: lmax,lloc,mmax,mxprj,nlim
+   integer :: npa(mxprj,6),irc(6),nproj(6)
+   real(dp) :: zz
+   real(dp) :: rr(mmax),vp(mmax,5),vfull(mmax),vkb(mmax,mxprj,4)
+   real(dp):: epa(mxprj,6),evkb(mxprj,4)
+   logical :: srel
 
 !Output variables - printing only
 
 !Local variables
- integer :: ll,l1,ii,jj,ierr,mch,mchf
- integer :: iprj,nnae,nnp,npr
- real(dp) :: al,emax,emin,etest,sls,umch,upmch,uldf,gam,gpr
- real(dp), allocatable :: uu(:),up(:)
+   integer :: ll,l1,ii,jj,ierr,mch,mchf
+   integer :: iprj,nnae,nnp,npr
+   real(dp) :: al,emax,emin,etest,sls,umch,upmch,uldf,gam,gpr
+   real(dp), allocatable :: uu(:),up(:)
 
- allocate(uu(mmax),up(mmax))
+   allocate(uu(mmax),up(mmax))
 
- al = 0.01d0 * dlog(rr(101)/rr(1))
+   al = 0.01d0 * dlog(rr(101)/rr(1))
 
 ! loop for diagnostic output using Vanderbilt Kleinman-Bylander projectors
 !
- write(6,'(/a/a)') &
-& 'Diagnostic tests using Vanderbilt-Kleinman-Bylander pseudopotentials',&
-& '  1 or more projectors used as specified by nproj input data'
- write(6,'(/2a)')'   l    rcore       rmatch      e in        ', &
-&   'delta e   norm test  slope test'
+   write(6,'(/a/a)') &
+   & 'Diagnostic tests using Vanderbilt-Kleinman-Bylander pseudopotentials',&
+   & '  1 or more projectors used as specified by nproj input data'
+   write(6,'(/2a)')'   l    rcore       rmatch      e in        ', &
+   &   'delta e   norm test  slope test'
 !
- do l1 = 1, lmax + 1
-  write(6,'(a)') ''
-  ll = l1 - 1
-  nnp=l1
-  do iprj=1,max(1,nproj(l1))
-    npr=nproj(l1)
+   do l1 = 1, lmax + 1
+      write(6,'(a)') ''
+      ll = l1 - 1
+      nnp=l1
+      do iprj=1,max(1,nproj(l1))
+         npr=nproj(l1)
 
 !   find cutoff radius for projectors
-    mchf=max(irc(l1),irc(lloc+1))+5
+         mchf=max(irc(l1),irc(lloc+1))+5
 
-    etest=epa(iprj,l1)
-    if(etest<0.0d0) then
-      call lschfb(npa(iprj,l1),ll,ierr,etest, &
-&                rr,vfull,uu,up,zz,mmax,mch,srel)
-      if(ierr .ne. 0) then
-         write(6,'(/a,3i4)') 'run_diag: lschfb convergence ERROR n,l,ierr=', &
-&        npa(iprj,l1),ll,ierr
-        stop
-      end if
+         etest=epa(iprj,l1)
+         if(etest<0.0d0) then
+            call lschfb(npa(iprj,l1),ll,ierr,etest, &
+            &                rr,vfull,uu,up,zz,mmax,mch,srel)
+            if(ierr /= 0) then
+               write(6,'(/a,3i4)') 'run_diag: lschfb convergence ERROR n,l,ierr=', &
+               &        npa(iprj,l1),ll,ierr
+               stop
+            end if
 
-    else
-      call lschfs(nnae,ll,ierr,etest, &
-&               rr,vfull,uu,up,zz,mmax,mchf,srel)
-    end if
+         else
+            call lschfs(nnae,ll,ierr,etest, &
+            &               rr,vfull,uu,up,zz,mmax,mchf,srel)
+         end if
 
-    umch=uu(mchf)
-    upmch=up(mchf)
-    uldf=upmch/umch
-    etest=epa(iprj,l1)
+         umch=uu(mchf)
+         upmch=up(mchf)
+         uldf=upmch/umch
+         etest=epa(iprj,l1)
 
-    if(l1==lloc+1) npr=0
+         if(l1==lloc+1) npr=0
 
-    etest=epa(iprj,l1)
-    emax=etest+0.1d0*dabs(etest)+0.05d0
-    emin=etest-0.1d0*dabs(etest)-0.05d0
+         etest=epa(iprj,l1)
+         emax=etest+0.1d0*dabs(etest)+0.05d0
+         emin=etest-0.1d0*dabs(etest)-0.05d0
 
 
-    if(epa(iprj,l1)<0.0d0) then
-      sls=(l1-1)*l1
+         if(epa(iprj,l1)<0.0d0) then
+            sls=(l1-1)*l1
 
-      emax=dmin1(emax,0.0d0)
+            emax=dmin1(emax,0.0d0)
 
-      call lschvkbb(ll+iprj,ll,npr,ierr,etest,emin,emax, &
-&                   rr,vp(1,lloc+1),vkb(1,1,l1),evkb(1,l1), &
-&                   uu,up,mmax,mch)
-      if(ierr/=0) then
-        write(6,'(a,3i4,1p,2e16.8)') 'run_diag: lschvkbb ERROR', &
-&             iprj,ll,ierr,epa(iprj,l1),etest
-      end if
+            call lschvkbb(ll+iprj,ll,npr,ierr,etest,emin,emax, &
+            &                   rr,vp(1,lloc+1),vkb(1,1,l1),evkb(1,l1), &
+            &                   uu,up,mmax,mch)
+            if(ierr/=0) then
+               write(6,'(a,3i4,1p,2e16.8)') 'run_diag: lschvkbb ERROR', &
+               &             iprj,ll,ierr,epa(iprj,l1),etest
+            end if
 
-      nnp=nnp+1
-    else
-!     calculate effective pseudo wave function principal quantum number 
+            nnp=nnp+1
+         else
+!     calculate effective pseudo wave function principal quantum number
 !     from all-electron node count
-      nnp=nnae-npa(1,l1)+ll+1
-      call lschvkbbe(nnp,ll,npr,ierr,etest,uldf,emin,emax, &
-&                   rr,vp(1,lloc+1),vkb(1,1,l1),evkb(1,l1), &
-&                   uu,up,mmax,mchf)
+            nnp=nnae-npa(1,l1)+ll+1
+            call lschvkbbe(nnp,ll,npr,ierr,etest,uldf,emin,emax, &
+            &                   rr,vp(1,lloc+1),vkb(1,1,l1),evkb(1,l1), &
+            &                   uu,up,mmax,mchf)
 
-      if(ierr/=0) then
-        write(6,'(a,4i4,1p,2e16.8)') 'run_diag: lschvkbbe ERROR', &
-&             iprj,nnp,ll,ierr,epa(iprj,l1),etest
+            if(ierr/=0) then
+               write(6,'(a,4i4,1p,2e16.8)') 'run_diag: lschvkbbe ERROR', &
+               &             iprj,nnp,ll,ierr,epa(iprj,l1),etest
 
-      end if
-    end if !epa<0 (bound or not)
+            end if
+         end if  !epa<0 (bound or not)
 
-    gam=dabs(umch/uu(mchf))
-    gpr=dabs(upmch/up(mchf))
-!  
-    write(6,'(i4,6f12.7)') ll,rr(irc(l1)),rr(mchf),epa(iprj,l1), &
-&         etest-epa(iprj,l1),gam,gpr
+         gam=dabs(umch/uu(mchf))
+         gpr=dabs(upmch/up(mchf))
+!
+         write(6,'(i4,6f12.7)') ll,rr(irc(l1)),rr(mchf),epa(iprj,l1), &
+         &         etest-epa(iprj,l1),gam,gpr
 
-  end do  !iprj
- end do !l1
+      end do  !iprj
+   end do  !l1
 
- deallocate(uu,up)
- return
- end subroutine run_diag
+   deallocate(uu,up)
+   return
+end subroutine run_diag

--- a/src/run_diag_r.f90
+++ b/src/run_diag_r.f90
@@ -1,21 +1,21 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- subroutine run_diag_r(lmax,npa,epa,lloc,irc, &
+subroutine run_diag_r(lmax,npa,epa,lloc,irc, &
 &                    vkb,evkb,nproj,rr,vfull,vp,zz,mmax,mxprj)
 
 !diagnostics for semi-local and Vanderbilt-Kleinman-bylander pseudopotentials
@@ -40,123 +40,123 @@
 !mmax  size of radial grid
 !mxprj  dimension of number of projectors
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !Input variables
- integer :: lmax,lloc,mmax,mxprj,nlim
- integer :: npa(mxprj,6),irc(6),nproj(6)
- real(dp) :: zz
- real(dp) :: rr(mmax),vp(mmax,5,2),vfull(mmax),vkb(mmax,mxprj,4,2)
- real(dp):: epa(mxprj,6,2),evkb(mxprj,4,2)
+   integer :: lmax,lloc,mmax,mxprj,nlim
+   integer :: npa(mxprj,6),irc(6),nproj(6)
+   real(dp) :: zz
+   real(dp) :: rr(mmax),vp(mmax,5,2),vfull(mmax),vkb(mmax,mxprj,4,2)
+   real(dp):: epa(mxprj,6,2),evkb(mxprj,4,2)
 
 !Output variables - printing only
 
 !Local variables
- integer :: ll,l1,ikap,kap,mkap,ii,jj,ierr,mch,mchf
- integer :: iprj,nnae,nnp,npr
- real(dp) :: al,emax,emin,etest,umch,upmch,uldf,gam,gpr,cnorm
- real(dp), allocatable :: uu(:),up(:),ur(:,:),urp(:,:)
+   integer :: ll,l1,ikap,kap,mkap,ii,jj,ierr,mch,mchf
+   integer :: iprj,nnae,nnp,npr
+   real(dp) :: al,emax,emin,etest,umch,upmch,uldf,gam,gpr,cnorm
+   real(dp), allocatable :: uu(:),up(:),ur(:,:),urp(:,:)
 
- allocate(uu(mmax),up(mmax),ur(mmax,2),urp(mmax,2))
+   allocate(uu(mmax),up(mmax),ur(mmax,2),urp(mmax,2))
 
 
- al = 0.01d0 * dlog(rr(101)/rr(1))
+   al = 0.01d0 * dlog(rr(101)/rr(1))
 
 ! loop for diagnostic output using Vanderbilt Kleinman-Bylander projectors
 !
- write(6,'(/a/a)') &
-& 'Diagnostic tests using Vanderbilt-Kleinman-Bylander pseudopotentials',&
-& '  relativistic with J = L +/- 1/2 projectors'
- write(6,'(/2a)')'   l  kap   rcore       rmatch      e in        ', &
-&   'delta e    norm test   slope test'
+   write(6,'(/a/a)') &
+   & 'Diagnostic tests using Vanderbilt-Kleinman-Bylander pseudopotentials',&
+   & '  relativistic with J = L +/- 1/2 projectors'
+   write(6,'(/2a)')'   l  kap   rcore       rmatch      e in        ', &
+   &   'delta e    norm test   slope test'
 !
- do l1 = 1, lmax + 1
-  write(6,'(a)') ''
-  ll = l1 - 1
-  nnp=l1
-  do iprj=1,max(1,nproj(l1))
-   if(l1==1) then
-    mkap=1
-   else
-    mkap=2
-   end if
+   do l1 = 1, lmax + 1
+      write(6,'(a)') ''
+      ll = l1 - 1
+      nnp=l1
+      do iprj=1,max(1,nproj(l1))
+         if(l1==1) then
+            mkap=1
+         else
+            mkap=2
+         end if
 !  loop on J = ll +/- 1/2
-   do ikap=1,mkap
-    if(ikap==1) then
-      kap=-(ll+1)
-    else
-      kap=  ll
-    end if
+         do ikap=1,mkap
+            if(ikap==1) then
+               kap=-(ll+1)
+            else
+               kap=  ll
+            end if
 
-    npr=nproj(l1)
+            npr=nproj(l1)
 
 !   find cutoff radius for projectors
-    mchf=max(irc(l1),irc(lloc+1))+5
+            mchf=max(irc(l1),irc(lloc+1))+5
 
-    etest=epa(iprj,l1,ikap)
-    if(epa(iprj,l1,1)<0.0d0) then
-      call ldiracfb(npa(iprj,l1),ll,kap,ierr,etest, &
-&                     rr,zz,vfull,ur,urp,mmax,mch)
-      if(ierr .ne. 0) then
-         write(6,'(/a,4i4)') 'run_diag_r: ldiracfb convergence ERROR &
-&         n,l,,kap,ierr=', &
-&        npa(iprj,l1),ll,kap,ierr
-        stop
-      end if
-    else
-      call ldiracfs(nnae,ll,kap,ierr,etest, &
-&                  rr,zz,vfull,ur,urp,mmax,mchf)
-    end if
-    call renorm_r(ur,rr,ll,kap,zz,mmax,cnorm)
-    umch=ur(mchf,1)
-    upmch=cnorm*urp(mchf,1)
-    uldf=upmch/umch
+            etest=epa(iprj,l1,ikap)
+            if(epa(iprj,l1,1)<0.0d0) then
+               call ldiracfb(npa(iprj,l1),ll,kap,ierr,etest, &
+               &                     rr,zz,vfull,ur,urp,mmax,mch)
+               if(ierr /= 0) then
+                  write(6,'(/a,4i4)') 'run_diag_r: ldiracfb convergence ERROR &
+                  &         n,l,,kap,ierr=', &
+                  &        npa(iprj,l1),ll,kap,ierr
+                  stop
+               end if
+            else
+               call ldiracfs(nnae,ll,kap,ierr,etest, &
+               &                  rr,zz,vfull,ur,urp,mmax,mchf)
+            end if
+            call renorm_r(ur,rr,ll,kap,zz,mmax,cnorm)
+            umch=ur(mchf,1)
+            upmch=cnorm*urp(mchf,1)
+            uldf=upmch/umch
 
-    if(l1==lloc+1) npr=0
+            if(l1==lloc+1) npr=0
 
-    etest=epa(iprj,l1,ikap)
-    emax=etest+0.1d0*dabs(etest)+0.05d0
-    emin=etest-0.1d0*dabs(etest)-0.05d0
+            etest=epa(iprj,l1,ikap)
+            emax=etest+0.1d0*dabs(etest)+0.05d0
+            emin=etest-0.1d0*dabs(etest)-0.05d0
 
-    if(epa(iprj,l1,1)<0.0d0) then
+            if(epa(iprj,l1,1)<0.0d0) then
 
-      emax=dmin1(emax,0.0d0)
+               emax=dmin1(emax,0.0d0)
 
-      call lschvkbb(ll+iprj,ll,npr,ierr,etest,emin,emax, &
-&                   rr,vp(1,lloc+1,ikap),vkb(1,1,l1,ikap),evkb(1,l1,ikap), &
-&                   uu,up,mmax,mch)
-      if(ierr/=0) then
-        write(6,'(a,4i4,1p,2e16.8)') 'run_diag_r: lschvkbb ERROR', &
-&             iprj,ll,kap,ierr,epa(iprj,l1,ikap),etest
-      end if
+               call lschvkbb(ll+iprj,ll,npr,ierr,etest,emin,emax, &
+               &                   rr,vp(1,lloc+1,ikap),vkb(1,1,l1,ikap),evkb(1,l1,ikap), &
+               &                   uu,up,mmax,mch)
+               if(ierr/=0) then
+                  write(6,'(a,4i4,1p,2e16.8)') 'run_diag_r: lschvkbb ERROR', &
+                  &             iprj,ll,kap,ierr,epa(iprj,l1,ikap),etest
+               end if
 
-      nnp=nnp+1
-    else
-!     calculate effective pseudo wave function principal quantum number 
+               nnp=nnp+1
+            else
+!     calculate effective pseudo wave function principal quantum number
 !     from all-electron node count
 
-      nnp=nnae-npa(1,l1)+ll+1
-      call lschvkbbe(nnp,ll,npr,ierr,etest,uldf,emin,emax, &
-&                    rr,vp(1,lloc+1,ikap),vkb(1,1,l1,ikap),evkb(1,l1,ikap), &
-&                    uu,up,mmax,mchf)
+               nnp=nnae-npa(1,l1)+ll+1
+               call lschvkbbe(nnp,ll,npr,ierr,etest,uldf,emin,emax, &
+               &                    rr,vp(1,lloc+1,ikap),vkb(1,1,l1,ikap),evkb(1,l1,ikap), &
+               &                    uu,up,mmax,mchf)
 
-      if(ierr/=0) then
-        write(6,'(a,4i4,1p,2e16.8)') 'run_diag_r: lschvkbbe ERROR', &
-&             iprj,ll,kap,ierr,epa(iprj,l1,ikap),etest
-      end if
-    end if !epa<0 (bound or not)
+               if(ierr/=0) then
+                  write(6,'(a,4i4,1p,2e16.8)') 'run_diag_r: lschvkbbe ERROR', &
+                  &             iprj,ll,kap,ierr,epa(iprj,l1,ikap),etest
+               end if
+            end if  !epa<0 (bound or not)
 
-    gam=dabs(umch/uu(mchf))
-    gpr=dabs(upmch/up(mchf))
-!  
-    write(6,'(2i4,6f12.7)') ll,kap,rr(irc(l1)),rr(mchf),epa(iprj,l1,ikap), &
-&         etest-epa(iprj,l1,ikap),gam,gpr
+            gam=dabs(umch/uu(mchf))
+            gpr=dabs(upmch/up(mchf))
+!
+            write(6,'(2i4,6f12.7)') ll,kap,rr(irc(l1)),rr(mchf),epa(iprj,l1,ikap), &
+            &         etest-epa(iprj,l1,ikap),gam,gpr
 
-   end do  !ikap
-  end do  !iprj
- end do !l1
+         end do  !ikap
+      end do  !iprj
+   end do  !l1
 
- deallocate(uu,up)
- return
- end subroutine run_diag_r
+   deallocate(uu,up)
+   return
+end subroutine run_diag_r

--- a/src/run_diag_sr_so_r.f90
+++ b/src/run_diag_sr_so_r.f90
@@ -1,20 +1,20 @@
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- subroutine run_diag_sr_so_r(lmax,npa,epa,lloc,irc, &
+subroutine run_diag_sr_so_r(lmax,npa,epa,lloc,irc, &
 &                    vsr,esr,vso,eso,nproj,rr,vfull,vp,zz,mmax,mxprj)
 
 !diagnostics for semi-local and Vanderbilt-Kleinman-bylander pseudopotentials
@@ -42,143 +42,143 @@
 !mmax  size of radial grid
 !mxprj  dimension of number of projectors
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !Input variables
- integer :: lmax,lloc,mmax,mxprj,nlim
- integer :: npa(mxprj,6),irc(6),nproj(6)
- real(dp) :: zz
- real(dp) :: rr(mmax),vp(mmax,5,2),vfull(mmax),vkb(mmax,mxprj,4,2)
- real(dp) :: vsr(mmax,2*mxprj,4),esr(2*mxprj,4)
- real(dp) :: vso(mmax,2*mxprj,4),eso(2*mxprj,4)
- real(dp):: epa(mxprj,6,2),evkb(mxprj,4,2)
+   integer :: lmax,lloc,mmax,mxprj,nlim
+   integer :: npa(mxprj,6),irc(6),nproj(6)
+   real(dp) :: zz
+   real(dp) :: rr(mmax),vp(mmax,5,2),vfull(mmax),vkb(mmax,mxprj,4,2)
+   real(dp) :: vsr(mmax,2*mxprj,4),esr(2*mxprj,4)
+   real(dp) :: vso(mmax,2*mxprj,4),eso(2*mxprj,4)
+   real(dp):: epa(mxprj,6,2),evkb(mxprj,4,2)
 
 !Output variables - printing only
 
 !Local variables
- integer :: ll,l1,ikap,kap,mkap,ii,jj,ierr,mch,mchf,nvkbt
- integer :: iprj,nnae,nnp,npr
- real(dp) :: al,emax,emin,etest,sls,umch,upmch,uldf,gam,gpr,cnorm,fso
- real(dp), allocatable :: uu(:),up(:),ur(:,:),urp(:,:)
- real(dp), allocatable :: evkbt(:),vkbt(:,:)
+   integer :: ll,l1,ikap,kap,mkap,ii,jj,ierr,mch,mchf,nvkbt
+   integer :: iprj,nnae,nnp,npr
+   real(dp) :: al,emax,emin,etest,sls,umch,upmch,uldf,gam,gpr,cnorm,fso
+   real(dp), allocatable :: uu(:),up(:),ur(:,:),urp(:,:)
+   real(dp), allocatable :: evkbt(:),vkbt(:,:)
 
- allocate(uu(mmax),up(mmax),ur(mmax,2),urp(mmax,2))
- allocate(evkbt(4*mxprj),vkbt(mmax,4*mxprj))
+   allocate(uu(mmax),up(mmax),ur(mmax,2),urp(mmax,2))
+   allocate(evkbt(4*mxprj),vkbt(mmax,4*mxprj))
 
 
- al = 0.01d0 * dlog(rr(101)/rr(1))
+   al = 0.01d0 * dlog(rr(101)/rr(1))
 
 ! loop for diagnostic output using Vanderbilt Kleinman-Bylander projectors
 !
- write(6,'(/a/a)') &
-& 'Diagnostic tests using Vanderbilt-Kleinman-Bylander pseudopotentials',&
-& '  relativistic with scalar and spin-orbit non-local projectors'
- write(6,'(/2a)')'   l  kap   rcore       rmatch      e in        ', &
-&   'delta e    norm test   slope test'
+   write(6,'(/a/a)') &
+   & 'Diagnostic tests using Vanderbilt-Kleinman-Bylander pseudopotentials',&
+   & '  relativistic with scalar and spin-orbit non-local projectors'
+   write(6,'(/2a)')'   l  kap   rcore       rmatch      e in        ', &
+   &   'delta e    norm test   slope test'
 !
- do l1 = 1, lmax + 1
-  write(6,'(a)') ''
-  ll = l1 - 1
-  nnp=l1
-  do iprj=1,max(1,nproj(l1))
-   if(l1==1) then
-    mkap=1
-   else
-    mkap=2
-   end if
+   do l1 = 1, lmax + 1
+      write(6,'(a)') ''
+      ll = l1 - 1
+      nnp=l1
+      do iprj=1,max(1,nproj(l1))
+         if(l1==1) then
+            mkap=1
+         else
+            mkap=2
+         end if
 !  loop on J = ll +/- 1/2
-   do ikap=1,mkap
-    if(ikap==1) then
-      kap=-(ll+1)
-    else
-      kap=  ll
-    end if
+         do ikap=1,mkap
+            if(ikap==1) then
+               kap=-(ll+1)
+            else
+               kap=  ll
+            end if
 
-    npr=nproj(l1)
+            npr=nproj(l1)
 
 ! construct multi-projector potential
-    vkbt(:,:)=0.0d0
-    evkbt(:)=0.0d0
-    if(ikap==1) fso= 0.5d0*ll
-    if(ikap==2) fso=-0.5d0*(ll+1)
-    if(ll==0) then
-     nvkbt=npr
-     do ii=1,npr
-       vkbt(:,ii)=vsr(:,ii,l1)
-       evkbt(ii)=esr(ii,l1)
-     end do
-    else
-     nvkbt=4*npr
-     do ii=1,2*npr
-       vkbt(:,ii)=vsr(:,ii,l1)
-       evkbt(ii)=esr(ii,l1)
-       vkbt(:,2*npr+ii)=vso(:,ii,l1)
-       evkbt(2*npr+ii)=fso*eso(ii,l1)
-     end do
-    end if
+            vkbt(:,:)=0.0d0
+            evkbt(:)=0.0d0
+            if(ikap==1) fso= 0.5d0*ll
+            if(ikap==2) fso=-0.5d0*(ll+1)
+            if(ll==0) then
+               nvkbt=npr
+               do ii=1,npr
+                  vkbt(:,ii)=vsr(:,ii,l1)
+                  evkbt(ii)=esr(ii,l1)
+               end do
+            else
+               nvkbt=4*npr
+               do ii=1,2*npr
+                  vkbt(:,ii)=vsr(:,ii,l1)
+                  evkbt(ii)=esr(ii,l1)
+                  vkbt(:,2*npr+ii)=vso(:,ii,l1)
+                  evkbt(2*npr+ii)=fso*eso(ii,l1)
+               end do
+            end if
 
 
 !   find cutoff radius for projectors
-    mchf=max(irc(l1),irc(lloc+1))+5
+            mchf=max(irc(l1),irc(lloc+1))+5
 
-    etest=epa(iprj,l1,ikap)
-    if(epa(iprj,l1,1)<0.0d0) then
-      call ldiracfb(npa(iprj,l1),ll,kap,ierr,etest, &
-&                     rr,zz,vfull,ur,urp,mmax,mch)
-    else
-      call ldiracfs(nnae,ll,kap,ierr,etest, &
-&                  rr,zz,vfull,ur,urp,mmax,mchf)
-    end if
-    call renorm_r(ur,rr,ll,kap,zz,mmax,cnorm)
-    umch=ur(mchf,1)
-    upmch=cnorm*urp(mchf,1)
-    uldf=upmch/umch
+            etest=epa(iprj,l1,ikap)
+            if(epa(iprj,l1,1)<0.0d0) then
+               call ldiracfb(npa(iprj,l1),ll,kap,ierr,etest, &
+               &                     rr,zz,vfull,ur,urp,mmax,mch)
+            else
+               call ldiracfs(nnae,ll,kap,ierr,etest, &
+               &                  rr,zz,vfull,ur,urp,mmax,mchf)
+            end if
+            call renorm_r(ur,rr,ll,kap,zz,mmax,cnorm)
+            umch=ur(mchf,1)
+            upmch=cnorm*urp(mchf,1)
+            uldf=upmch/umch
 
 
-    if(l1==lloc+1) npr=0
+            if(l1==lloc+1) npr=0
 
-    etest=epa(iprj,l1,ikap)
-    emax=etest+0.1d0*dabs(etest)+0.05d0
-    emin=etest-0.1d0*dabs(etest)-0.05d0
+            etest=epa(iprj,l1,ikap)
+            emax=etest+0.1d0*dabs(etest)+0.05d0
+            emin=etest-0.1d0*dabs(etest)-0.05d0
 
-    if(epa(iprj,l1,1)<0.0d0) then
-      sls=(l1-1)*l1
-      emax=dmin1(emax,0.0d0)
+            if(epa(iprj,l1,1)<0.0d0) then
+               sls=(l1-1)*l1
+               emax=dmin1(emax,0.0d0)
 
-      call lschvkbb(ll+iprj,ll,nvkbt,ierr,etest,emin,emax, &
-&                   rr,vp(1,lloc+1,ikap),vkbt,evkbt, &
-&                   uu,up,mmax,mch)
-      if(ierr/=0) then
-        write(6,'(a,4i4,1p,2e16.8)') 'run_diag_sr_so_r: lschvkbb ERROR', &
-&             iprj,ll,kap,ierr,epa(iprj,l1,ikap),etest
-      end if
+               call lschvkbb(ll+iprj,ll,nvkbt,ierr,etest,emin,emax, &
+               &                   rr,vp(1,lloc+1,ikap),vkbt,evkbt, &
+               &                   uu,up,mmax,mch)
+               if(ierr/=0) then
+                  write(6,'(a,4i4,1p,2e16.8)') 'run_diag_sr_so_r: lschvkbb ERROR', &
+                  &             iprj,ll,kap,ierr,epa(iprj,l1,ikap),etest
+               end if
 
-      nnp=nnp+1
-    else
-!     calculate effective pseudo wave function principal quantum number 
+               nnp=nnp+1
+            else
+!     calculate effective pseudo wave function principal quantum number
 !     from all-electron node count
-      nnp=nnae-npa(1,l1)+ll+1
-      call lschvkbbe(nnp,ll,nvkbt,ierr,etest,uldf,emin,emax, &
-&                    rr,vp(1,lloc+1,ikap),vkbt,evkbt, &
-&                    uu,up,mmax,mchf)
+               nnp=nnae-npa(1,l1)+ll+1
+               call lschvkbbe(nnp,ll,nvkbt,ierr,etest,uldf,emin,emax, &
+               &                    rr,vp(1,lloc+1,ikap),vkbt,evkbt, &
+               &                    uu,up,mmax,mchf)
 
-      if(ierr/=0) then
-        write(6,'(a,4i4,1p,2e16.8)') 'run_diag_r: lschvkbbe ERROR', &
-&             iprj,ll,kap,ierr,epa(iprj,l1,ikap),etest
-      end if
-    end if !epa<0 (bound or not)
+               if(ierr/=0) then
+                  write(6,'(a,4i4,1p,2e16.8)') 'run_diag_r: lschvkbbe ERROR', &
+                  &             iprj,ll,kap,ierr,epa(iprj,l1,ikap),etest
+               end if
+            end if  !epa<0 (bound or not)
 
-    gam=dabs(umch/uu(mchf))
-    gpr=dabs(upmch/up(mchf))
-!  
-    write(6,'(2i4,6f12.7)') ll,kap,rr(irc(l1)),rr(mchf),epa(iprj,l1,ikap), &
-&         etest-epa(iprj,l1,ikap),gam,gpr
+            gam=dabs(umch/uu(mchf))
+            gpr=dabs(upmch/up(mchf))
+!
+            write(6,'(2i4,6f12.7)') ll,kap,rr(irc(l1)),rr(mchf),epa(iprj,l1,ikap), &
+            &         etest-epa(iprj,l1,ikap),gam,gpr
 
-   end do  !ikap
-  end do  !iprj
- end do !l1
+         end do  !ikap
+      end do  !iprj
+   end do  !l1
 
- deallocate(uu,up)
- return
- end subroutine run_diag_sr_so_r
+   deallocate(uu,up)
+   return
+end subroutine run_diag_sr_so_r

--- a/src/run_ghosts.f90
+++ b/src/run_ghosts.f90
@@ -2,21 +2,21 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- subroutine run_ghosts(lmax,la,ea,nc,nv,lloc,irc,qmsbf, &
+subroutine run_ghosts(lmax,la,ea,nc,nv,lloc,irc,qmsbf, &
 &                    vkb,evkb,nproj,rr,vp,mmax,mxprj)
 
 ! Two tests for ghosts;  The local potential is terminated by a hard wall
@@ -28,7 +28,7 @@
 ! as follows:
 !
 ! Test 1) Negative eigenvalues are compared with those of the radial
-! Schroedinger equation for the full-range pseudopotential.  Those 
+! Schroedinger equation for the full-range pseudopotential.  Those
 ! lying below the Schroedinger Eq. results and which presumably have
 ! more nodes are reported and tagged as GHOST(-).
 !
@@ -57,236 +57,236 @@
 !mmax  size of radial grid
 !mxprj  dimension of number of projectors
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
- real(dp), parameter :: pi=3.141592653589793238462643383279502884197_dp
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
+   real(dp), parameter :: pi=3.141592653589793238462643383279502884197_dp
 
 !Input variables
- integer :: nc,nv,lmax,lloc,mmax,mxprj
- integer :: la(30),irc(6),nproj(6)
- real(dp) :: rr(mmax),vp(mmax,5),vkb(mmax,mxprj,4)
- real(dp):: qmsbf(6),ea(30),evkb(mxprj,4)
+   integer :: nc,nv,lmax,lloc,mmax,mxprj
+   integer :: la(30),irc(6),nproj(6)
+   real(dp) :: rr(mmax),vp(mmax,5),vkb(mmax,mxprj,4)
+   real(dp):: qmsbf(6),ea(30),evkb(mxprj,4)
 
 !Output variables - printing only
 
 !Local variables
- integer :: ll,l1,ii,jj,kk,ierr,mbfact,mbar,mch,nn,npgh
- integer :: iprj,nprj,nbas,nbmax,lwork,info
- integer :: nodes(4),lpgh(20)
- real(dp) :: al,amesh,basfact,ee,ecut,eps,et,emin,emax,sn,ro,tht
- real(dp) :: cpgh(20),ebcut(6),epgh(20),rpgh(20)
- real(dp), allocatable :: uu(:),up(:)
- real(dp), allocatable :: gg0(:,:),hmat(:,:),hmev(:),work(:)
- real(dp), allocatable :: uua(:,:)
+   integer :: ll,l1,ii,jj,kk,ierr,mbfact,mbar,mch,nn,npgh
+   integer :: iprj,nprj,nbas,nbmax,lwork,info
+   integer :: nodes(4),lpgh(20)
+   real(dp) :: al,amesh,basfact,ee,ecut,eps,et,emin,emax,sn,ro,tht
+   real(dp) :: cpgh(20),ebcut(6),epgh(20),rpgh(20)
+   real(dp), allocatable :: uu(:),up(:)
+   real(dp), allocatable :: gg0(:,:),hmat(:,:),hmev(:),work(:)
+   real(dp), allocatable :: uua(:,:)
 
- allocate(uu(mmax),up(mmax))
+   allocate(uu(mmax),up(mmax))
 
- al = 0.01d0 * dlog(rr(101)/rr(1))
- amesh = dexp(al)
- eps=1.0d-4 !threshold for negative-energy ghost report
- tht=0.0d0 !sets barrier boundary conditions to zero
+   al = 0.01d0 * dlog(rr(101)/rr(1))
+   amesh = dexp(al)
+   eps=1.0d-4  !threshold for negative-energy ghost report
+   tht=0.0d0  !sets barrier boundary conditions to zero
 
 ! loop for diagnostic output using Vanderbilt Kleinman-Bylander projectors
 
    write(6,'(/a)') ' Testing for bound ghosts'
    write(6,'(5a)') '   n','   l','    E NL Schr. Eq', &
-&        '   E Basis Diag.','   E Cutoff'
+   &        '   E Basis Diag.','   E Cutoff'
 
- nodes(:)=0
- npgh=0
- do l1 = 1, lmax + 1
-   nprj=nproj(l1)  
-   if(nprj==0) cycle
+   nodes(:)=0
+   npgh=0
+   do l1 = 1, lmax + 1
+      nprj=nproj(l1)
+      if(nprj==0) cycle
 
-   write(6,'()')
-   ll = l1 - 1
+      write(6,'()')
+      ll = l1 - 1
 
 !Construct basis of local-pseidupotential plus hard-wall barrier eigenfunctions
 !Barrier is set at mbfact*rc
 
-   mbfact=3
-   mbar = idint(dlog(mbfact*rr(irc(l1))/rr(1))/al+1.0d0)
+      mbfact=3
+      mbar = idint(dlog(mbfact*rr(irc(l1))/rr(1))/al+1.0d0)
 
 ! Basis cutoff energy is based on largest q in sbf optimization basis
-  basfact=1.25d0
-  ebcut(l1)= basfact*0.5d0*qmsbf(l1)**2
+      basfact=1.25d0
+      ebcut(l1)= basfact*0.5d0*qmsbf(l1)**2
 
 ! Estimate maximum basis set size nbmax based on ll=0 sbf
 ! with 20% allowance for binding by local potential
 
-   nbmax=idint(2.0d0*dsqrt(1.2d0*ebcut(l1))*rr(mbar)/pi)
+      nbmax=idint(2.0d0*dsqrt(1.2d0*ebcut(l1))*rr(mbar)/pi)
 
-   lwork=3*nbmax
+      lwork=3*nbmax
 
-   allocate(gg0(nprj,nbmax),hmat(nbmax,nbmax),hmev(nbmax),work(lwork))
-   allocate(uua(mmax,nbmax))
+      allocate(gg0(nprj,nbmax),hmat(nbmax,nbmax),hmev(nbmax),work(lwork))
+      allocate(uua(mmax,nbmax))
 
-   gg0(:,:)=0.0d0
-   hmat(:,:)=0.0d0
-   hmev(:)=0.0d0
+      gg0(:,:)=0.0d0
+      hmat(:,:)=0.0d0
+      hmev(:)=0.0d0
 
-   
-   nbas=0
-   do jj=1,nbmax
-     nn=ll+jj
 
-     emin=0.0d0
-     emax=ebcut(l1)
-     ee=0.0d0
+      nbas=0
+      do jj=1,nbmax
+         nn=ll+jj
 
-     call lschpsbar(nn,ll,ierr,ee,emin,emax,rr,vp(1,lloc+1),uu,up, &
-&                   mmax,mbar,tht)
+         emin=0.0d0
+         emax=ebcut(l1)
+         ee=0.0d0
 
-     if(ierr/=0) then
-         if(emax/=ebcut(l1)) then
-         write(6,'(a,3i4,3f12.6)')  &
-&              'run_ghosts 143: lschpsbar ERROR ierr,nn,ll,ee,emin,emax', &
-&              ierr,nn,ll,ee,emin,emax
-         stop
+         call lschpsbar(nn,ll,ierr,ee,emin,emax,rr,vp(1,lloc+1),uu,up, &
+         &                   mmax,mbar,tht)
+
+         if(ierr/=0) then
+            if(emax/=ebcut(l1)) then
+               write(6,'(a,3i4,3f12.6)')  &
+               &              'run_ghosts 143: lschpsbar ERROR ierr,nn,ll,ee,emin,emax', &
+               &              ierr,nn,ll,ee,emin,emax
+               stop
+            end if
+            nbas=jj-1
+            exit
          end if
-       nbas=jj-1
-       exit
-     end if
 
 ! barrier potential eigenvalues are contirbution to hamiltonian matrix diagonal
-     hmat(jj,jj)=ee
+         hmat(jj,jj)=ee
 
-     uua(:,jj)=uu(:)
+         uua(:,jj)=uu(:)
 
 ! oerlap of eigenfunction jj and projectors
-     do iprj=1,nprj
-       call vpinteg(uu,vkb(1,iprj,l1),irc(l1),2*ll+2,gg0(iprj,jj),rr)
-     end do
+         do iprj=1,nprj
+            call vpinteg(uu,vkb(1,iprj,l1),irc(l1),2*ll+2,gg0(iprj,jj),rr)
+         end do
 
-   end do !jj
+      end do  !jj
 
-   ecut=ebcut(l1)
+      ecut=ebcut(l1)
 
 ! add non-local terms to hamiltonian matrix
-   do jj=1,nbas
-     do ii=1,jj
-       do iprj=1,nprj
-         hmat(ii,jj)=hmat(ii,jj)+evkb(iprj,l1)*gg0(iprj,ii)*gg0(iprj,jj)
-       end do
-       hmat(jj,ii)=hmat(ii,jj)
-     end  do
-   end do
+      do jj=1,nbas
+         do ii=1,jj
+            do iprj=1,nprj
+               hmat(ii,jj)=hmat(ii,jj)+evkb(iprj,l1)*gg0(iprj,ii)*gg0(iprj,jj)
+            end do
+            hmat(jj,ii)=hmat(ii,jj)
+         end  do
+      end do
 
 ! find eigenvalues of the hamiltonian matrix
 
 !      SUBROUTINE DSYEV( JOBZ, UPLO, N, A, LDA, W, WORK, LWORK, INFO )
 
-     call dsyev( 'V', 'U', nbas, hmat, nbmax, hmev, work, lwork, info )
-     if(info .ne. 0) then
-      write(6,'(a,i4)') 'run_ghosts: hamiltonian matrix eigenvalue ERROR, &
-&          info=',info
-      stop
-     end if
+      call dsyev( 'V', 'U', nbas, hmat, nbmax, hmev, work, lwork, info )
+      if(info /= 0) then
+         write(6,'(a,i4)') 'run_ghosts: hamiltonian matrix eigenvalue ERROR, &
+         &          info=',info
+         stop
+      end if
 !treat valence states for this l
-     nn=ll
-     jj=0
-     do kk=1,nv
-       if(la(nc+kk)/=ll) cycle
-       jj=jj+1
-       nn=nn+1
-       ee=ea(nc+kk)
-       emax=0.9d0*ea(nc+kk)
-       emin=1.1d0*ea(nc+kk)
-       call lschvkbb(nn,ll,nprj,ierr,ee,emin,emax, &
-&                    rr,vp(1,lloc+1),vkb(1,1,l1),evkb(1,l1), &
-&                    uu,up,mmax,mch)
-       if(ierr/=0) then
-         write(6,'(a,3i4,2f12.6)') 'run_ghosts: lschvkbb ERROR', &
-&              nn,ll,ierr,ea(nc+kk),ee
-       end if
-
-       do ii=1,10
-         et=dmin1(ee-eps,ee*(1.0d0+eps))
-         if(hmev(jj)<et) then
-           write(6,'(4x,i4,16x,f16.6,f10.2,a)') ll,hmev(jj),ecut, &
-&                '  WARNING - GHOST(-)'
-           jj=jj+1
-         else
-           exit
+      nn=ll
+      jj=0
+      do kk=1,nv
+         if(la(nc+kk)/=ll) cycle
+         jj=jj+1
+         nn=nn+1
+         ee=ea(nc+kk)
+         emax=0.9d0*ea(nc+kk)
+         emin=1.1d0*ea(nc+kk)
+         call lschvkbb(nn,ll,nprj,ierr,ee,emin,emax, &
+         &                    rr,vp(1,lloc+1),vkb(1,1,l1),evkb(1,l1), &
+         &                    uu,up,mmax,mch)
+         if(ierr/=0) then
+            write(6,'(a,3i4,2f12.6)') 'run_ghosts: lschvkbb ERROR', &
+            &              nn,ll,ierr,ea(nc+kk),ee
          end if
-       end do !ii
 
-       write(6,'(2i4,2f16.6,f10.2)') nn,ll,ee,hmev(jj),ecut
-     end do !kk
+         do ii=1,10
+            et=dmin1(ee-eps,ee*(1.0d0+eps))
+            if(hmev(jj)<et) then
+               write(6,'(4x,i4,16x,f16.6,f10.2,a)') ll,hmev(jj),ecut, &
+               &                '  WARNING - GHOST(-)'
+               jj=jj+1
+            else
+               exit
+            end if
+         end do  !ii
+
+         write(6,'(2i4,2f16.6,f10.2)') nn,ll,ee,hmev(jj),ecut
+      end do  !kk
 
 !if there were no valence states, look for any nodeless bound state
 !if this fails, use vacuum level (0.0) to compare to basis-set states
 
-     if(jj==0) then
-       ee=-1.0d5
-       do kk=1,nv
-         ee=max(ee,ea(nc+kk))
-       end do
-       emax=0.0d0
-       emin=2.0d0*ee
-       call lschvkbb(ll+1,ll,nprj,ierr,ee,emin,emax, &
-&                    rr,vp(1,lloc+1),vkb(1,1,l1),evkb(1,l1), &
-&                    uu,up,mmax,mch)
-       if(ierr/=0) ee=0.0d0
-       do jj=1,10
-         et=dmin1(ee-eps,ee*(1.0d0+eps))
-         if(hmev(jj)<et) then
-           write(6,'(4x,i4,16x,f16.6,f10.2,a)') ll,hmev(jj),ecut, &
-&                '  WARNING - GHOST(-)'
-         else if(ee<0.0d0) then
-           write(6,'(2i4,2f16.6,f10.2)') ll+1,ll,ee,hmev(jj),ecut
-           exit
-         else
-           exit
-         end if
-       end do
-     end if
+      if(jj==0) then
+         ee=-1.0d5
+         do kk=1,nv
+            ee=max(ee,ea(nc+kk))
+         end do
+         emax=0.0d0
+         emin=2.0d0*ee
+         call lschvkbb(ll+1,ll,nprj,ierr,ee,emin,emax, &
+         &                    rr,vp(1,lloc+1),vkb(1,1,l1),evkb(1,l1), &
+         &                    uu,up,mmax,mch)
+         if(ierr/=0) ee=0.0d0
+         do jj=1,10
+            et=dmin1(ee-eps,ee*(1.0d0+eps))
+            if(hmev(jj)<et) then
+               write(6,'(4x,i4,16x,f16.6,f10.2,a)') ll,hmev(jj),ecut, &
+               &                '  WARNING - GHOST(-)'
+            else if(ee<0.0d0) then
+               write(6,'(2i4,2f16.6,f10.2)') ll+1,ll,ee,hmev(jj),ecut
+               exit
+            else
+               exit
+            end if
+         end do
+      end if
 
 !calculate mean radius of all eigenstates to look for highly localized
 !states which indicate postive-energy ghosts
-     do jj=1,nbas
-       uu(:)=0.0d0
-       do ii=1,nbas
-         uu(:)=uu(:)+hmat(ii,jj)*uua(:,ii)
-       end do
+      do jj=1,nbas
+         uu(:)=0.0d0
+         do ii=1,nbas
+            uu(:)=uu(:)+hmat(ii,jj)*uua(:,ii)
+         end do
 
-       ro=rr(1)/dsqrt(amesh)
-       sn=(ro*uu(1))**2/dfloat(2*ll+4)
+         ro=rr(1)/dsqrt(amesh)
+         sn=(ro*uu(1))**2/dfloat(2*ll+4)
 
-       do ii=1,mbar-3
-         sn=sn+al*(rr(ii)*uu(ii))**2
-       end do
+         do ii=1,mbar-3
+            sn=sn+al*(rr(ii)*uu(ii))**2
+         end do
 
-       sn=sn + al*(23.0d0*(rr(mbar-2)*uu(mbar-2))**2 &
-&                + 28.0d0*(rr(mbar-1)*uu(mbar-1))**2 &
-&                +  9.0d0*(rr(mbar  )*uu(mbar  ))**2)/24.0d0
+         sn=sn + al*(23.0d0*(rr(mbar-2)*uu(mbar-2))**2 &
+         &                + 28.0d0*(rr(mbar-1)*uu(mbar-1))**2 &
+         &                +  9.0d0*(rr(mbar  )*uu(mbar  ))**2)/24.0d0
 
 !      if(sn<rr(irc(l1)) .and. hmev(jj)>0.0d0 .and. npgh<20) then
-       if(sn<rr(irc(l1)) .and. hmev(jj)>ee+0.05d0 .and. npgh<20) then
-         npgh=npgh+1
-         lpgh(npgh)=ll
-         epgh(npgh)=hmev(jj)
-         rpgh(npgh)=sn/rr(irc(l1))
-         cpgh(npgh)=ecut
-       end if
-     end do
+         if(sn<rr(irc(l1)) .and. hmev(jj)>ee+0.05d0 .and. npgh<20) then
+            npgh=npgh+1
+            lpgh(npgh)=ll
+            epgh(npgh)=hmev(jj)
+            rpgh(npgh)=sn/rr(irc(l1))
+            cpgh(npgh)=ecut
+         end if
+      end do
 
 
-   deallocate(gg0,hmat,hmev,work)
-   deallocate(uua)
- end do !l1
+      deallocate(gg0,hmat,hmev,work)
+      deallocate(uua)
+   end do  !l1
 
    write(6,'(/a)') ' Testing for highly-localized positive-energy ghosts'
    write(6,'(5a)') '    ','   l','    <radius>/rc  ', &
-&        '   E Basis Diag.','   E Cutoff'
+   &        '   E Basis Diag.','   E Cutoff'
 
- if(npgh>0) then
-   do jj=1,npgh
-           write(6,'(/4x,i4,2f16.6,f10.2,a)') lpgh(jj),rpgh(jj), &
-&                epgh(jj),cpgh(jj),'  WARNING - GHOST(+)'
-   end do
- end if
+   if(npgh>0) then
+      do jj=1,npgh
+         write(6,'(/4x,i4,2f16.6,f10.2,a)') lpgh(jj),rpgh(jj), &
+         &                epgh(jj),cpgh(jj),'  WARNING - GHOST(+)'
+      end do
+   end if
 
- deallocate(uu,up)
- return
- end subroutine run_ghosts
+   deallocate(uu,up)
+   return
+end subroutine run_ghosts

--- a/src/run_optimize.f90
+++ b/src/run_optimize.f90
@@ -2,26 +2,26 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
-   subroutine run_optimize(eig,ll,mmax,mxprj,rr,uua,qq,&
+subroutine run_optimize(eig,ll,mmax,mxprj,rr,uua,qq,&
 &                        irc,qcut,qmsbf,ncon_in,nbas_in,npr, &
 &                        psopt,vpsp,vkb,vae,cvgplt)
 
 ! calls routines to generate optimized pseudo wave function and semi-local
-! pseudopotential and prints diagnostic information on process and 
+! pseudopotential and prints diagnostic information on process and
 ! convergence performance
 
 !eig  energy at which pseudo wave function is computed
@@ -44,62 +44,62 @@
 !vae  all-electron potential
 !cvgplt  energy error vs. cutoff energy for plotting
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
- real(dp), parameter :: Ha_eV=27.21138386d0 ! 1 Hartree, in eV
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
+   real(dp), parameter :: Ha_eV=27.21138386d0  ! 1 Hartree, in eV
 
 !Input variables
- integer :: ll,mmax,mxprj,irc,ncon_in,nbas_in,npr
- real(dp) :: rr(mmax)
- real(dp) :: uua(mmax,mxprj),vae(mmax),qq(mxprj,mxprj)
- real(dp) :: eig(mxprj),qcut
+   integer :: ll,mmax,mxprj,irc,ncon_in,nbas_in,npr
+   real(dp) :: rr(mmax)
+   real(dp) :: uua(mmax,mxprj),vae(mmax),qq(mxprj,mxprj)
+   real(dp) :: eig(mxprj),qcut
 
 !Output variables
- real(dp) :: qmsbf
- real(dp) :: psopt(mmax,mxprj),vpsp(mmax),vkb(mmax,mxprj)
+   real(dp) :: qmsbf
+   real(dp) :: psopt(mmax,mxprj),vpsp(mmax),vkb(mmax,mxprj)
 
 !Local variables
- real(dp) :: uord(6)
- real(dp) :: al,rc,ulgd,tt
- real(dp) :: sn,ps0norm,amesh,ro
- real(dp) :: err,lerr,qerr,ehaerr,eeverr
- real(dp) :: sbf(mmax)
- real(dp) :: cons(6),cvgplt(2,7,mxprj)
- real(dp), allocatable :: orbasis(:,:)
- real(dp), allocatable :: orbasis_der(:,:),pswf0_sb(:),pswfnull_sb(:,:)
- real(dp), allocatable :: pswf0_or(:),pswfnull_or(:,:)
- real(dp), allocatable :: work(:)
- integer :: ii,iprj,jj,l1,lmax,nbas,ncon,nconmx
- logical :: found_root
+   real(dp) :: uord(6)
+   real(dp) :: al,rc,ulgd,tt
+   real(dp) :: sn,ps0norm,amesh,ro
+   real(dp) :: err,lerr,qerr,ehaerr,eeverr
+   real(dp) :: sbf(mmax)
+   real(dp) :: cons(6),cvgplt(2,7,mxprj)
+   real(dp), allocatable :: orbasis(:,:)
+   real(dp), allocatable :: orbasis_der(:,:),pswf0_sb(:),pswfnull_sb(:,:)
+   real(dp), allocatable :: pswf0_or(:),pswfnull_or(:,:)
+   real(dp), allocatable :: work(:)
+   integer :: ii,iprj,jj,l1,lmax,nbas,ncon,nconmx
+   logical :: found_root
 
- integer :: nnull,nqout
+   integer :: nnull,nqout
 
- real(dp), allocatable :: qroot(:),sbasis(:)
- real(dp), allocatable :: eresid0(:),eresiddot(:,:)
- real(dp), allocatable :: eresidmat(:,:,:),pswfresid_sb(:,:)
- real(dp), allocatable :: qout(:),eresq(:),leresq(:)
+   real(dp), allocatable :: qroot(:),sbasis(:)
+   real(dp), allocatable :: eresid0(:),eresiddot(:,:)
+   real(dp), allocatable :: eresidmat(:,:,:),pswfresid_sb(:,:)
+   real(dp), allocatable :: qout(:),eresq(:),leresq(:)
 
- real(dp), allocatable :: pswfopt_sb(:),pswfopt_or(:)
- real(dp) :: eresidmin
- real(dp) :: ekin_anal,ekin_num,qmax
+   real(dp), allocatable :: pswfopt_sb(:),pswfopt_or(:)
+   real(dp) :: eresidmin
+   real(dp) :: ekin_anal,ekin_num,qmax
 
 !parameters whose default values here give well-converged results
 ! increasing dq and/or dr will speed up the code at some cost
 ! in optimization accuracy
- real(dp) :: dq,dr,dqout
- dq=0.02d0  !linear integration mesh spacing for above
- dr=0.02d0  !linear integration spacing for Fourier transforms
+   real(dp) :: dq,dr,dqout
+   dq=0.02d0  !linear integration mesh spacing for above
+   dr=0.02d0  !linear integration spacing for Fourier transforms
 !dr=0.002d0  !linear integration spacing for Fourier transforms
- dqout=0.5000001d0  !linear mesh spacing for final E_resid(q) interpolation
-                    !increment is to avoid exact commnesurability with dq mesh
+   dqout=0.5000001d0  !linear mesh spacing for final E_resid(q) interpolation
+   !increment is to avoid exact commnesurability with dq mesh
 
- al = 0.01d0 * dlog(rr(101) / rr(1))
- rc=rr(irc)
- l1=ll+1
+   al = 0.01d0 * dlog(rr(101) / rr(1))
+   rc=rr(irc)
+   l1=ll+1
 
- nconmx=ncon_in+npr-1
+   nconmx=ncon_in+npr-1
 
- allocate(work(mmax))
+   allocate(work(mmax))
 
 !maximum basis size
    nbas=nbas_in+npr-1
@@ -121,154 +121,154 @@
 !write(6,'(/a)') 'qroots'
 !write(6,'(6f12.6)') (qroot(ii),ii=1,nbas)
 
- psopt(:,:)=0.0d0
+   psopt(:,:)=0.0d0
 
 ! loop over projectors
- do iprj=1,npr
+   do iprj=1,npr
 
-   write(6,'(/a,i4)') 'Calculating optimized projector #',iprj, &
-&        ' for l=',ll
+      write(6,'(/a,i4)') 'Calculating optimized projector #',iprj, &
+      &        ' for l=',ll
 
 !basis size and number of constraints for this projector
-   nbas=nbas_in+iprj-1
-   ncon=ncon_in+iprj-1
-   nnull=nbas-ncon
+      nbas=nbas_in+iprj-1
+      ncon=ncon_in+iprj-1
+      nnull=nbas-ncon
 
-   allocate(sbasis(nbas))
-   allocate(orbasis(nbas,nbas))
-   allocate(orbasis_der(ncon,nbas))
-   allocate(pswf0_sb(nbas),pswf0_or(nbas))
-   allocate(pswfopt_sb(nbas),pswfopt_or(nbas))
-   allocate(pswfresid_sb(nbas,nnull))
-   allocate(pswfnull_sb(nbas,nnull))
-   allocate(pswfnull_or(nbas,nnull))
+      allocate(sbasis(nbas))
+      allocate(orbasis(nbas,nbas))
+      allocate(orbasis_der(ncon,nbas))
+      allocate(pswf0_sb(nbas),pswf0_or(nbas))
+      allocate(pswfopt_sb(nbas),pswfopt_or(nbas))
+      allocate(pswfresid_sb(nbas,nnull))
+      allocate(pswfnull_sb(nbas,nnull))
+      allocate(pswfnull_or(nbas,nnull))
 
 !calculate derivatives of all-electron wave function at r_c
 !to define basis set for current projector and derivative constraints
 
-   call wf_rc_der(rr,uua(1,iprj),al,rc,irc,mmax,uord)
+      call wf_rc_der(rr,uua(1,iprj),al,rc,irc,mmax,uord)
 
 !q considered infinity for E_resid calculation
-   qmax=dq*int(2.0d0*qroot(nbas)/dq) 
-   qmax=max(qmax,20.0d0)
+      qmax=dq*int(2.0d0*qroot(nbas)/dq)
+      qmax=max(qmax,20.0d0)
 
 
-   nqout=2 + 0.75d0*qmax/dqout
+      nqout=2 + 0.75d0*qmax/dqout
 
-   allocate(qout(nqout),eresq(nqout),leresq(nqout),eresid0(nqout))
-   allocate(eresiddot(nnull,nqout),eresidmat(nnull,nnull,nqout))
+      allocate(qout(nqout),eresq(nqout),leresq(nqout),eresid0(nqout))
+      allocate(eresiddot(nnull,nqout),eresidmat(nnull,nnull,nqout))
 
-   qout(1)=qcut
-   do ii=nqout,2,-1
-    qout(ii)=(ii-2)*dqout
-   end do
+      qout(1)=qcut
+      do ii=nqout,2,-1
+         qout(ii)=(ii-2)*dqout
+      end do
 
 !calculate orthogonal basis and constraint matrix
-   call sbf_basis_con(ll,rr,mmax,irc,nbas,qroot,psopt,orbasis,orbasis_der, &
-&                     iprj,mxprj,ncon,ncon_in)
+      call sbf_basis_con(ll,rr,mmax,irc,nbas,qroot,psopt,orbasis,orbasis_der, &
+      &                     iprj,mxprj,ncon,ncon_in)
 
 
 !load constraint vector for value/derivative matching
-   cons(:)=0.0d0
-   do jj=1,ncon_in
-    cons(jj)=uord(jj)
-   end do
+      cons(:)=0.0d0
+      do jj=1,ncon_in
+         cons(jj)=uord(jj)
+      end do
 !load overlap constraints if present
-   if(iprj>=2) then
-     do jj=1,iprj-1
-       cons(ncon_in+jj)=qq(jj,iprj)
-     end do
-   end if
+      if(iprj>=2) then
+         do jj=1,iprj-1
+            cons(ncon_in+jj)=qq(jj,iprj)
+         end do
+      end if
 
 !calculate constrained basis for residual energy minimization
 !satisfying off-diagonal norm conservation
-   call const_basis(nbas,ncon,cons,orbasis,orbasis_der, &
-&                   pswf0_or,pswfnull_or, &
-&                   pswf0_sb,pswfnull_sb,ps0norm)
+      call const_basis(nbas,ncon,cons,orbasis,orbasis_der, &
+      &                   pswf0_or,pswfnull_or, &
+      &                   pswf0_sb,pswfnull_sb,ps0norm)
 
 !calculate eigenvectors, eigenvalues, and inhomogeneous terms for
 !the residual energy for a set of q lower cutoffs
 
-   write(6,'(/a,f10.6)') '    Fraction of norm inside rc',qq(iprj,iprj)
+      write(6,'(/a,f10.6)') '    Fraction of norm inside rc',qq(iprj,iprj)
 
-   call eresid(ll,irc,nnull,nbas,mmax,rr,dr,dq,qmax,qroot, &
-&                    uua(1,iprj),pswf0_sb,pswfnull_sb, nqout,qout, &
-&                    eresid0,eresiddot,eresidmat)
+      call eresid(ll,irc,nnull,nbas,mmax,rr,dr,dq,qmax,qroot, &
+      &                    uua(1,iprj),pswf0_sb,pswfnull_sb, nqout,qout, &
+      &                    eresid0,eresiddot,eresidmat)
 
-   write(6,'(a,f7.2,a,f7.2,a)') '    Optimizing pswf for qcut=',qout(1), &
-&   ' a_B^-1,  ecut=',0.5d0*qout(1)**2,' Ha'
-   write(6,'(a,f6.2,a,f7.1,a)') '    q_infinity defining residual KE=',&
-&   qmax,'  (E_inf=',0.5d0*qmax**2,' Ha)'
+      write(6,'(a,f7.2,a,f7.2,a)') '    Optimizing pswf for qcut=',qout(1), &
+      &   ' a_B^-1,  ecut=',0.5d0*qout(1)**2,' Ha'
+      write(6,'(a,f6.2,a,f7.1,a)') '    q_infinity defining residual KE=',&
+      &   qmax,'  (E_inf=',0.5d0*qmax**2,' Ha)'
 
 !find the null-basis coefficients which minimize the eresid while
 !satisfying diagonal norm conservation
 
-   call optimize(nnull,nbas,pswf0_sb,pswf0_or,nqout,qout,&
-&                eresid0,eresiddot,eresidmat,&
-&                pswfnull_sb,pswfnull_or,qq(iprj,iprj),ps0norm,eresidmin, &
-&                pswfopt_sb,pswfopt_or,ekin_anal,eresq)
+      call optimize(nnull,nbas,pswf0_sb,pswf0_or,nqout,qout,&
+      &                eresid0,eresiddot,eresidmat,&
+      &                pswfnull_sb,pswfnull_or,qq(iprj,iprj),ps0norm,eresidmin, &
+      &                pswfopt_sb,pswfopt_or,ekin_anal,eresq)
 
-   write(6,'(a,1p,d10.2,a)') '    Residual kinetic energy error=', &
-&        eresidmin,' Ha'
+      write(6,'(a,1p,d10.2,a)') '    Residual kinetic energy error=', &
+      &        eresidmin,' Ha'
 
 ! find the Vanderbilt projectors and optimized wave functions
 
-   call pspot(iprj,ll,rr,irc,mmax,al,nbas,qroot,eig(iprj),uua(1,iprj), &
-&             pswfopt_sb,psopt(1,iprj),vae,work,vkb(1,iprj),ekin_num)
+      call pspot(iprj,ll,rr,irc,mmax,al,nbas,qroot,eig(iprj),uua(1,iprj), &
+      &             pswfopt_sb,psopt(1,iprj),vae,work,vkb(1,iprj),ekin_num)
 
 !semi-local potential
-   if(iprj==1) then
-     do ii=1,irc
-       vpsp(ii)=work(ii)
-     end do
-     do ii=irc+1,mmax
-       vpsp(ii)=vae(ii)
-     end do
-   end if
+      if(iprj==1) then
+         do ii=1,irc
+            vpsp(ii)=work(ii)
+         end do
+         do ii=irc+1,mmax
+            vpsp(ii)=vae(ii)
+         end do
+      end if
 
-   write(6,'(/a)') '    Total kinetic energy consistency test'
-   write(6,'(a)') '      Fourier integration compared to d^2/dr^2 integral'
-   write(6,'(a,f12.8,a,f12.8,a,f12.8)') '      Fourier',ekin_anal, &
-&    '  r-space=',ekin_num,'  ratio=',ekin_anal/ekin_num
-   write(6,'(a)') '    Potential consistency test at r_c'
-   write(6,'(a,f12.8,a,f12.8,a,1p,d10.2)') '    "vpsp"=',work(irc),'  vae=', &
-&    vae(irc),'  difference=',vae(irc)-work(irc)
+      write(6,'(/a)') '    Total kinetic energy consistency test'
+      write(6,'(a)') '      Fourier integration compared to d^2/dr^2 integral'
+      write(6,'(a,f12.8,a,f12.8,a,f12.8)') '      Fourier',ekin_anal, &
+      &    '  r-space=',ekin_num,'  ratio=',ekin_anal/ekin_num
+      write(6,'(a)') '    Potential consistency test at r_c'
+      write(6,'(a,f12.8,a,f12.8,a,1p,d10.2)') '    "vpsp"=',work(irc),'  vae=', &
+      &    vae(irc),'  difference=',vae(irc)-work(irc)
 
 !interpolate the convergence behavior of the optimized pseudo wave function
 
-   write(6,'(/a)') '    Energy error per electron        Cutoff'
-   write(6,'(a)') '         Ha          eV             Ha'
-   leresq(:)=log(eresq(:))
-   err=0.01d0
-   do jj=1,7
-    lerr=log(err)
-    do ii=3,nqout
-     if(leresq(ii-1)>lerr .and. leresq(ii)<=lerr) then
-      qerr=qout(ii)-dqout*(lerr-leresq(ii))/(leresq(ii-1)-leresq(ii))
-      cvgplt(1,jj,iprj)= 0.5d0*qerr**2
-      cvgplt(2,jj,iprj)= err
-      if(mod(jj,2)/=0) then
-        write(6,'(4x,2f12.5,f12.2)') err,err*Ha_eV,0.5d0*qerr**2
-      end if
-     end if
-    end do
-    err=sqrt(0.1d0)*err
-   end do
+      write(6,'(/a)') '    Energy error per electron        Cutoff'
+      write(6,'(a)') '         Ha          eV             Ha'
+      leresq(:)=log(eresq(:))
+      err=0.01d0
+      do jj=1,7
+         lerr=log(err)
+         do ii=3,nqout
+            if(leresq(ii-1)>lerr .and. leresq(ii)<=lerr) then
+               qerr=qout(ii)-dqout*(lerr-leresq(ii))/(leresq(ii-1)-leresq(ii))
+               cvgplt(1,jj,iprj)= 0.5d0*qerr**2
+               cvgplt(2,jj,iprj)= err
+               if(mod(jj,2)/=0) then
+                  write(6,'(4x,2f12.5,f12.2)') err,err*Ha_eV,0.5d0*qerr**2
+               end if
+            end if
+         end do
+         err=sqrt(0.1d0)*err
+      end do
 
-   deallocate(sbasis)
-   deallocate(orbasis)
-   deallocate(orbasis_der)
-   deallocate(pswf0_sb,pswf0_or)
-   deallocate(pswfopt_sb,pswfopt_or)
-   deallocate(pswfresid_sb)
-   deallocate(pswfnull_sb)
-   deallocate(pswfnull_or)
-   deallocate(eresiddot,eresidmat)
-   deallocate(qout,eresq,leresq,eresid0)
+      deallocate(sbasis)
+      deallocate(orbasis)
+      deallocate(orbasis_der)
+      deallocate(pswf0_sb,pswf0_or)
+      deallocate(pswfopt_sb,pswfopt_or)
+      deallocate(pswfresid_sb)
+      deallocate(pswfnull_sb)
+      deallocate(pswfnull_or)
+      deallocate(eresiddot,eresidmat)
+      deallocate(qout,eresq,leresq,eresid0)
 
- end do !iprj
+   end do  !iprj
 
- deallocate(work,qroot)
+   deallocate(work,qroot)
 
- return
- end subroutine run_optimize
+   return
+end subroutine run_optimize

--- a/src/run_phsft.f90
+++ b/src/run_phsft.f90
@@ -2,21 +2,21 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- subroutine run_phsft(lmax,lloc,nproj,epa,epsh1,epsh2,depsh,vkb,evkb, &
+subroutine run_phsft(lmax,lloc,nproj,epa,epsh1,epsh2,depsh,vkb,evkb, &
 &                     rr,vfull,vp,zz,mmax,mxprj,irc,srel)
 
 ! computes log derivatives, actually atan(r * ((d psi(r)/dr)/psi(r)))
@@ -43,60 +43,60 @@
 !irphs  index of rr beyond which all vp==vlocal
 !srel .true. for scalar-relativistic, .false. for non-relativistic
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !Input variables
- integer :: lmax,lloc,mmax,mxprj
- integer :: nproj(6),irc(6)
- real(dp) :: epsh1,epsh2,depsh,zz
- real(dp) :: rr(mmax),vp(mmax,5),epa(mxprj,6)
- real(dp) :: vfull(mmax),vkb(mmax,mxprj,4),evkb(mxprj,4)
- logical :: srel
+   integer :: lmax,lloc,mmax,mxprj
+   integer :: nproj(6),irc(6)
+   real(dp) :: epsh1,epsh2,depsh,zz
+   real(dp) :: rr(mmax),vp(mmax,5),epa(mxprj,6)
+   real(dp) :: vfull(mmax),vkb(mmax,mxprj,4),evkb(mxprj,4)
+   logical :: srel
 
 !Output variables - printing only
 
 !Local variables
- integer :: ii,irphs,ll,l1,npsh
- real(dp) :: epsh
+   integer :: ii,irphs,ll,l1,npsh
+   real(dp) :: epsh
 
- real(dp),allocatable :: pshf(:),pshp(:)
+   real(dp),allocatable :: pshf(:),pshp(:)
 
- npsh=int(((epsh2-epsh1)/depsh)-0.5d0)+1
+   npsh=int(((epsh2-epsh1)/depsh)-0.5d0)+1
 
- allocate(pshf(npsh),pshp(npsh))
+   allocate(pshf(npsh),pshp(npsh))
 
 ! loop for phase shift calculation -- full, then local or Kleinman-
 ! Bylander / Vanderbilt
- 
- do l1 = 1, 4
 
-   ll = l1 - 1
-   if(ll<=lmax) then
-     irphs=irc(l1)+2
-   else
-     irphs=irc(lloc+1)
-   end if
+   do l1 = 1, 4
 
-   call fphsft(ll,epsh2,depsh,pshf,rr,vfull,zz,mmax,irphs,npsh,srel)
-   if(ll .eq. lloc) then  
-     call  vkbphsft(ll,0,epsh2,depsh,epa(1,l1),pshf,pshp, &
-&                   rr,vp(1,lloc+1),vkb(1,1,l1),evkb(1,l1), &
-&                   mmax,irphs,npsh)
-   else
-     call  vkbphsft(ll,nproj(l1),epsh2,depsh,epa(1,l1),pshf,pshp, &
-&                   rr,vp(1,lloc+1),vkb(1,1,l1),evkb(1,l1), &
-&                   mmax,irphs,npsh)
-   end if
+      ll = l1 - 1
+      if(ll<=lmax) then
+         irphs=irc(l1)+2
+      else
+         irphs=irc(lloc+1)
+      end if
 
-   write(6,'(/a,i2)') 'log derivativve data for plotting, l=',ll
-   write(6,'(a,f6.2)') 'atan(r * ((d psi(r)/dr)/psi(r))), r=',rr(irphs)
-   write(6,'(a/)') 'l, energy, all-electron, pseudopotential'
-   do ii = 1, npsh
-     epsh = epsh2 - depsh * dfloat(ii - 1)
-     write(6,'(a, i6, 3f12.6)') '! ',ll, epsh, pshf(ii), pshp(ii)
+      call fphsft(ll,epsh2,depsh,pshf,rr,vfull,zz,mmax,irphs,npsh,srel)
+      if(ll == lloc) then
+         call  vkbphsft(ll,0,epsh2,depsh,epa(1,l1),pshf,pshp, &
+         &                   rr,vp(1,lloc+1),vkb(1,1,l1),evkb(1,l1), &
+         &                   mmax,irphs,npsh)
+      else
+         call  vkbphsft(ll,nproj(l1),epsh2,depsh,epa(1,l1),pshf,pshp, &
+         &                   rr,vp(1,lloc+1),vkb(1,1,l1),evkb(1,l1), &
+         &                   mmax,irphs,npsh)
+      end if
+
+      write(6,'(/a,i2)') 'log derivativve data for plotting, l=',ll
+      write(6,'(a,f6.2)') 'atan(r * ((d psi(r)/dr)/psi(r))), r=',rr(irphs)
+      write(6,'(a/)') 'l, energy, all-electron, pseudopotential'
+      do ii = 1, npsh
+         epsh = epsh2 - depsh * dfloat(ii - 1)
+         write(6,'(a, i6, 3f12.6)') '! ',ll, epsh, pshf(ii), pshp(ii)
+      end do
    end do
- end do
- deallocate(pshf,pshp)
- return
- end subroutine run_phsft
+   deallocate(pshf,pshp)
+   return
+end subroutine run_phsft

--- a/src/run_phsft_r.f90
+++ b/src/run_phsft_r.f90
@@ -2,21 +2,21 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- subroutine run_phsft_r(lmax,lloc,nproj,ep,epsh1,epsh2,depsh,vkb,evkb, &
+subroutine run_phsft_r(lmax,lloc,nproj,ep,epsh1,epsh2,depsh,vkb,evkb, &
 &                     rr,vfull,vp,zz,mmax,mxprj,irc)
 
 ! computes log derivatives, actually atan(r * ((d psi(r)/dr)/psi(r)))
@@ -44,74 +44,74 @@
 !irc  core radii
 !irphs  index of rr beyond which all vp==vlocal
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !Input variables
- integer :: lmax,lloc,mmax,mxprj
- integer :: nproj(6),irc(6)
- real(dp) :: epsh1,epsh2,depsh,zz
- real(dp) :: rr(mmax),vp(mmax,5,2),ep(6,2)
- real(dp) :: vfull(mmax),vkb(mmax,mxprj,4,2),evkb(mxprj,4,2)
+   integer :: lmax,lloc,mmax,mxprj
+   integer :: nproj(6),irc(6)
+   real(dp) :: epsh1,epsh2,depsh,zz
+   real(dp) :: rr(mmax),vp(mmax,5,2),ep(6,2)
+   real(dp) :: vfull(mmax),vkb(mmax,mxprj,4,2),evkb(mxprj,4,2)
 
 !Output variables - printing only
 
 !Local variables
- integer :: ii,ll,l1,irphs,npsh
- integer :: ikap,kap,mkap
- real(dp) :: epsh
+   integer :: ii,ll,l1,irphs,npsh
+   integer :: ikap,kap,mkap
+   real(dp) :: epsh
 
- real(dp),allocatable :: pshf(:),pshp(:)
+   real(dp),allocatable :: pshf(:),pshp(:)
 
- npsh=int(((epsh2-epsh1)/depsh)-0.5d0)+1
+   npsh=int(((epsh2-epsh1)/depsh)-0.5d0)+1
 
- allocate(pshf(npsh),pshp(npsh))
+   allocate(pshf(npsh),pshp(npsh))
 
 ! loop for phase shift calculation -- full, then local or Kleinman-
 ! Bylander / Vanderbilt
- 
- do l1 = 1, 4
-   ll = l1 - 1
 
-   if(ll<=lmax) then
-     irphs=irc(l1)+2
-   else
-     irphs=irc(lloc+1)
-   end if
+   do l1 = 1, 4
+      ll = l1 - 1
 
-  if(l1==1) then
-   mkap=1
-  else
-   mkap=2
-  end if
+      if(ll<=lmax) then
+         irphs=irc(l1)+2
+      else
+         irphs=irc(lloc+1)
+      end if
+
+      if(l1==1) then
+         mkap=1
+      else
+         mkap=2
+      end if
 ! loop on J = ll +/- 1/2
-  do ikap=1,mkap
-   if(ikap==1) kap=-(ll+1)
-   if(ikap==2) kap=  ll
-   call fphsft_r(ll,kap,epsh2,depsh,pshf,rr,vfull,zz,mmax,irphs,npsh)
-   if(ll .eq. lloc) then  
-     call  vkbphsft(ll,0,epsh2,depsh,ep(l1,ikap),pshf,pshp, &
-&                   rr,vp(1,lloc+1,ikap),vkb(1,1,l1,ikap),evkb(1,l1,ikap), &
-&                   mmax,irphs,npsh)
-   else
-     call  vkbphsft(ll,nproj(l1),epsh2,depsh,ep(l1,ikap),pshf,pshp, &
-&                   rr,vp(1,lloc+1,ikap),vkb(1,1,l1,ikap),evkb(1,l1,ikap), &
-&                   mmax,irphs,npsh)
-   end if
+      do ikap=1,mkap
+         if(ikap==1) kap=-(ll+1)
+         if(ikap==2) kap=  ll
+         call fphsft_r(ll,kap,epsh2,depsh,pshf,rr,vfull,zz,mmax,irphs,npsh)
+         if(ll == lloc) then
+            call  vkbphsft(ll,0,epsh2,depsh,ep(l1,ikap),pshf,pshp, &
+            &                   rr,vp(1,lloc+1,ikap),vkb(1,1,l1,ikap),evkb(1,l1,ikap), &
+            &                   mmax,irphs,npsh)
+         else
+            call  vkbphsft(ll,nproj(l1),epsh2,depsh,ep(l1,ikap),pshf,pshp, &
+            &                   rr,vp(1,lloc+1,ikap),vkb(1,1,l1,ikap),evkb(1,l1,ikap), &
+            &                   mmax,irphs,npsh)
+         end if
 
-   write(6,'(/a,i2)') 'log derivativve data for plotting, l=',ll
-   write(6,'(a,f6.2)') 'atan(r * ((d psi(r)/dr)/psi(r))), r=',rr(irphs)
-   write(6,'(a/)') 'l, energy, all-electron, pseudopotential'
-   do ii = 1, npsh
-    epsh = epsh2 - depsh * dfloat(ii - 1)
-    if(ikap==1) then
-     write(6,'(a, i6, 3f12.6)') '! ',-ll, epsh, pshf(ii), pshp(ii)
-    else
-     write(6,'(a, i6, 3f12.6)') '! ',ll, epsh, pshf(ii), pshp(ii)
-    end if
-   end do
-  end do !ikap
- end do !l1
- deallocate(pshf,pshp)
- return
- end subroutine run_phsft_r
+         write(6,'(/a,i2)') 'log derivativve data for plotting, l=',ll
+         write(6,'(a,f6.2)') 'atan(r * ((d psi(r)/dr)/psi(r))), r=',rr(irphs)
+         write(6,'(a/)') 'l, energy, all-electron, pseudopotential'
+         do ii = 1, npsh
+            epsh = epsh2 - depsh * dfloat(ii - 1)
+            if(ikap==1) then
+               write(6,'(a, i6, 3f12.6)') '! ',-ll, epsh, pshf(ii), pshp(ii)
+            else
+               write(6,'(a, i6, 3f12.6)') '! ',ll, epsh, pshf(ii), pshp(ii)
+            end if
+         end do
+      end do  !ikap
+   end do  !l1
+   deallocate(pshf,pshp)
+   return
+end subroutine run_phsft_r

--- a/src/run_plot.f90
+++ b/src/run_plot.f90
@@ -2,21 +2,21 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- subroutine run_plot(lmax,npa,epa,lloc,irc, &
+subroutine run_plot(lmax,npa,epa,lloc,irc, &
 &                    vkb,evkb,nproj,rr,vfull,vp,vpuns,zz,mmax,mxprj,drl,nrl, &
 &                    rho,rhoc,rhomod,srel,cvgplt)
 
@@ -45,164 +45,164 @@
 !rhoc core charge
 !rhomod  model core charge
 !srel .true. for scalar-relativistic, .false. for non-relativistic
-!cvgplt  Energy per electron error vs. cutoff 
+!cvgplt  Energy per electron error vs. cutoff
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !Input variables
- integer :: lmax,lloc,mmax,mxprj,nlim,nrl
- integer :: npa(mxprj,6),npx(6),irc(6),lpx(6),nproj(6)
- real(dp) :: zz,drl
- real(dp) :: rr(mmax),vp(mmax,5),vpuns(mmax,5),vfull(mmax),vkb(mmax,mxprj,4)
- real(dp) :: rho(mmax),rhoc(mmax),rhomod(mmax,5)
- real(dp):: epa(mxprj,6),evkb(mxprj,4),cvgplt(2,7,mxprj,4)
- logical :: srel
+   integer :: lmax,lloc,mmax,mxprj,nlim,nrl
+   integer :: npa(mxprj,6),npx(6),irc(6),lpx(6),nproj(6)
+   real(dp) :: zz,drl
+   real(dp) :: rr(mmax),vp(mmax,5),vpuns(mmax,5),vfull(mmax),vkb(mmax,mxprj,4)
+   real(dp) :: rho(mmax),rhoc(mmax),rhomod(mmax,5)
+   real(dp):: epa(mxprj,6),evkb(mxprj,4),cvgplt(2,7,mxprj,4)
+   logical :: srel
 
 !Output variables - printing only
 
 !Local variables
- integer :: ll,l1,ii,jj,ierr,mch,mchf,n1,n2,n3,n4,nn
- integer :: iprj,nnp,npr
- real(dp) :: al,emax,emin,etest,sls,rmx,sgnae,sgnps
- real(dp) :: r0,dr
- real(dp), allocatable :: uu(:),u2(:),up(:)
+   integer :: ll,l1,ii,jj,ierr,mch,mchf,n1,n2,n3,n4,nn
+   integer :: iprj,nnp,npr
+   real(dp) :: al,emax,emin,etest,sls,rmx,sgnae,sgnps
+   real(dp) :: r0,dr
+   real(dp), allocatable :: uu(:),u2(:),up(:)
 
- allocate(uu(mmax),u2(mmax),up(mmax))
+   allocate(uu(mmax),u2(mmax),up(mmax))
 
- al = 0.01d0 * dlog(rr(101)/rr(1))
+   al = 0.01d0 * dlog(rr(101)/rr(1))
 
- write(6,'(/a)') 'DATA FOR PLOTTING'
+   write(6,'(/a)') 'DATA FOR PLOTTING'
 
- n1 = idint(dlog(drl/rr(1))/al+1.0d0)
- n2 = idint(dlog(dfloat(nrl)*drl/rr(1))/al+1.0d0)
- n3=0
- do l1=1,lmax+1
-   n3=max(n3,irc(l1)-1)
- end do
- n4=min(n2,idint(dlog((rr(n3)+1.0d0)/rr(1))/al))
- n3=idint(dlog(1.1d0*rr(n3)/rr(1))/al+1.0d0)
+   n1 = idint(dlog(drl/rr(1))/al+1.0d0)
+   n2 = idint(dlog(dfloat(nrl)*drl/rr(1))/al+1.0d0)
+   n3=0
+   do l1=1,lmax+1
+      n3=max(n3,irc(l1)-1)
+   end do
+   n4=min(n2,idint(dlog((rr(n3)+1.0d0)/rr(1))/al))
+   n3=idint(dlog(1.1d0*rr(n3)/rr(1))/al+1.0d0)
 
- dr=dmin1(drl,rr(n4)/200)
- write(6,'(/2a/)') ' radii, charge,',' pseudopotentials (ll=0, 1, lmax)'
- r0=rr(n1)-dr
- do ii=n1,n4
-   if(rr(ii)>r0) then
-     write(6,'(a,6(f12.7,1x))') '!p',rr(ii),rho(ii),(vpuns(ii,l1),l1=1,lmax+1)
-     r0=rr(ii)+dr
-   end if
- end do
-
- if(lloc .eq. 4) then
+   dr=dmin1(drl,rr(n4)/200)
+   write(6,'(/2a/)') ' radii, charge,',' pseudopotentials (ll=0, 1, lmax)'
    r0=rr(n1)-dr
    do ii=n1,n4
-   if(rr(ii)>r0) then
-     write(6,'(a, 2(f12.7,1x))') ' !L',rr(ii),vpuns(ii,lloc + 1)
-     r0=rr(ii)+dr
-   end if
+      if(rr(ii)>r0) then
+         write(6,'(a,6(f12.7,1x))') '!p',rr(ii),rho(ii),(vpuns(ii,l1),l1=1,lmax+1)
+         r0=rr(ii)+dr
+      end if
    end do
- end if
+
+   if(lloc == 4) then
+      r0=rr(n1)-dr
+      do ii=n1,n4
+         if(rr(ii)>r0) then
+            write(6,'(a, 2(f12.7,1x))') ' !L',rr(ii),vpuns(ii,lloc + 1)
+            r0=rr(ii)+dr
+         end if
+      end do
+   end if
 
 ! output for analysis of core charge and models
- rmx=0
- do ii=n1,n2
-  rmx=max(rmx,5.0d0*rho(ii),rhomod(ii,1))
- end do
+   rmx=0
+   do ii=n1,n2
+      rmx=max(rmx,5.0d0*rho(ii),rhomod(ii,1))
+   end do
 
- write(6,'(//2a/)') ' radii, charge,',' core charge, model core charge'
- dr=dmin1(drl,rr(n2)/200.0d0)
- r0=rr(n1)-dr
- do ii=n1,n2
-   if(rr(ii)>r0) then
-      if(rhoc(ii)<rmx)then
-       write(6,'(a,8(f12.7,1x))') '!r',rr(ii),rho(ii),rhoc(ii), &
-&       rhomod(ii,1)
-      else if(rr(ii)>0.01d0) then
-        write(6,'(a,8(f12.7,1x))') '!r',rr(ii),rho(ii),rmx, &
-&       rhomod(ii,1)
+   write(6,'(//2a/)') ' radii, charge,',' core charge, model core charge'
+   dr=dmin1(drl,rr(n2)/200.0d0)
+   r0=rr(n1)-dr
+   do ii=n1,n2
+      if(rr(ii)>r0) then
+         if(rhoc(ii)<rmx)then
+            write(6,'(a,8(f12.7,1x))') '!r',rr(ii),rho(ii),rhoc(ii), &
+            &       rhomod(ii,1)
+         else if(rr(ii)>0.01d0) then
+            write(6,'(a,8(f12.7,1x))') '!r',rr(ii),rho(ii),rmx, &
+            &       rhomod(ii,1)
+         end if
+         r0=rr(ii)+dr
       end if
-     r0=rr(ii)+dr
-   end if
- end do
+   end do
 
 ! loop for wave function output
 
- do l1 = 1, lmax + 1
-   ll = l1 - 1
-    npr=nproj(l1)   
-    if(l1==lloc+1) npr=0
+   do l1 = 1, lmax + 1
+      ll = l1 - 1
+      npr=nproj(l1)
+      if(l1==lloc+1) npr=0
 
-   do iprj=1,nproj(l1)
-     if(epa(iprj,l1)<0.0d0) then
-       write(6,'(//a,i2,a,i2,a,a/)') 'n=',npa(iprj,l1),',  l=',ll, &
-&           ', all-electron wave function', ', pseudo w-f'
-       etest=epa(iprj,l1)
-       call lschfb(npa(iprj,l1),ll,ierr,etest, &
-&                  rr,vfull,uu,up,zz,mmax,mch,srel)
-       if(ierr .ne. 0) then
-          write(6,'(/a,3i4)') 'run_plot: lschfb convergence ERROR n,l,ierr=', &
-&         npa(iprj,l1),ll,ierr
-        stop
-       end if
+      do iprj=1,nproj(l1)
+         if(epa(iprj,l1)<0.0d0) then
+            write(6,'(//a,i2,a,i2,a,a/)') 'n=',npa(iprj,l1),',  l=',ll, &
+            &           ', all-electron wave function', ', pseudo w-f'
+            etest=epa(iprj,l1)
+            call lschfb(npa(iprj,l1),ll,ierr,etest, &
+            &                  rr,vfull,uu,up,zz,mmax,mch,srel)
+            if(ierr /= 0) then
+               write(6,'(/a,3i4)') 'run_plot: lschfb convergence ERROR n,l,ierr=', &
+               &         npa(iprj,l1),ll,ierr
+               stop
+            end if
 
-       emax=0.9d0*etest
-       emin=1.1d0*etest
-        
-       call lschvkbb(ll+iprj,ll,npr,ierr,etest,emin,emax, &
-&                    rr,vp(1,lloc+1),vkb(1,1,l1),evkb(1,l1), &
-&                    u2,up,mmax,mch)
-       sgnae=1.0d0
-       sgnps=1.0d0
-     else
-       write(6,'(//a,i2,a,i2,a,a/)') 'scattering, iprj=',iprj,',  l=',ll, &
-&           ', all-electron wave function', ', pseudo w-f'
-       call lschfs(nn,ll,ierr,epa(iprj,l1), &
-&                  rr,vfull,uu,up,zz,mmax,n2,srel)
-       call lschvkbs(ll,npr,epa(iprj,l1),rr,vp(1,lloc+1), &
-&                    vkb(1,1,l1),evkb(1,l1),u2,up,mmax,n2)
-       sgnae=sign(1.0d0,uu(n2))
-       sgnps=sign(1.0d0,u2(n2))
-     end if
+            emax=0.9d0*etest
+            emin=1.1d0*etest
 
-     dr=dmin1(drl,rr(n2)/200.0d0)
-     r0=rr(n1)-dr
-     do ii = n1, n2
-       if(rr(ii)>r0) then
-          write(6,'(a,i5,i1,3(f12.6,1x))') '&',iprj,ll,rr(ii),sgnae*uu(ii),&
-&          sgnps*u2(ii)
-          r0=rr(ii)+dr
-       end if
-     end do
-   end do !iproj
+            call lschvkbb(ll+iprj,ll,npr,ierr,etest,emin,emax, &
+            &                    rr,vp(1,lloc+1),vkb(1,1,l1),evkb(1,l1), &
+            &                    u2,up,mmax,mch)
+            sgnae=1.0d0
+            sgnps=1.0d0
+         else
+            write(6,'(//a,i2,a,i2,a,a/)') 'scattering, iprj=',iprj,',  l=',ll, &
+            &           ', all-electron wave function', ', pseudo w-f'
+            call lschfs(nn,ll,ierr,epa(iprj,l1), &
+            &                  rr,vfull,uu,up,zz,mmax,n2,srel)
+            call lschvkbs(ll,npr,epa(iprj,l1),rr,vp(1,lloc+1), &
+            &                    vkb(1,1,l1),evkb(1,l1),u2,up,mmax,n2)
+            sgnae=sign(1.0d0,uu(n2))
+            sgnps=sign(1.0d0,u2(n2))
+         end if
+
+         dr=dmin1(drl,rr(n2)/200.0d0)
+         r0=rr(n1)-dr
+         do ii = n1, n2
+            if(rr(ii)>r0) then
+               write(6,'(a,i5,i1,3(f12.6,1x))') '&',iprj,ll,rr(ii),sgnae*uu(ii),&
+               &          sgnps*u2(ii)
+               r0=rr(ii)+dr
+            end if
+         end do
+      end do  !iproj
 
 ! orthonormal projector plots
 
-   write(6,'(/)')
-   dr=dmin1(drl,rr(n3)/200.0d0)
-   r0=rr(n1)-dr
-   do ii=n1,n3
-     if(rr(ii)>r0) then
-       write(6,'(a,i6,6(f12.6,1x))') '!J',ll,rr(ii), &
-&       (vkb(ii,jj,l1),jj=1,nproj(l1))
-       r0=rr(ii)+dr
-     end if
-   end do
+      write(6,'(/)')
+      dr=dmin1(drl,rr(n3)/200.0d0)
+      r0=rr(n1)-dr
+      do ii=n1,n3
+         if(rr(ii)>r0) then
+            write(6,'(a,i6,6(f12.6,1x))') '!J',ll,rr(ii), &
+            &       (vkb(ii,jj,l1),jj=1,nproj(l1))
+            r0=rr(ii)+dr
+         end if
+      end do
 
- end do !l1
+   end do  !l1
 !
 ! convergence profile plots
 
- write(6,'(/a)') 'convergence profiles, (ll=0,lmax)'
- write(6,*) 'lmax',lmax
- do l1=1,lmax+1
-   ll=l1-1
-   do jj=1,7
-     if(cvgplt(1,jj,1,l1)/=0.d0) then
-       write(6,'(a,i6,3(f12.6,1x))') '!C',ll,cvgplt(1,jj,1,l1),cvgplt(2,jj,1,l1)
-     end if
+   write(6,'(/a)') 'convergence profiles, (ll=0,lmax)'
+   write(6,*) 'lmax',lmax
+   do l1=1,lmax+1
+      ll=l1-1
+      do jj=1,7
+         if(cvgplt(1,jj,1,l1)/=0.d0) then
+            write(6,'(a,i6,3(f12.6,1x))') '!C',ll,cvgplt(1,jj,1,l1),cvgplt(2,jj,1,l1)
+         end if
+      end do
    end do
- end do
 
- deallocate(uu,u2,up)
- return
- end subroutine run_plot
+   deallocate(uu,u2,up)
+   return
+end subroutine run_plot

--- a/src/run_plot_r.f90
+++ b/src/run_plot_r.f90
@@ -2,21 +2,21 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- subroutine run_plot_r(lmax,npa,epa,lloc,irc, &
+subroutine run_plot_r(lmax,npa,epa,lloc,irc, &
 &                    vkb,evkb,nproj,rr,vfull,vp,vpuns,zz,mmax,mxprj,drl,nrl, &
 &                    rho,rhoc,rhomod,cvgplt)
 
@@ -45,201 +45,201 @@
 !rhoc core charge
 !rhomod  model core charge
 !srel .true. for scalar-relativistic, .false. for non-relativistic
-!cvgplt  Energy per electron error vs. cutoff 
+!cvgplt  Energy per electron error vs. cutoff
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !Input variables
- integer :: lmax,lloc,mmax,mxprj,nlim,nrl
- integer :: npa(mxprj,6),npx(6),irc(6),lpx(6),nproj(6)
- real(dp) :: zz,drl
- real(dp) :: rr(mmax),vp(mmax,5,2),vpuns(mmax,5),vfull(mmax),vkb(mmax,mxprj,4,2)
- real(dp) :: rho(mmax),rhoc(mmax),rhomod(mmax,5)
- real(dp):: epa(mxprj,6,2),evkb(mxprj,4,2),cvgplt(2,7,mxprj,4,2)
- logical :: srel
+   integer :: lmax,lloc,mmax,mxprj,nlim,nrl
+   integer :: npa(mxprj,6),npx(6),irc(6),lpx(6),nproj(6)
+   real(dp) :: zz,drl
+   real(dp) :: rr(mmax),vp(mmax,5,2),vpuns(mmax,5),vfull(mmax),vkb(mmax,mxprj,4,2)
+   real(dp) :: rho(mmax),rhoc(mmax),rhomod(mmax,5)
+   real(dp):: epa(mxprj,6,2),evkb(mxprj,4,2),cvgplt(2,7,mxprj,4,2)
+   logical :: srel
 
 !Output variables - printing only
 
 !Local variables
- integer :: ll,l1,ii,jj,ierr,mch,mchf,n1,n2,n3,n4,nn,nnae
- integer :: iprj,nnp,npr
- integer :: ikap,kap,mkap
- real(dp) :: al,cnorm,emax,emin,etest,sls,rmx,sgnae,sgnps
- real(dp) :: r0,dr
- real(dp), allocatable :: u2(:),up(:),ur(:,:),urp(:,:)
+   integer :: ll,l1,ii,jj,ierr,mch,mchf,n1,n2,n3,n4,nn,nnae
+   integer :: iprj,nnp,npr
+   integer :: ikap,kap,mkap
+   real(dp) :: al,cnorm,emax,emin,etest,sls,rmx,sgnae,sgnps
+   real(dp) :: r0,dr
+   real(dp), allocatable :: u2(:),up(:),ur(:,:),urp(:,:)
 
- allocate(u2(mmax),up(mmax),ur(mmax,2),urp(mmax,2))
+   allocate(u2(mmax),up(mmax),ur(mmax,2),urp(mmax,2))
 
 
- al = 0.01d0 * dlog(rr(101)/rr(1))
+   al = 0.01d0 * dlog(rr(101)/rr(1))
 
- write(6,'(/a)') 'DATA FOR PLOTTING'
+   write(6,'(/a)') 'DATA FOR PLOTTING'
 
- n1 = idint(dlog(drl/rr(1))/al+1.0d0)
- n2 = idint(dlog(dfloat(nrl)*drl/rr(1))/al+1.0d0)
- n3=0
- do l1=1,lmax+1
-   n3=max(n3,irc(l1)-1)
- end do
+   n1 = idint(dlog(drl/rr(1))/al+1.0d0)
+   n2 = idint(dlog(dfloat(nrl)*drl/rr(1))/al+1.0d0)
+   n3=0
+   do l1=1,lmax+1
+      n3=max(n3,irc(l1)-1)
+   end do
 
- n4=min(n2,idint(dlog((rr(n3)+1.0d0)/rr(1))/al))
- n3=idint(dlog(1.1d0*rr(n3)/rr(1))/al+1.0d0)
+   n4=min(n2,idint(dlog((rr(n3)+1.0d0)/rr(1))/al))
+   n3=idint(dlog(1.1d0*rr(n3)/rr(1))/al+1.0d0)
 
- dr=dmin1(drl,rr(n4)/200)
- write(6,'(/2a/)') ' radii, charge,',' pseudopotentials (ll=0, 1, lmax)'
- r0=rr(n1)-dr
- do ii=n1,n4
-   write(6,'(a,6(f12.7,1x))') '!p',rr(ii),rho(ii),(vpuns(ii,l1),l1=1,lmax+1)
-   r0=rr(ii)+dr
- end do
-
- if(lloc .eq. 4) then
+   dr=dmin1(drl,rr(n4)/200)
+   write(6,'(/2a/)') ' radii, charge,',' pseudopotentials (ll=0, 1, lmax)'
    r0=rr(n1)-dr
    do ii=n1,n4
-     if(rr(ii)>r0) then
-       write(6,'(a, 2(f12.7,1x))') ' !L',rr(ii),vpuns(ii,lloc + 1)
-       r0=rr(ii)+dr
-     end if
+      write(6,'(a,6(f12.7,1x))') '!p',rr(ii),rho(ii),(vpuns(ii,l1),l1=1,lmax+1)
+      r0=rr(ii)+dr
    end do
- end if
+
+   if(lloc == 4) then
+      r0=rr(n1)-dr
+      do ii=n1,n4
+         if(rr(ii)>r0) then
+            write(6,'(a, 2(f12.7,1x))') ' !L',rr(ii),vpuns(ii,lloc + 1)
+            r0=rr(ii)+dr
+         end if
+      end do
+   end if
 
 ! output for analysis of core charge and models
- rmx=0
- do ii=n1,n2
-  rmx=max(rmx,5.0d0*rho(ii),rhomod(ii,1))
- end do
+   rmx=0
+   do ii=n1,n2
+      rmx=max(rmx,5.0d0*rho(ii),rhomod(ii,1))
+   end do
 
- write(6,'(//2a/)') ' radii, charge,',' core charge, model core charge'
- dr=dmin1(drl,rr(n2)/200.0d0)
- r0=rr(n1)-dr
- do ii=n1,n2
-   if(rr(ii)>r0) then
-      if(rhoc(ii)<rmx)then
-       write(6,'(a,8(f12.7,1x))') '!r',rr(ii),rho(ii),rhoc(ii), &
-&       rhomod(ii,1)
-      else if(rr(ii)>0.01d0) then
-        write(6,'(a,8(f12.7,1x))') '!r',rr(ii),rho(ii),rmx, &
-&       rhomod(ii,1)
+   write(6,'(//2a/)') ' radii, charge,',' core charge, model core charge'
+   dr=dmin1(drl,rr(n2)/200.0d0)
+   r0=rr(n1)-dr
+   do ii=n1,n2
+      if(rr(ii)>r0) then
+         if(rhoc(ii)<rmx)then
+            write(6,'(a,8(f12.7,1x))') '!r',rr(ii),rho(ii),rhoc(ii), &
+            &       rhomod(ii,1)
+         else if(rr(ii)>0.01d0) then
+            write(6,'(a,8(f12.7,1x))') '!r',rr(ii),rho(ii),rmx, &
+            &       rhomod(ii,1)
+         end if
+         r0=rr(ii)+dr
       end if
-     r0=rr(ii)+dr
-   end if
- end do
+   end do
 
 ! loop for wave function output
 
- do l1 = 1, lmax + 1
-  ll = l1 - 1
-  npr=nproj(l1)   
-  if(l1==lloc+1) npr=0
-   ll=l1-1
-   if(ll==0) then
-    mkap=1
-   else
-    mkap=2
-   end if
+   do l1 = 1, lmax + 1
+      ll = l1 - 1
+      npr=nproj(l1)
+      if(l1==lloc+1) npr=0
+      ll=l1-1
+      if(ll==0) then
+         mkap=1
+      else
+         mkap=2
+      end if
 ! loop on J = ll +/- 1/2
-  do ikap=1,mkap
-    if(ikap==1) then
-      kap=-(ll+1)
-    else
-      kap=  ll
-    end if
-
-   do iprj=1,nproj(l1)
-     if(epa(iprj,l1,ikap)<0.0d0) then
-        write(6,'(//a,i2,a,i2,a,i2,a,a/)') 'n=',npa(iprj,l1),',  l=',ll, &
-&             ', kap=',kap, ', all-electron wave function', ', pseudo w-f'
-
-       etest=epa(iprj,l1,ikap)
-       call ldiracfb(npa(iprj,l1),ll,kap,ierr,etest, &
-&                    rr,zz,vfull,ur,urp,mmax,mch)
-         if(ierr .ne. 0) then
-           write(6,'(a,i2,a,i2,a,i2,a,i4)') &
-&                'run_plot_r 409: ldiracfb convergence ERROR, n=',&
-&                 npa(iprj,l1),'  l=',ll, 'kap-',kap,'  ierr=',ierr
-           stop
-         end if
-       call renorm_r(ur,rr,ll,kap,zz,mmax,cnorm)
-
-       emax=0.9d0*etest
-       emin=1.1d0*etest
-        
-       call lschvkbb(ll+iprj,ll,npr,ierr,etest,emin,emax, &
-&                    rr,vp(1,lloc+1,ikap),vkb(1,1,l1,ikap),evkb(1,l1,ikap), &
-&                    u2,up,mmax,mch)
-       sgnae=1.0d0
-       sgnps=1.0d0
-     else
-       write(6,'(//a,i2,a,i2,a,i2,a,a/)') 'scattering, iprj=',iprj,',  l=',ll, &
-&           ', kap=',kap,', all-electron wave function', ', pseudo w-f'
-       call ldiracfs(nnae,ll,kap,ierr,epa(iprj,l1,ikap), &
-&                    rr,zz,vfull,ur,urp,mmax,n2)
-       call renorm_r(ur,rr,ll,kap,zz,mmax,cnorm)
-
-       call lschvkbs(ll,npr,epa(iprj,l1,ikap),rr,vp(1,lloc+1,ikap), &
-&                    vkb(1,1,l1,ikap),evkb(1,l1,ikap),u2,up,mmax,n2)
-       sgnae=sign(1.0d0,ur(n2,1))
-       sgnps=sign(1.0d0,u2(n2))
-     end if
-
-     dr=dmin1(drl,rr(n2)/200)
-     r0=rr(n1)+dr
-     do ii = n1, n2
-       if(rr(ii)>r0) then
+      do ikap=1,mkap
          if(ikap==1) then
-            write(6,'(a,i5,i1,3(f12.6,1x))') '&',-iprj,ll,rr(ii), &
-&                 sgnae*ur(ii,1),sgnps*u2(ii)
+            kap=-(ll+1)
          else
-            write(6,'(a,i5,i1,3(f12.6,1x))') '&',iprj,ll,rr(ii), &
-&                 sgnae*ur(ii,1),sgnps*u2(ii)
+            kap=  ll
          end if
-         r0=rr(ii)+dr
-       end if
-     end do
-   end do !iproj
+
+         do iprj=1,nproj(l1)
+            if(epa(iprj,l1,ikap)<0.0d0) then
+               write(6,'(//a,i2,a,i2,a,i2,a,a/)') 'n=',npa(iprj,l1),',  l=',ll, &
+               &             ', kap=',kap, ', all-electron wave function', ', pseudo w-f'
+
+               etest=epa(iprj,l1,ikap)
+               call ldiracfb(npa(iprj,l1),ll,kap,ierr,etest, &
+               &                    rr,zz,vfull,ur,urp,mmax,mch)
+               if(ierr /= 0) then
+                  write(6,'(a,i2,a,i2,a,i2,a,i4)') &
+                  &                'run_plot_r 409: ldiracfb convergence ERROR, n=',&
+                  &                 npa(iprj,l1),'  l=',ll, 'kap-',kap,'  ierr=',ierr
+                  stop
+               end if
+               call renorm_r(ur,rr,ll,kap,zz,mmax,cnorm)
+
+               emax=0.9d0*etest
+               emin=1.1d0*etest
+
+               call lschvkbb(ll+iprj,ll,npr,ierr,etest,emin,emax, &
+               &                    rr,vp(1,lloc+1,ikap),vkb(1,1,l1,ikap),evkb(1,l1,ikap), &
+               &                    u2,up,mmax,mch)
+               sgnae=1.0d0
+               sgnps=1.0d0
+            else
+               write(6,'(//a,i2,a,i2,a,i2,a,a/)') 'scattering, iprj=',iprj,',  l=',ll, &
+               &           ', kap=',kap,', all-electron wave function', ', pseudo w-f'
+               call ldiracfs(nnae,ll,kap,ierr,epa(iprj,l1,ikap), &
+               &                    rr,zz,vfull,ur,urp,mmax,n2)
+               call renorm_r(ur,rr,ll,kap,zz,mmax,cnorm)
+
+               call lschvkbs(ll,npr,epa(iprj,l1,ikap),rr,vp(1,lloc+1,ikap), &
+               &                    vkb(1,1,l1,ikap),evkb(1,l1,ikap),u2,up,mmax,n2)
+               sgnae=sign(1.0d0,ur(n2,1))
+               sgnps=sign(1.0d0,u2(n2))
+            end if
+
+            dr=dmin1(drl,rr(n2)/200)
+            r0=rr(n1)+dr
+            do ii = n1, n2
+               if(rr(ii)>r0) then
+                  if(ikap==1) then
+                     write(6,'(a,i5,i1,3(f12.6,1x))') '&',-iprj,ll,rr(ii), &
+                     &                 sgnae*ur(ii,1),sgnps*u2(ii)
+                  else
+                     write(6,'(a,i5,i1,3(f12.6,1x))') '&',iprj,ll,rr(ii), &
+                     &                 sgnae*ur(ii,1),sgnps*u2(ii)
+                  end if
+                  r0=rr(ii)+dr
+               end if
+            end do
+         end do  !iproj
 
 ! orthonormal projector plots
 
-   write(6,'(/)')
-   dr=dmin1(drl,rr(n3)/200)
-   r0=rr(n1)-dr
-   do ii=n1,n3
-     if(rr(ii)>r0) then
-       if(ikap==1) then
-         write(6,'(a,i6,6(f12.6,1x))') '!J',-ll,rr(ii), &
-&              (vkb(ii,jj,l1,ikap),jj=1,nproj(l1))
-       else
-         write(6,'(a,i6,6(f12.6,1x))') '!J',ll,rr(ii), &
-&              (vkb(ii,jj,l1,ikap),jj=1,nproj(l1))
-       end if
-       r0=rr(ii)+dr
-     end if
-    end do
-  end do !ikap
- end do !l1
+         write(6,'(/)')
+         dr=dmin1(drl,rr(n3)/200)
+         r0=rr(n1)-dr
+         do ii=n1,n3
+            if(rr(ii)>r0) then
+               if(ikap==1) then
+                  write(6,'(a,i6,6(f12.6,1x))') '!J',-ll,rr(ii), &
+                  &              (vkb(ii,jj,l1,ikap),jj=1,nproj(l1))
+               else
+                  write(6,'(a,i6,6(f12.6,1x))') '!J',ll,rr(ii), &
+                  &              (vkb(ii,jj,l1,ikap),jj=1,nproj(l1))
+               end if
+               r0=rr(ii)+dr
+            end if
+         end do
+      end do  !ikap
+   end do  !l1
 !
 ! convergence profile plots
 
- write(6,'(/a)') 'convergence profiles, (ll=0,lmax), kappa average'
- l1=1
- ll=l1-1
- do jj=1,7
-   if(cvgplt(1,jj,1,l1,1)/=0.d0) then
-     write(6,'(a,i6,3f12.6)') '!C',ll,cvgplt(1,jj,1,l1,1),cvgplt(2,jj,1,l1,1)
-   end if
- end do
- do l1=2,lmax+1
+   write(6,'(/a)') 'convergence profiles, (ll=0,lmax), kappa average'
+   l1=1
    ll=l1-1
    do jj=1,7
-     if(cvgplt(1,jj,1,l1,1)/=0.d0 .and. cvgplt(1,jj,1,l1,2)/=0.0d0) then
-       write(6,'(a,i6,3f12.6)') '!C',ll,cvgplt(1,jj,1,l1,1), &
-&       0.5d0*(cvgplt(2,jj,1,l1,1)+cvgplt(2,jj,1,l1,2))
-     end if
+      if(cvgplt(1,jj,1,l1,1)/=0.d0) then
+         write(6,'(a,i6,3f12.6)') '!C',ll,cvgplt(1,jj,1,l1,1),cvgplt(2,jj,1,l1,1)
+      end if
    end do
- end do
+   do l1=2,lmax+1
+      ll=l1-1
+      do jj=1,7
+         if(cvgplt(1,jj,1,l1,1)/=0.d0 .and. cvgplt(1,jj,1,l1,2)/=0.0d0) then
+            write(6,'(a,i6,3f12.6)') '!C',ll,cvgplt(1,jj,1,l1,1), &
+            &       0.5d0*(cvgplt(2,jj,1,l1,1)+cvgplt(2,jj,1,l1,2))
+         end if
+      end do
+   end do
 
- deallocate(u2,up,ur,urp)
- return
+   deallocate(u2,up,ur,urp)
+   return
 
- end subroutine run_plot_r
+end subroutine run_plot_r

--- a/src/run_vkb.f90
+++ b/src/run_vkb.f90
@@ -2,21 +2,21 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- subroutine run_vkb(lmax,lloc,lpopt,dvloc0,irc,nproj,rr,mmax,mxprj,pswf, &
+subroutine run_vkb(lmax,lloc,lpopt,dvloc0,irc,nproj,rr,mmax,mxprj,pswf, &
 &                   vfull,vp,evkb,vkb,nlim,vr)
 
 ! computes Vanderbilt / Kleinman-Bylander non-local potentials
@@ -32,284 +32,284 @@
 !mxprj  dimension of number of projectors
 !pswf pseudo wave functions
 !vfull  all-electron potential
-!vp  semi-local pseudopotentials for first projectors 
+!vp  semi-local pseudopotentials for first projectors
 !     (vp(:,5) is local potential if lloc=4)
 !vkb  semi-local "potentials"*pswf (input); VKB projectors (output)
 !evkb  coefficients of BKB projectors (output)
 !nlim  index of maximum rc including that of vlocal (output)
 !vr  effective scalar-relativisic "potential" calculated in vrel
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !Input variables
- integer :: lmax,lloc,lpopt,lwork,mmax,mxprj
- integer :: irc(6),nproj(6)
- real(dp) :: rr(mmax),pswf(mmax,mxprj,5),vfull(mmax),vp(mmax,5)
- real(dp) :: dvloc0
+   integer :: lmax,lloc,lpopt,lwork,mmax,mxprj
+   integer :: irc(6),nproj(6)
+   real(dp) :: rr(mmax),pswf(mmax,mxprj,5),vfull(mmax),vp(mmax,5)
+   real(dp) :: dvloc0
 
 !Input/Output variables
- real(dp) :: vkb(mmax,mxprj,4),evkb(mxprj,4)
- real(dp) :: vr(mmax,mxprj,6)
- integer :: nlim
+   real(dp) :: vkb(mmax,mxprj,4),evkb(mxprj,4)
+   real(dp) :: vr(mmax,mxprj,6)
+   integer :: nlim
 
 !Local variables
- integer :: ii,ipk,jj,kk,ierr,l1,info,np
- real(dp) :: apk,sn,tt,qq12
- real(dp) :: xx,ff
- real(dp) :: bb(mxprj,mxprj),bbev(mxprj),bbi(mxprj,mxprj)
- real(dp) :: sovl(mxprj,mxprj),sovlev(mxprj),smhalf(mxprj,mxprj)
- real(dp) :: sphalf(mxprj,mxprj)
- real(dp) :: bbist(mxprj,mxprj),bbistev(mxprj),bbit(mxprj,mxprj)
- real(dp), allocatable :: vloc(:),vkbt(:,:),vkbst(:,:),work(:)
- logical :: sorted
+   integer :: ii,ipk,jj,kk,ierr,l1,info,np
+   real(dp) :: apk,sn,tt,qq12
+   real(dp) :: xx,ff
+   real(dp) :: bb(mxprj,mxprj),bbev(mxprj),bbi(mxprj,mxprj)
+   real(dp) :: sovl(mxprj,mxprj),sovlev(mxprj),smhalf(mxprj,mxprj)
+   real(dp) :: sphalf(mxprj,mxprj)
+   real(dp) :: bbist(mxprj,mxprj),bbistev(mxprj),bbit(mxprj,mxprj)
+   real(dp), allocatable :: vloc(:),vkbt(:,:),vkbst(:,:),work(:)
+   logical :: sorted
 
- evkb(:,:)=0.0d0
+   evkb(:,:)=0.0d0
 
- lwork=3*mxprj
- allocate(vloc(mmax),vkbt(mmax,mxprj),vkbst(mmax,mxprj),work(lwork))
+   lwork=3*mxprj
+   allocate(vloc(mmax),vkbt(mmax,mxprj),vkbst(mmax,mxprj),work(lwork))
 
 
 ! calculate local potential
 
- if(lloc==4) then
-   call vploc(rr,vfull,vp,dvloc0,irc(5),mmax,lpopt)
- end if
+   if(lloc==4) then
+      call vploc(rr,vfull,vp,dvloc0,irc(5),mmax,lpopt)
+   end if
 
- vloc(:)=vp(:,lloc+1)
+   vloc(:)=vp(:,lloc+1)
 
 ! Vanderbilt / Kleinman-Bylander projector construction
- nlim=irc(lloc+1)
- do l1=1,lmax+1
-   nlim=max(nlim,irc(l1))
-   if(l1==lloc+1) cycle
-   do jj=1,nproj(l1)
+   nlim=irc(lloc+1)
+   do l1=1,lmax+1
+      nlim=max(nlim,irc(l1))
+      if(l1==lloc+1) cycle
+      do jj=1,nproj(l1)
 !incorporates scalar-relativistic "potential" in last 5% of [0:rc] to smoothly
 !force projectors to zero
-     do ii=1,irc(l1)
-       xx=20.0d0*((rr(ii)/rr(irc(l1)))-1.0d0)
-       if(xx>-1.0d0) then
-         ff=(1.0d0-xx**2)**2
-       else
-         ff=0.0d0
-       end if
-       vkb(ii,jj,l1)=vkb(ii,jj,l1)-(vloc(ii)+ff*vr(ii,jj,l1))*pswf(ii,jj,l1)
-     end do
-     do ii=irc(l1)+1,mmax
-       vkb(ii,jj,l1)=0.0d0
-     end do
+         do ii=1,irc(l1)
+            xx=20.0d0*((rr(ii)/rr(irc(l1)))-1.0d0)
+            if(xx>-1.0d0) then
+               ff=(1.0d0-xx**2)**2
+            else
+               ff=0.0d0
+            end if
+            vkb(ii,jj,l1)=vkb(ii,jj,l1)-(vloc(ii)+ff*vr(ii,jj,l1))*pswf(ii,jj,l1)
+         end do
+         do ii=irc(l1)+1,mmax
+            vkb(ii,jj,l1)=0.0d0
+         end do
+      end do
    end do
- end do
 
 ! Vanderbilt B-matrix construction
 
- do l1=1,lmax+1
-   if(l1==lloc+1) cycle
-   np=nproj(l1)
-   bb(:,:)=0.0d0
-   call vpinteg(pswf(1,1,l1),vkb(1,1,l1),irc(l1),2*l1,bb(1,1),rr)
-   evkb(1,l1)=1.0d0/bb(1,1)
+   do l1=1,lmax+1
+      if(l1==lloc+1) cycle
+      np=nproj(l1)
+      bb(:,:)=0.0d0
+      call vpinteg(pswf(1,1,l1),vkb(1,1,l1),irc(l1),2*l1,bb(1,1),rr)
+      evkb(1,l1)=1.0d0/bb(1,1)
 ! this is Kleinman-Bylander result if nproj==1
 
-   if(nproj(l1)>=2) then
+      if(nproj(l1)>=2) then
 
-   do jj=1,np
-     do ii=1,np
-       call vpinteg(pswf(1,ii,l1),vkb(1,jj,l1),irc(l1),2*l1,bb(ii,jj),rr)
-     end do
-   end do
+         do jj=1,np
+            do ii=1,np
+               call vpinteg(pswf(1,ii,l1),vkb(1,jj,l1),irc(l1),2*l1,bb(ii,jj),rr)
+            end do
+         end do
 
 ! symmetrize exactly
-   write(6,'(/a,i4)') 'B matrix Hermiticity error, ll=',l1-1
-   do jj=2,np
-     do ii=1,jj-1
-       write(6,'(2i4,1p,e14.4)') ii,jj,bb(ii,jj)-bb(jj,ii)
-       tt=0.5d0*(bb(ii,jj)+bb(jj,ii))
-       bb(ii,jj)=tt
-       bb(jj,ii)=tt
-     end do
-   end do
+         write(6,'(/a,i4)') 'B matrix Hermiticity error, ll=',l1-1
+         do jj=2,np
+            do ii=1,jj-1
+               write(6,'(2i4,1p,e14.4)') ii,jj,bb(ii,jj)-bb(jj,ii)
+               tt=0.5d0*(bb(ii,jj)+bb(jj,ii))
+               bb(ii,jj)=tt
+               bb(jj,ii)=tt
+            end do
+         end do
 
 ! find eigenvalues and eigenvectors of the B matrix
 
 !      SUBROUTINE DSYEV( JOBZ, UPLO, N, A, LDA, W, WORK, LWORK, INFO )
 
-     call dsyev( 'V', 'U', np, bb, mxprj, bbev, work, lwork, info )
-     if(info .ne. 0) then
-      write(6,'(a,i4)') 'run_vkb: B matrix eigenvalue ERROR, info=',info
-      stop
-     end if
+         call dsyev( 'V', 'U', np, bb, mxprj, bbev, work, lwork, info )
+         if(info /= 0) then
+            write(6,'(a,i4)') 'run_vkb: B matrix eigenvalue ERROR, info=',info
+            stop
+         end if
 
 ! take linear combinations to form diagonal projectors
 
-   do jj=1,np
-   vkbt(:,jj)=vkb(:,jj,l1)
-   end do
+         do jj=1,np
+            vkbt(:,jj)=vkb(:,jj,l1)
+         end do
 
-   do jj=1,np
-     vkb(:,jj,l1)=0.0d0
-     evkb(jj,l1)=1.0d0/bbev(jj)
-     do ii=1,np
-       vkb(:,jj,l1)=vkb(:,jj,l1)+bb(ii,jj)*vkbt(:,ii)
-     end do
-   end do
-   
-   end if !nproj>=2
+         do jj=1,np
+            vkb(:,jj,l1)=0.0d0
+            evkb(jj,l1)=1.0d0/bbev(jj)
+            do ii=1,np
+               vkb(:,jj,l1)=vkb(:,jj,l1)+bb(ii,jj)*vkbt(:,ii)
+            end do
+         end do
+
+      end if  !nproj>=2
 
 ! normalize projectors
-   do jj=1,np
-     call vpinteg(vkb(1,jj,l1),vkb(1,jj,l1),irc(l1),2*l1,sn,rr)
-     if(vkb(irc(l1)-10,jj,l1)>=0.0d0) then
-       vkb(:,jj,l1)=vkb(:,jj,l1)/sqrt(sn)
-     else
-       vkb(:,jj,l1)=-vkb(:,jj,l1)/sqrt(sn)
-     end if
-     evkb(jj,l1)=sn*evkb(jj,l1)
-   end do
+      do jj=1,np
+         call vpinteg(vkb(1,jj,l1),vkb(1,jj,l1),irc(l1),2*l1,sn,rr)
+         if(vkb(irc(l1)-10,jj,l1)>=0.0d0) then
+            vkb(:,jj,l1)=vkb(:,jj,l1)/sqrt(sn)
+         else
+            vkb(:,jj,l1)=-vkb(:,jj,l1)/sqrt(sn)
+         end if
+         evkb(jj,l1)=sn*evkb(jj,l1)
+      end do
 
 
 ! calculate overlap
-   if(nproj(l1)>=2) then
+      if(nproj(l1)>=2) then
 
 
-    bbi(:,:)=0.0d0
-    do jj=1,np
-      sovl(jj,jj)=1.0d0
-      bbi(jj,jj)=evkb(jj,l1)
-      do ii=jj+1,np
-        call vpinteg(vkb(1,ii,l1),vkb(1,jj,l1),irc(l1),2*l1,sn,rr)
-        sovl(ii,jj)=sn
-        sovl(jj,ii)=sn
-      end do
-    end do
-    call vpinteg(vkb(1,1,l1),vkb(1,2,l1),irc(l1),2*l1,sn,rr)
+         bbi(:,:)=0.0d0
+         do jj=1,np
+            sovl(jj,jj)=1.0d0
+            bbi(jj,jj)=evkb(jj,l1)
+            do ii=jj+1,np
+               call vpinteg(vkb(1,ii,l1),vkb(1,jj,l1),irc(l1),2*l1,sn,rr)
+               sovl(ii,jj)=sn
+               sovl(jj,ii)=sn
+            end do
+         end do
+         call vpinteg(vkb(1,1,l1),vkb(1,2,l1),irc(l1),2*l1,sn,rr)
 
 ! find eigenvalues and eigenvectors of the overlap matrix
 
 !      SUBROUTINE DSYEV( JOBZ, UPLO, N, A, LDA, W, WORK, LWORK, INFO )
 
-    call dsyev( 'V', 'U', np, sovl, mxprj, sovlev, work, lwork, info )
-    if(info .ne. 0) then
-     write(6,'(a,i4)') 'run_vkb: sovl matrix ERROR error, info=',info
-     stop
-    end if
+         call dsyev( 'V', 'U', np, sovl, mxprj, sovlev, work, lwork, info )
+         if(info /= 0) then
+            write(6,'(a,i4)') 'run_vkb: sovl matrix ERROR error, info=',info
+            stop
+         end if
 
 !   write(6,'(/1p,2e12.4)') (sovlev(ii),ii=1,2)
 
 ! construct S^(-1/2) AND s^(1/2)
 
-     do jj=1,np
-      tt=sqrt(sovlev(jj))
-      do ii=1,np
-       sphalf(ii,jj)=tt*sovl(ii,jj)
-       smhalf(ii,jj)=sovl(ii,jj)/tt
-      end do
-     end do
+         do jj=1,np
+            tt=sqrt(sovlev(jj))
+            do ii=1,np
+               sphalf(ii,jj)=tt*sovl(ii,jj)
+               smhalf(ii,jj)=sovl(ii,jj)/tt
+            end do
+         end do
 
 ! construct B^(-1)* = S^(1/2)^T B^(-1) S^(1/2)
 
-     bbit(:,:)=0.0d0
-     bbist(:,:)=0.0d0
+         bbit(:,:)=0.0d0
+         bbist(:,:)=0.0d0
 
-     do ii=1,np
-      do jj=1,np
-       do kk=1,np
-        bbit(ii,jj)=bbit(ii,jj)+bbi(ii,kk)*sphalf(kk,jj)
-       end do
-      end do
-     end do
+         do ii=1,np
+            do jj=1,np
+               do kk=1,np
+                  bbit(ii,jj)=bbit(ii,jj)+bbi(ii,kk)*sphalf(kk,jj)
+               end do
+            end do
+         end do
 
-     do ii=1,np
-      do jj=1,np
-       do kk=1,np
-        bbist(ii,jj)=bbist(ii,jj)+bbit(kk,jj)*sphalf(kk,ii)
-       end do
-      end do
-     end do
+         do ii=1,np
+            do jj=1,np
+               do kk=1,np
+                  bbist(ii,jj)=bbist(ii,jj)+bbit(kk,jj)*sphalf(kk,ii)
+               end do
+            end do
+         end do
 
 !      SUBROUTINE DSYEV( JOBZ, UPLO, N, A, LDA, W, WORK, LWORK, INFO )
 
-     call dsyev( 'V', 'U', np , bbist, mxprj, bbistev, work, lwork, info )
-     if(info .ne. 0) then
-      write(6,'(a,i4)') 'run_vkb: B^(-1)* matrix eigenvalue ERROR, info=',info
-      stop
-     end if
+         call dsyev( 'V', 'U', np , bbist, mxprj, bbistev, work, lwork, info )
+         if(info /= 0) then
+            write(6,'(a,i4)') 'run_vkb: B^(-1)* matrix eigenvalue ERROR, info=',info
+            stop
+         end if
 
 
 ! take linear combinations to form orthonormal basis functions
 
-     vkbt(:,:)=vkb(:,:,l1)
-     vkbst(:,:)=0.0d0
+         vkbt(:,:)=vkb(:,:,l1)
+         vkbst(:,:)=0.0d0
 
-     do jj=1,np
-      do ii=1,np
-       vkbst(:,jj)=vkbst(:,jj) + smhalf(ii,jj)*vkbt(:,ii)
-      end do
-     end do
+         do jj=1,np
+            do ii=1,np
+               vkbst(:,jj)=vkbst(:,jj) + smhalf(ii,jj)*vkbt(:,ii)
+            end do
+         end do
 
 
 ! take linear combinations to form orthonormal projectors
 
-     vkb(:,:,L1)=0.0d0
+         vkb(:,:,L1)=0.0d0
 
-     do ii=1,np
-      evkb(ii,l1)=bbistev(ii)
-      do jj=1,np
-       vkb(:,ii,l1)=vkb(:,ii,l1) + bbist(jj,ii)*vkbst(:,jj)
-      end do
-     end do
+         do ii=1,np
+            evkb(ii,l1)=bbistev(ii)
+            do jj=1,np
+               vkb(:,ii,l1)=vkb(:,ii,l1) + bbist(jj,ii)*vkbst(:,jj)
+            end do
+         end do
 
 ! re-order if necessary so first projector has largest magnitude coefficient
 ! which is consistent with relativistic sr_so_r.f90 output
 
-     do ii=1,100
-       sorted=.true.
-       do jj=2,np
+         do ii=1,100
+            sorted=.true.
+            do jj=2,np
 
-         if(abs(evkb(jj,l1))>abs(evkb(jj-1,l1))) then
-           tt=evkb(jj-1,l1)
-           vkbt(:,1)=vkb(:,jj-1,l1)
-           evkb(jj-1,l1)=evkb(jj,l1)
-           vkb(:,jj-1,l1)=vkb(:,jj,l1)
-           evkb(jj,l1)=tt
-           vkb(:,jj,l1)=vkbt(:,1)
-           sorted=.false.
-         end if
-       end do
-       if(sorted) exit
-     end do
-  
-     write(6,'(/a,1p,5e12.4)') '  Orthonormal projector coefficients',&
-&        (evkb(jj,l1),jj=1,np)
+               if(abs(evkb(jj,l1))>abs(evkb(jj-1,l1))) then
+                  tt=evkb(jj-1,l1)
+                  vkbt(:,1)=vkb(:,jj-1,l1)
+                  evkb(jj-1,l1)=evkb(jj,l1)
+                  vkb(:,jj-1,l1)=vkb(:,jj,l1)
+                  evkb(jj,l1)=tt
+                  vkb(:,jj,l1)=vkbt(:,1)
+                  sorted=.false.
+               end if
+            end do
+            if(sorted) exit
+         end do
+
+         write(6,'(/a,1p,5e12.4)') '  Orthonormal projector coefficients',&
+         &        (evkb(jj,l1),jj=1,np)
 
 ! Set sign of projectors (physically irrelevant) so that they are positive
 ! at their peak (needed for compaisons apparently)
 
-     do jj=1,np
-       apk=0.0d0
-       do ii=1,mmax
-         if(abs(vkb(ii,jj,l1))>apk) then
-           apk=abs(vkb(ii,jj,l1))
-           ipk=ii
-         end if
-       end do
-       if(vkb(ipk,jj,l1)<0.0d0) then
-         vkb(:,jj,l1)=-vkb(:,jj,l1)
-       end if
-     end do
+         do jj=1,np
+            apk=0.0d0
+            do ii=1,mmax
+               if(abs(vkb(ii,jj,l1))>apk) then
+                  apk=abs(vkb(ii,jj,l1))
+                  ipk=ii
+               end if
+            end do
+            if(vkb(ipk,jj,l1)<0.0d0) then
+               vkb(:,jj,l1)=-vkb(:,jj,l1)
+            end if
+         end do
 
-   end if !nproj(l1)>=2
+      end if  !nproj(l1)>=2
 
-   if(nproj(l1)<mxprj) then
-     do jj=nproj(l1)+1, mxprj
-       evkb(jj,l1)=0.0d0
-       vkb(:,jj,l1)=0.0d0
-     end do
-   end if
+      if(nproj(l1)<mxprj) then
+         do jj=nproj(l1)+1, mxprj
+            evkb(jj,l1)=0.0d0
+            vkb(:,jj,l1)=0.0d0
+         end do
+      end if
 
- end do  ! l1
+   end do  ! l1
 
- deallocate(vloc,vkbt,vkbst,work)
+   deallocate(vloc,vkbt,vkbst,work)
 
- return
- end subroutine run_vkb
+   return
+end subroutine run_vkb

--- a/src/run_vkb_r.f90
+++ b/src/run_vkb_r.f90
@@ -2,21 +2,21 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- subroutine run_vkb_r(lmax,lloc,lpopt,dvloc0,irc,nproj,rr,mmax,mxprj,pswf,vfull,vp, &
+subroutine run_vkb_r(lmax,lloc,lpopt,dvloc0,irc,nproj,rr,mmax,mxprj,pswf,vfull,vp, &
 &                   evkb,vkb,nlim,vr)
 
 ! computes Vanderbilt / Kleinman-Bylander non-local potentials
@@ -32,318 +32,318 @@
 !mxprj  dimension of number of projectors
 !pswf pseudo wave functions
 !vfull  all-electron potential
-!vp  semi-local pseudopotentials for first projectors 
+!vp  semi-local pseudopotentials for first projectors
 !     (vp(:,5) is local potential if lloc=4)
 !vkb  semi-local "potentials"*pswf (input); VKB projectors (output)
 !evkb  coefficients of BKB projectors (output)
 !nlim  index of maximum rc including that of vlocal (output)
 !vr  effective scalar-relativisic "potential" calculated in vrel
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !Input variables
- integer :: lmax,lloc,lpopt,lwork,mmax,mxprj
- integer :: irc(6),nproj(6)
- real(dp) :: rr(mmax),pswf(mmax,mxprj,4,2),vfull(mmax),vp(mmax,5,2)
-real(dp) :: vr(mmax,mxprj,6,2)
- real(dp) :: dvloc0
+   integer :: lmax,lloc,lpopt,lwork,mmax,mxprj
+   integer :: irc(6),nproj(6)
+   real(dp) :: rr(mmax),pswf(mmax,mxprj,4,2),vfull(mmax),vp(mmax,5,2)
+   real(dp) :: vr(mmax,mxprj,6,2)
+   real(dp) :: dvloc0
 
 !Input/Output variables
- real(dp) :: vkb(mmax,mxprj,4,2),evkb(mxprj,4,2)
- integer :: nlim
+   real(dp) :: vkb(mmax,mxprj,4,2),evkb(mxprj,4,2)
+   integer :: nlim
 
 !Local variables
- integer :: ii,ipk,jj,kk,ikap,ll,l1,info,np,kap,mkap
- real(dp) :: apk,sn,tt,qq12,xx,ff
- real(dp) :: bb(mxprj,mxprj),bbev(mxprj),bbi(mxprj,mxprj)
- real(dp) :: sovl(mxprj,mxprj),sovlev(mxprj),smhalf(mxprj,mxprj)
- real(dp) :: sphalf(mxprj,mxprj)
- real(dp) :: bbist(mxprj,mxprj),bbistev(mxprj),bbit(mxprj,mxprj)
- real(dp), allocatable :: vloc(:),vkbt(:,:),vkbst(:,:),work(:)
- logical :: sorted
+   integer :: ii,ipk,jj,kk,ikap,ll,l1,info,np,kap,mkap
+   real(dp) :: apk,sn,tt,qq12,xx,ff
+   real(dp) :: bb(mxprj,mxprj),bbev(mxprj),bbi(mxprj,mxprj)
+   real(dp) :: sovl(mxprj,mxprj),sovlev(mxprj),smhalf(mxprj,mxprj)
+   real(dp) :: sphalf(mxprj,mxprj)
+   real(dp) :: bbist(mxprj,mxprj),bbistev(mxprj),bbit(mxprj,mxprj)
+   real(dp), allocatable :: vloc(:),vkbt(:,:),vkbst(:,:),work(:)
+   logical :: sorted
 
- lwork=3*mxprj
- allocate(vloc(mmax),vkbt(mmax,mxprj),vkbst(mmax,mxprj),work(lwork))
+   lwork=3*mxprj
+   allocate(vloc(mmax),vkbt(mmax,mxprj),vkbst(mmax,mxprj),work(lwork))
 
 
 ! calculate local potential
 ! use "scalar-relativistic" weighted average if real ll/=0 is specified
 ! reset semi-local potential to this average (ie., there is no SO for this l)
 
- l1=0
- if(lloc==4) then
-   call vploc(rr,vfull,vp(1,1,1),dvloc0,irc(5),mmax,lpopt)
-   vloc(:)=vp(:,5,1)
-   vp(:,5,2)=vp(:,5,1)
- else if (l1==1) then
-   vloc(:)=vp(:,1,1)
- else
-   l1=lloc+1
-   vloc(:)=(dble(l1)*vp(:,l1,1) + dble(l1-1)*vp(:,l1,2))/dble(2*l1-1)
-   vp(:,l1,1)=vloc(:)
-   vp(:,l1,2)=vloc(:)
- end if
+   l1=0
+   if(lloc==4) then
+      call vploc(rr,vfull,vp(1,1,1),dvloc0,irc(5),mmax,lpopt)
+      vloc(:)=vp(:,5,1)
+      vp(:,5,2)=vp(:,5,1)
+   else if (l1==1) then
+      vloc(:)=vp(:,1,1)
+   else
+      l1=lloc+1
+      vloc(:)=(dble(l1)*vp(:,l1,1) + dble(l1-1)*vp(:,l1,2))/dble(2*l1-1)
+      vp(:,l1,1)=vloc(:)
+      vp(:,l1,2)=vloc(:)
+   end if
 
 
 ! Vanderbilt / Kleinman-Bylander projector construction
- nlim=irc(lloc+1)
- do l1=1,lmax+1
-  if(l1==lloc+1) cycle
-  ll=l1-1
-  if(l1==1) then
-   mkap=1
-  else
-   mkap=2
-  end if
+   nlim=irc(lloc+1)
+   do l1=1,lmax+1
+      if(l1==lloc+1) cycle
+      ll=l1-1
+      if(l1==1) then
+         mkap=1
+      else
+         mkap=2
+      end if
 ! loop on J = ll +/- 1/2
-  do ikap=1,mkap
-   if(ikap==1) kap=-(ll+1)
-   if(ikap==2) kap=  ll
+      do ikap=1,mkap
+         if(ikap==1) kap=-(ll+1)
+         if(ikap==2) kap=  ll
 
-   nlim=max(nlim,irc(l1))
-   do jj=1,nproj(l1)
+         nlim=max(nlim,irc(l1))
+         do jj=1,nproj(l1)
 !incorporates scalar-relativistic "potential" in last 5% of [0:rc] to smoothly
 !force projectors to zero.
-     do ii=1,irc(l1)
-       xx=20.0d0*((rr(ii)/rr(irc(l1)))-1.0d0)
-       if(xx>-1.0d0) then
-         ff=(1.0d0-xx**2)**2
+            do ii=1,irc(l1)
+               xx=20.0d0*((rr(ii)/rr(irc(l1)))-1.0d0)
+               if(xx>-1.0d0) then
+                  ff=(1.0d0-xx**2)**2
 !        ff=0.0d0
-       else
-         ff=0.0d0
-       end if
+               else
+                  ff=0.0d0
+               end if
 
-       vkb(ii,jj,l1,ikap)=vkb(ii,jj,l1,ikap) &
-&                         -(vloc(ii)+ff*vr(ii,jj,l1,ikap))*pswf(ii,jj,l1,ikap)
-     end do
-     do ii=irc(l1)+1,mmax
-       vkb(ii,jj,l1,ikap)=0.0d0
-     end do
-   end do
-  end do !ikap
- end do !l1
+               vkb(ii,jj,l1,ikap)=vkb(ii,jj,l1,ikap) &
+               &                         -(vloc(ii)+ff*vr(ii,jj,l1,ikap))*pswf(ii,jj,l1,ikap)
+            end do
+            do ii=irc(l1)+1,mmax
+               vkb(ii,jj,l1,ikap)=0.0d0
+            end do
+         end do
+      end do  !ikap
+   end do  !l1
 
 ! Vanderbilt B-matrix construction
 
- do l1=1,lmax+1
-  if(l1==lloc+1) cycle
-  ll=l1-1
-  if(l1==1) then
-   mkap=1
-  else
-   mkap=2
-  end if
+   do l1=1,lmax+1
+      if(l1==lloc+1) cycle
+      ll=l1-1
+      if(l1==1) then
+         mkap=1
+      else
+         mkap=2
+      end if
 ! loop on J = ll +/- 1/2
-  do ikap=1,mkap
-   if(ikap==1) kap=-(ll+1)
-   if(ikap==2) kap=  ll
-   np=nproj(l1)
-   bb(:,:)=0.0d0
-   call vpinteg(pswf(1,1,l1,ikap),vkb(1,1,l1,ikap),irc(l1),2*l1,bb(1,1),rr)
-   evkb(1,l1,ikap)=1.0d0/bb(1,1)
+      do ikap=1,mkap
+         if(ikap==1) kap=-(ll+1)
+         if(ikap==2) kap=  ll
+         np=nproj(l1)
+         bb(:,:)=0.0d0
+         call vpinteg(pswf(1,1,l1,ikap),vkb(1,1,l1,ikap),irc(l1),2*l1,bb(1,1),rr)
+         evkb(1,l1,ikap)=1.0d0/bb(1,1)
 ! this is Kleinman-Bylander result if nproj==1
 
-   if(nproj(l1)>=2) then
+         if(nproj(l1)>=2) then
 
-   do jj=1,np
-     do ii=1,np
-       call vpinteg(pswf(1,ii,l1,ikap),vkb(1,jj,l1,ikap),irc(l1),2*l1,bb(ii,jj),rr)
-     end do
-   end do
+            do jj=1,np
+               do ii=1,np
+                  call vpinteg(pswf(1,ii,l1,ikap),vkb(1,jj,l1,ikap),irc(l1),2*l1,bb(ii,jj),rr)
+               end do
+            end do
 
 ! symmetrize exactly
-   write(6,'(/a,i3,a,i3)') 'B matrix Hermiticity error, ll=',l1-1, &
-&        '  kap=',kap
-   do jj=2,np
-     do ii=1,jj-1
-       write(6,'(2i4,1p,d14.4)') ii,jj,bb(ii,jj)-bb(jj,ii)
-       tt=0.5d0*(bb(ii,jj)+bb(jj,ii))
-       bb(ii,jj)=tt
-       bb(jj,ii)=tt
-     end do
-   end do
+            write(6,'(/a,i3,a,i3)') 'B matrix Hermiticity error, ll=',l1-1, &
+            &        '  kap=',kap
+            do jj=2,np
+               do ii=1,jj-1
+                  write(6,'(2i4,1p,d14.4)') ii,jj,bb(ii,jj)-bb(jj,ii)
+                  tt=0.5d0*(bb(ii,jj)+bb(jj,ii))
+                  bb(ii,jj)=tt
+                  bb(jj,ii)=tt
+               end do
+            end do
 
 ! find eigenvalues and eigenvectors of the B matrix
 
 !      SUBROUTINE DSYEV( JOBZ, UPLO, N, A, LDA, W, WORK, LWORK, INFO )
 
-     call dsyev( 'V', 'U', np, bb, mxprj, bbev, work, lwork, info )
-     if(info .ne. 0) then
-      write(6,'(a,i4)') 'run_vkb: B matrix eigenvalue ERROR, info=',info
-      stop
-     end if
+            call dsyev( 'V', 'U', np, bb, mxprj, bbev, work, lwork, info )
+            if(info /= 0) then
+               write(6,'(a,i4)') 'run_vkb: B matrix eigenvalue ERROR, info=',info
+               stop
+            end if
 
 ! take linear combinations to form diagonal projectors
 
-   do jj=1,np
-   vkbt(:,jj)=vkb(:,jj,l1,ikap)
-   end do
+            do jj=1,np
+               vkbt(:,jj)=vkb(:,jj,l1,ikap)
+            end do
 
-   do jj=1,np
-     vkb(:,jj,l1,ikap)=0.0d0
-     evkb(jj,l1,ikap)=1.0d0/bbev(jj)
-     do ii=1,np
-       vkb(:,jj,l1,ikap)=vkb(:,jj,l1,ikap)+bb(ii,jj)*vkbt(:,ii)
-     end do
-   end do
-   
-   end if !nproj>=2
+            do jj=1,np
+               vkb(:,jj,l1,ikap)=0.0d0
+               evkb(jj,l1,ikap)=1.0d0/bbev(jj)
+               do ii=1,np
+                  vkb(:,jj,l1,ikap)=vkb(:,jj,l1,ikap)+bb(ii,jj)*vkbt(:,ii)
+               end do
+            end do
+
+         end if  !nproj>=2
 
 ! normalize projectors
-   do jj=1,np
-     call vpinteg(vkb(1,jj,l1,ikap),vkb(1,jj,l1,ikap),irc(l1),2*l1,sn,rr)
-     if(vkb(irc(l1)-10,jj,l1,ikap)>=0.0d0) then
-       vkb(:,jj,l1,ikap)=vkb(:,jj,l1,ikap)/sqrt(sn)
-     else
-       vkb(:,jj,l1,ikap)=-vkb(:,jj,l1,ikap)/sqrt(sn)
-     end if
-     evkb(jj,l1,ikap)=sn*evkb(jj,l1,ikap)
-   end do
+         do jj=1,np
+            call vpinteg(vkb(1,jj,l1,ikap),vkb(1,jj,l1,ikap),irc(l1),2*l1,sn,rr)
+            if(vkb(irc(l1)-10,jj,l1,ikap)>=0.0d0) then
+               vkb(:,jj,l1,ikap)=vkb(:,jj,l1,ikap)/sqrt(sn)
+            else
+               vkb(:,jj,l1,ikap)=-vkb(:,jj,l1,ikap)/sqrt(sn)
+            end if
+            evkb(jj,l1,ikap)=sn*evkb(jj,l1,ikap)
+         end do
 
 
 ! calculate overlap
-   if(nproj(l1)>=2) then
+         if(nproj(l1)>=2) then
 
 
-    bbi(:,:)=0.0d0
-    do jj=1,np
-      sovl(jj,jj)=1.0d0
-      bbi(jj,jj)=evkb(jj,l1,ikap)
-      do ii=jj+1,np
-        call vpinteg(vkb(1,ii,l1,ikap),vkb(1,jj,l1,ikap),irc(l1),2*l1,sn,rr)
-        sovl(ii,jj)=sn
-        sovl(jj,ii)=sn
-      end do
-    end do
-    call vpinteg(vkb(1,1,l1,ikap),vkb(1,2,l1,ikap),irc(l1),2*l1,sn,rr)
+            bbi(:,:)=0.0d0
+            do jj=1,np
+               sovl(jj,jj)=1.0d0
+               bbi(jj,jj)=evkb(jj,l1,ikap)
+               do ii=jj+1,np
+                  call vpinteg(vkb(1,ii,l1,ikap),vkb(1,jj,l1,ikap),irc(l1),2*l1,sn,rr)
+                  sovl(ii,jj)=sn
+                  sovl(jj,ii)=sn
+               end do
+            end do
+            call vpinteg(vkb(1,1,l1,ikap),vkb(1,2,l1,ikap),irc(l1),2*l1,sn,rr)
 
 ! find eigenvalues and eigenvectors of the overlap matrix
 
 !      SUBROUTINE DSYEV( JOBZ, UPLO, N, A, LDA, W, WORK, LWORK, INFO )
 
-    call dsyev( 'V', 'U', np, sovl, mxprj, sovlev, work, lwork, info )
-    if(info .ne. 0) then
-     write(6,'(a,i4)') 'run_vkb: sovl matrix eigenvalue ERROR, info=',info
-     stop
-    end if
+            call dsyev( 'V', 'U', np, sovl, mxprj, sovlev, work, lwork, info )
+            if(info /= 0) then
+               write(6,'(a,i4)') 'run_vkb: sovl matrix eigenvalue ERROR, info=',info
+               stop
+            end if
 
 !   write(6,'(/1p,2e12.4)') (sovlev(ii),ii=1,2)
 
 ! construct S^(-1/2) AND s^(1/2)
 
-     do jj=1,np
-      tt=sqrt(sovlev(jj))
-      do ii=1,np
-       sphalf(ii,jj)=tt*sovl(ii,jj)
-       smhalf(ii,jj)=sovl(ii,jj)/tt
-      end do
-     end do
+            do jj=1,np
+               tt=sqrt(sovlev(jj))
+               do ii=1,np
+                  sphalf(ii,jj)=tt*sovl(ii,jj)
+                  smhalf(ii,jj)=sovl(ii,jj)/tt
+               end do
+            end do
 
 ! construct B^(-1)* = S^(1/2)^T B^(-1) S^(1/2)
 
-     bbit(:,:)=0.0d0
-     bbist(:,:)=0.0d0
+            bbit(:,:)=0.0d0
+            bbist(:,:)=0.0d0
 
-     do ii=1,np
-      do jj=1,np
-       do kk=1,np
-        bbit(ii,jj)=bbit(ii,jj)+bbi(ii,kk)*sphalf(kk,jj)
-       end do
-      end do
-     end do
+            do ii=1,np
+               do jj=1,np
+                  do kk=1,np
+                     bbit(ii,jj)=bbit(ii,jj)+bbi(ii,kk)*sphalf(kk,jj)
+                  end do
+               end do
+            end do
 
-     do ii=1,np
-      do jj=1,np
-       do kk=1,np
-        bbist(ii,jj)=bbist(ii,jj)+bbit(kk,jj)*sphalf(kk,ii)
-       end do
-      end do
-     end do
+            do ii=1,np
+               do jj=1,np
+                  do kk=1,np
+                     bbist(ii,jj)=bbist(ii,jj)+bbit(kk,jj)*sphalf(kk,ii)
+                  end do
+               end do
+            end do
 
 !      SUBROUTINE DSYEV( JOBZ, UPLO, N, A, LDA, W, WORK, LWORK, INFO )
 
-     call dsyev( 'V', 'U', np , bbist, mxprj, bbistev, work, lwork, info )
-     if(info .ne. 0) then
-      write(6,'(a,i4)') 'run_vkb: B^(-1)* matrix eigenvalue ERROR, info=',info
-      stop
-     end if
+            call dsyev( 'V', 'U', np , bbist, mxprj, bbistev, work, lwork, info )
+            if(info /= 0) then
+               write(6,'(a,i4)') 'run_vkb: B^(-1)* matrix eigenvalue ERROR, info=',info
+               stop
+            end if
 
 
 ! take linear combinations to form orthonormal basis functions
 
-     vkbt(:,:)=vkb(:,:,l1,ikap)
-     vkbst(:,:)=0.0d0
+            vkbt(:,:)=vkb(:,:,l1,ikap)
+            vkbst(:,:)=0.0d0
 
-     do jj=1,np
-      do ii=1,np
-       vkbst(:,jj)=vkbst(:,jj) + smhalf(ii,jj)*vkbt(:,ii)
-      end do
-     end do
+            do jj=1,np
+               do ii=1,np
+                  vkbst(:,jj)=vkbst(:,jj) + smhalf(ii,jj)*vkbt(:,ii)
+               end do
+            end do
 
 
 ! take linear combinations to form orthonormal projectors
 
-     vkb(:,:,L1,ikap)=0.0d0
+            vkb(:,:,L1,ikap)=0.0d0
 
-     do ii=1,np
-      evkb(ii,l1,ikap)=bbistev(ii)
-      do jj=1,np
-       vkb(:,ii,l1,ikap)=vkb(:,ii,l1,ikap) + bbist(jj,ii)*vkbst(:,jj)
-      end do
-     end do
+            do ii=1,np
+               evkb(ii,l1,ikap)=bbistev(ii)
+               do jj=1,np
+                  vkb(:,ii,l1,ikap)=vkb(:,ii,l1,ikap) + bbist(jj,ii)*vkbst(:,jj)
+               end do
+            end do
 
 ! re-order if necessary so first projector has largest magnitude coefficient
 ! which is consistent with relativistic sr_so_r.f90 output
 
-     do ii=1,100
-       sorted=.true.
-       do jj=2,np
+            do ii=1,100
+               sorted=.true.
+               do jj=2,np
 
-         if(abs(evkb(jj,l1,ikap))>abs(evkb(jj-1,l1,ikap))) then
-           tt=evkb(jj-1,l1,ikap)
-           vkbt(:,1)=vkb(:,jj-1,l1,ikap)
-           evkb(jj-1,l1,ikap)=evkb(jj,l1,ikap)
-           vkb(:,jj-1,l1,ikap)=vkb(:,jj,l1,ikap)
-           evkb(jj,l1,ikap)=tt
-           vkb(:,jj,l1,ikap)=vkbt(:,1)
-           sorted=.false.
-         end if
-       end do
-       if(sorted) exit
-     end do
-  
-     write(6,'(/a,1p,5e12.4)') '  Orthonormal projector coefficients',&
-&        (evkb(jj,l1,ikap),jj=1,np)
+                  if(abs(evkb(jj,l1,ikap))>abs(evkb(jj-1,l1,ikap))) then
+                     tt=evkb(jj-1,l1,ikap)
+                     vkbt(:,1)=vkb(:,jj-1,l1,ikap)
+                     evkb(jj-1,l1,ikap)=evkb(jj,l1,ikap)
+                     vkb(:,jj-1,l1,ikap)=vkb(:,jj,l1,ikap)
+                     evkb(jj,l1,ikap)=tt
+                     vkb(:,jj,l1,ikap)=vkbt(:,1)
+                     sorted=.false.
+                  end if
+               end do
+               if(sorted) exit
+            end do
+
+            write(6,'(/a,1p,5e12.4)') '  Orthonormal projector coefficients',&
+            &        (evkb(jj,l1,ikap),jj=1,np)
 
 ! Set sign of projectors (physically irrelevant) so that they are positive
 ! at their peak (needed for compaisons apparently)
 
-     do jj=1,np
-       apk=0.0d0
-       do ii=1,mmax
-         if(abs(vkb(ii,jj,l1,ikap))>apk) then
-           apk=abs(vkb(ii,jj,l1,ikap))
-           ipk=ii
+            do jj=1,np
+               apk=0.0d0
+               do ii=1,mmax
+                  if(abs(vkb(ii,jj,l1,ikap))>apk) then
+                     apk=abs(vkb(ii,jj,l1,ikap))
+                     ipk=ii
+                  end if
+               end do
+               if(vkb(ipk,jj,l1,ikap)<0.0d0) then
+                  vkb(:,jj,l1,ikap)=-vkb(:,jj,l1,ikap)
+               end if
+            end do
+
+         end if  !nproj(l1)>=2
+
+         if(nproj(l1)<mxprj) then
+            do jj=nproj(l1)+1, mxprj
+               evkb(jj,l1,ikap)=0.0d0
+               vkb(:,jj,l1,ikap)=0.0d0
+            end do
          end if
-       end do
-       if(vkb(ipk,jj,l1,ikap)<0.0d0) then
-         vkb(:,jj,l1,ikap)=-vkb(:,jj,l1,ikap)
-       end if
-     end do
+      end do  !ikap
+   end do  !l1
 
-   end if !nproj(l1)>=2
+   deallocate(vloc,vkbt,vkbst,work)
 
-   if(nproj(l1)<mxprj) then
-     do jj=nproj(l1)+1, mxprj
-       evkb(jj,l1,ikap)=0.0d0
-       vkb(:,jj,l1,ikap)=0.0d0
-     end do
-   end if
-  end do !ikap
- end do !l1
-
- deallocate(vloc,vkbt,vkbst,work)
-
- return
- end subroutine run_vkb_r
+   return
+end subroutine run_vkb_r

--- a/src/sbf8.f90
+++ b/src/sbf8.f90
@@ -2,17 +2,17 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
@@ -24,83 +24,83 @@ subroutine sbf8(nm,xx,sb_out)
 !xx  argument of spherical bessel function
 !sb_out  output of sbf_l(xx) for l=0,...,nm-1
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
- real(dp), parameter :: pi=3.141592653589793238462643383279502884197_dp
- real(dp), parameter :: pi2=2.0_dp*pi
+   real(dp), parameter :: pi=3.141592653589793238462643383279502884197_dp
+   real(dp), parameter :: pi2=2.0_dp*pi
 
 !Input variables
-  integer :: nm
-  real(dp) :: xx
+   integer :: nm
+   real(dp) :: xx
 
 !Output variables
-  real(dp) :: sb_out(nm)
+   real(dp) :: sb_out(nm)
 
 !Local variables
- integer :: nlim,nn
- real(dp) :: cc,fn,sn,ss,xi,xn,xs,xmod
- real(dp),allocatable :: sb(:)
+   integer :: nlim,nn
+   real(dp) :: cc,fn,sn,ss,xi,xn,xs,xmod
+   real(dp),allocatable :: sb(:)
 
 
- if(xx<= 1.0d-36) then
+   if(xx<= 1.0d-36) then
 !  zero argument section
-   sb_out(:)=0.0d0
-   sb_out(1)=1.0d0
- else if(xx<1.0d-3) then
+      sb_out(:)=0.0d0
+      sb_out(1)=1.0d0
+   else if(xx<1.0d-3) then
 !  small argument section
-   xn=1.0d0
-   xs=0.5d0*xx**2
-   do nn=1,nm
-     sb_out(nn)=xn*(1.0d0 - xs*(1.0d0 - xs/(4*nn+6))/(2*nn+1))
-     xn=xx*xn/(2*nn+1)
-   end do
+      xn=1.0d0
+      xs=0.5d0*xx**2
+      do nn=1,nm
+         sb_out(nn)=xn*(1.0d0 - xs*(1.0d0 - xs/(4*nn+6))/(2*nn+1))
+         xn=xx*xn/(2*nn+1)
+      end do
 !  trigonometric section (small l values)
- else if(nm==1) then
-   xmod=mod(xx,pi2)
-   ss=sin(xmod)
-   sb_out(1)=ss/xx 
- else if(nm==2) then
-   xmod=mod(xx,pi2)
-   ss=sin(xmod)
-   cc=cos(xmod)
-   sb_out(1)=ss/xx 
-   sb_out(2)=(ss-xx*cc)/xx**2
- else if(nm==3) then
-   xmod=mod(xx,pi2)
-   ss=sin(xmod)
-   cc=cos(xmod)
-   sb_out(1)=ss/xx 
-   sb_out(3)=((3.0d0-xx**2)*ss - 3.0d0*xx*cc)/xx**3
- else if(nm==4) then
-   xmod=mod(xx,pi2)
-   ss=sin(xmod)
-   cc=cos(xmod)
-   sb_out(1)=ss/xx 
-   sb_out(3)=((3.0d0-xx**2)*ss - 3.0d0*xx*cc)/xx**3
-   sb_out(4)=(15.d0*ss-15.d0*xx*cc - 6.d0*xx**2*ss + xx**3*cc )/xx**4
- else
-!  recursion method (accurate for large l, slow for large arguments)
-   if(xx<1.0d0) then
-     nlim=nm+int(15.0d0*xx)+1
+   else if(nm==1) then
+      xmod=mod(xx,pi2)
+      ss=sin(xmod)
+      sb_out(1)=ss/xx
+   else if(nm==2) then
+      xmod=mod(xx,pi2)
+      ss=sin(xmod)
+      cc=cos(xmod)
+      sb_out(1)=ss/xx
+      sb_out(2)=(ss-xx*cc)/xx**2
+   else if(nm==3) then
+      xmod=mod(xx,pi2)
+      ss=sin(xmod)
+      cc=cos(xmod)
+      sb_out(1)=ss/xx
+      sb_out(3)=((3.0d0-xx**2)*ss - 3.0d0*xx*cc)/xx**3
+   else if(nm==4) then
+      xmod=mod(xx,pi2)
+      ss=sin(xmod)
+      cc=cos(xmod)
+      sb_out(1)=ss/xx
+      sb_out(3)=((3.0d0-xx**2)*ss - 3.0d0*xx*cc)/xx**3
+      sb_out(4)=(15.d0*ss-15.d0*xx*cc - 6.d0*xx**2*ss + xx**3*cc )/xx**4
    else
-     nlim=nm+int(1.36d0*xx)+15
+!  recursion method (accurate for large l, slow for large arguments)
+      if(xx<1.0d0) then
+         nlim=nm+int(15.0d0*xx)+1
+      else
+         nlim=nm+int(1.36d0*xx)+15
+      end if
+      allocate(sb(nlim+1))
+      nn=nlim
+      xi=1.0d0/xx
+      sb(nn+1)=0.0d0
+      sb(nn)=1.0d-18
+      sn=dble(2*nn-1)*1.0d-36
+      do nn=nlim-1,1,-1
+         sb(nn)=dble(2*nn+1)*xi*sb(nn+1) - sb(nn+2)
+      end do
+      do nn=1,nlim-1
+         sn=sn + dble(2*nn-1)*sb(nn)*sb(nn)
+      end do
+      fn=1.0d0/sqrt(sn)
+      sb_out(:)=fn*sb(1:nm)
+      deallocate(sb)
    end if
-   allocate(sb(nlim+1))
-   nn=nlim
-   xi=1.0d0/xx
-   sb(nn+1)=0.0d0
-   sb(nn)=1.0d-18
-   sn=dble(2*nn-1)*1.0d-36
-   do nn=nlim-1,1,-1
-     sb(nn)=dble(2*nn+1)*xi*sb(nn+1) - sb(nn+2)
-   end do
-   do nn=1,nlim-1
-     sn=sn + dble(2*nn-1)*sb(nn)*sb(nn)
-   end do
-   fn=1.0d0/sqrt(sn)
-   sb_out(:)=fn*sb(1:nm)
-   deallocate(sb)
- end if
- return
+   return
 end subroutine sbf8

--- a/src/sbf_basis_con.f90
+++ b/src/sbf_basis_con.f90
@@ -2,29 +2,29 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- subroutine sbf_basis_con(ll,rr,mmax,irc,nbas,qroot,psopt,orbasis,orbasis_der, &
+subroutine sbf_basis_con(ll,rr,mmax,irc,nbas,qroot,psopt,orbasis,orbasis_der, &
 &                     iprj,mxprj,ncon,ncon_in)
 
 ! orthonormalize basis functions and derivatives at rc and form constraint
 ! matrix based on derivative to be matched and overlaps with prior
 ! optimized wave functions
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !INPUT
 !ll  angujlar momentum
@@ -41,69 +41,69 @@
 ! norm constraint vectors from already-computed psopt
 
 !Input variables
- integer :: ll,mmax,ncon,ncon_in,irc,nbas,iprj,mxprj
- real(dp) :: rr(mmax),qroot(nbas)
- real(dp) :: psopt(mmax,mxprj)
+   integer :: ll,mmax,ncon,ncon_in,irc,nbas,iprj,mxprj
+   real(dp) :: rr(mmax),qroot(nbas)
+   real(dp) :: psopt(mmax,mxprj)
 
 !Output variables
- real(dp) :: orbasis(nbas,nbas)
- real(dp) :: orbasis_der(ncon,nbas)
+   real(dp) :: orbasis(nbas,nbas)
+   real(dp) :: orbasis_der(ncon,nbas)
 
 !Local variables
- integer :: ii,jj,kk,ll1,ibas,info
- real(dp) :: al,amesh,ro,rc,sn,xx,tt
- real(dp) :: sb_out(10),sbfder(5),tder(6)
- real(dp), allocatable :: sbfar(:,:),sev(:),work(:),sovlp(:,:)
- real(dp), allocatable :: sbf_or(:,:)
+   integer :: ii,jj,kk,ll1,ibas,info
+   real(dp) :: al,amesh,ro,rc,sn,xx,tt
+   real(dp) :: sb_out(10),sbfder(5),tder(6)
+   real(dp), allocatable :: sbfar(:,:),sev(:),work(:),sovlp(:,:)
+   real(dp), allocatable :: sbf_or(:,:)
 
- ll1=ll+1
- rc=rr(irc)
- al = 0.01d0 * log(rr(101) / rr(1))
- amesh = exp(al)
+   ll1=ll+1
+   rc=rr(irc)
+   al = 0.01d0 * log(rr(101) / rr(1))
+   amesh = exp(al)
 
- allocate(sbfar(irc,nbas),sev(nbas),work(5*nbas),sovlp(nbas,nbas))
- allocate(sbf_or(irc,nbas))
+   allocate(sbfar(irc,nbas),sev(nbas),work(5*nbas),sovlp(nbas,nbas))
+   allocate(sbf_or(irc,nbas))
 
- do ibas=1,nbas
-  do jj=1,irc
-   xx=qroot(ibas)*rr(jj)
-   call sbf8(ll1,xx,sb_out)
-   sbfar(jj,ibas)=rr(jj)*sb_out(ll1)
-  end do
- end do
+   do ibas=1,nbas
+      do jj=1,irc
+         xx=qroot(ibas)*rr(jj)
+         call sbf8(ll1,xx,sb_out)
+         sbfar(jj,ibas)=rr(jj)*sb_out(ll1)
+      end do
+   end do
 
 !perform sbf orthonormalization sum for overlap matrix
 
- sovlp(:,:)=0.0d0
- ro=rr(1)/sqrt(amesh)
- do ibas=1,nbas
-  do jj=ibas,nbas
+   sovlp(:,:)=0.0d0
+   ro=rr(1)/sqrt(amesh)
+   do ibas=1,nbas
+      do jj=ibas,nbas
 
-   sn=(sbfar(1,ibas)/rr(1)**ll)*(sbfar(1,jj)/rr(1)**ll)&
-&     *ro**(2*ll+3)/dfloat(2*ll+3)
- 
-   do ii=1,irc-3
-     sn=sn+al*rr(ii)*sbfar(ii,ibas)*sbfar(ii,jj)
+         sn=(sbfar(1,ibas)/rr(1)**ll)*(sbfar(1,jj)/rr(1)**ll)&
+         &     *ro**(2*ll+3)/dfloat(2*ll+3)
+
+         do ii=1,irc-3
+            sn=sn+al*rr(ii)*sbfar(ii,ibas)*sbfar(ii,jj)
+         end do
+
+         sn=sn + al*(23.0d0*rr(irc-2)*sbfar(irc-2,ibas)*sbfar(irc-2,jj)&
+         &            + 28.0d0*rr(irc-1)*sbfar(irc-1,ibas)*sbfar(irc-1,jj)&
+         &            +  9.0d0*rr(irc  )*sbfar(irc  ,ibas)*sbfar(irc  ,jj))/24.0d0
+
+         sovlp(ibas,jj)=sn
+         sovlp(jj,ibas)=sn
+      end do
    end do
- 
-   sn=sn + al*(23.0d0*rr(irc-2)*sbfar(irc-2,ibas)*sbfar(irc-2,jj)&
-&            + 28.0d0*rr(irc-1)*sbfar(irc-1,ibas)*sbfar(irc-1,jj)&
-&            +  9.0d0*rr(irc  )*sbfar(irc  ,ibas)*sbfar(irc  ,jj))/24.0d0
- 
-   sovlp(ibas,jj)=sn
-   sovlp(jj,ibas)=sn
-  end do
- end do
 
 !find eigenvalues and eigenvectors of the overlap matrix
 
 !      SUBROUTINE DSYEV( JOBZ, UPLO, N, A, LDA, W, WORK, LWORK, INFO )
 
- call dsyev( 'V', 'U', nbas, sovlp, nbas, sev, work, 5*nbas, info )
- if(info .ne. 0) then
-  write(6,'(a,i4)') 'sbf_basis: overlap matrix eigenvalue error, info=',info
-  stop
- end if
+   call dsyev( 'V', 'U', nbas, sovlp, nbas, sev, work, 5*nbas, info )
+   if(info /= 0) then
+      write(6,'(a,i4)') 'sbf_basis: overlap matrix eigenvalue error, info=',info
+      stop
+   end if
 
 !write(6,'(/a)') 'sbf overlap matrix eigenvalues'
 !write(6,'(1p,6d12.3)') (sev(ibas),ibas=1,nbas)
@@ -111,62 +111,62 @@
 !scale eigenvectors to form orthonormal basis coefficients for sbf's
 !note that we are reversing order so that the leading eigenvector is the
 !most linearly independent
- do ibas=1,nbas
-  if(sev(ibas)>0.0d0) then
-   tt=1.0d0/sqrt(sev(ibas))
-  else
-   write(6,'(a,f12.6)') 'sbfbasis: negative eigenvalue of overlap matrix'
-   stop
-  end if
-  do jj=1,nbas
-   orbasis(jj,nbas-ibas+1)=tt*sovlp(jj,ibas)
-  end do
- end do
+   do ibas=1,nbas
+      if(sev(ibas)>0.0d0) then
+         tt=1.0d0/sqrt(sev(ibas))
+      else
+         write(6,'(a,f12.6)') 'sbfbasis: negative eigenvalue of overlap matrix'
+         stop
+      end if
+      do jj=1,nbas
+         orbasis(jj,nbas-ibas+1)=tt*sovlp(jj,ibas)
+      end do
+   end do
 
 !find rc derivatives of basis funtction
- orbasis_der(:,:)=0.0d0
- do jj=1,nbas !sbf loop
-  call sbf_rc_der(ll,qroot(jj),rc,sbfder)
-  do ibas=1,nbas !orbasis loop
-   do ii=1,ncon_in
-    orbasis_der(ii,ibas)=orbasis_der(ii,ibas)+orbasis(jj,ibas)*sbfder(ii)
+   orbasis_der(:,:)=0.0d0
+   do jj=1,nbas  !sbf loop
+      call sbf_rc_der(ll,qroot(jj),rc,sbfder)
+      do ibas=1,nbas  !orbasis loop
+         do ii=1,ncon_in
+            orbasis_der(ii,ibas)=orbasis_der(ii,ibas)+orbasis(jj,ibas)*sbfder(ii)
+         end do
+      end do
    end do
-  end do
- end do
 
 !find orthogonal basis radial functiona
- sbf_or(:,:)=0.0d0
- do jj=1,nbas !sbf loop
-   do ibas=1,nbas !orbasis loop
-     sbf_or(:,ibas)=sbf_or(:,ibas)+orbasis(jj,ibas)*sbfar(:,jj)
+   sbf_or(:,:)=0.0d0
+   do jj=1,nbas  !sbf loop
+      do ibas=1,nbas  !orbasis loop
+         sbf_or(:,ibas)=sbf_or(:,ibas)+orbasis(jj,ibas)*sbfar(:,jj)
+      end do
    end do
- end do
 
 !find new or-basis representation of previous optimized wave functions
 !fill in last rows of orbssis_der constraint matrix for overlap constraint
 
- if(iprj>=2) then
-   ro=rr(1)/sqrt(amesh)
-   do kk=1,iprj-1
-    do jj=1,nbas
-  
-     sn=(psopt(1,kk)/rr(1)**ll)*(sbf_or(1,jj)/rr(1)**ll)&
-  &     *ro**(2*ll+3)/dfloat(2*ll+3)
-   
-     do ii=1,irc-3
-       sn=sn+al*rr(ii)*psopt(ii,kk)*sbf_or(ii,jj)
-     end do
-   
-     sn=sn + al*(23.0d0*rr(irc-2)*psopt(irc-2,kk)*sbf_or(irc-2,jj)&
-  &            + 28.0d0*rr(irc-1)*psopt(irc-1,kk)*sbf_or(irc-1,jj)&
-  &            +  9.0d0*rr(irc  )*psopt(irc  ,kk)*sbf_or(irc  ,jj))/24.0d0
-   
-     orbasis_der(ncon_in+kk,jj)=sn
-    end do !jj
-   end do !kk
- end if !iprj>=2
+   if(iprj>=2) then
+      ro=rr(1)/sqrt(amesh)
+      do kk=1,iprj-1
+         do jj=1,nbas
 
- deallocate(sbfar,sbf_or,sev,work,sovlp)
+            sn=(psopt(1,kk)/rr(1)**ll)*(sbf_or(1,jj)/rr(1)**ll)&
+            &     *ro**(2*ll+3)/dfloat(2*ll+3)
 
- return
- end subroutine sbf_basis_con
+            do ii=1,irc-3
+               sn=sn+al*rr(ii)*psopt(ii,kk)*sbf_or(ii,jj)
+            end do
+
+            sn=sn + al*(23.0d0*rr(irc-2)*psopt(irc-2,kk)*sbf_or(irc-2,jj)&
+            &            + 28.0d0*rr(irc-1)*psopt(irc-1,kk)*sbf_or(irc-1,jj)&
+            &            +  9.0d0*rr(irc  )*psopt(irc  ,kk)*sbf_or(irc  ,jj))/24.0d0
+
+            orbasis_der(ncon_in+kk,jj)=sn
+         end do  !jj
+      end do  !kk
+   end if  !iprj>=2
+
+   deallocate(sbfar,sbf_or,sev,work,sovlp)
+
+   return
+end subroutine sbf_basis_con

--- a/src/sbf_rc_der.f90
+++ b/src/sbf_rc_der.f90
@@ -2,26 +2,26 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- subroutine sbf_rc_der(llin,qq,rc,sbfder)
+subroutine sbf_rc_der(llin,qq,rc,sbfder)
 
 !calculate spherical Bessel function values and first four derivatives
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !INPUT
 ! llin  angular momentum l
@@ -32,22 +32,22 @@
 ! sbfder  values and first 4 derivatives of j_l(qq*rc)
 
 !Arguments
- integer :: llin
- real(dp) :: qq,rc,xx,sbfder(5)
+   integer :: llin
+   real(dp) :: qq,rc,xx,sbfder(5)
 !
 !local variables
- real(dp) :: sb_out(10),sbfad(5,10)
- integer :: ii,ll
+   real(dp) :: sb_out(10),sbfad(5,10)
+   integer :: ii,ll
 
- if(llin>5) then
-  write(6,'(a,i4,a)') 'sbf_rc_der: argument ERROR, llin = ',llin,&
-&  ' >5'
-  stop
- end if
+   if(llin>5) then
+      write(6,'(a,i4,a)') 'sbf_rc_der: argument ERROR, llin = ',llin,&
+      &  ' >5'
+      stop
+   end if
 
 ! calculate sbf for needed l values
- xx=qq*rc
- call sbf8(llin+5,xx,sb_out)
+   xx=qq*rc
+   call sbf8(llin+5,xx,sb_out)
 
 ! derivatives based on derivative formula applied recursively
 !
@@ -55,43 +55,43 @@
 !
 
 ! store values
- do ll=llin,llin+5
-  sbfad(1,ll+1)=sb_out(ll+1)
- end do
+   do ll=llin,llin+5
+      sbfad(1,ll+1)=sb_out(ll+1)
+   end do
 
 ! first derivatives
- do ll=llin,llin+3
-  sbfad(2,ll+1)=ll*sbfad(1,ll+1)/xx &
-&                - sbfad(1,ll+2)
- end do
- 
+   do ll=llin,llin+3
+      sbfad(2,ll+1)=ll*sbfad(1,ll+1)/xx &
+      &                - sbfad(1,ll+2)
+   end do
+
 ! second derivatives
- do ll=llin,llin+2
-  sbfad(3,ll+1)=-ll*sbfad(1,ll+1)/xx**2 &
-&              + ll*sbfad(2,ll+1)/xx&
-&                  -sbfad(2,ll+2)
- end do
+   do ll=llin,llin+2
+      sbfad(3,ll+1)=-ll*sbfad(1,ll+1)/xx**2 &
+      &              + ll*sbfad(2,ll+1)/xx&
+      &                  -sbfad(2,ll+2)
+   end do
 
 ! third derivatives
- do ll=llin,llin+1
-  sbfad(4,ll+1)= 2*ll*sbfad(1,ll+1)/xx**3 &
-&               -2*ll*sbfad(2,ll+1)/xx**2 &
-&                 +ll*sbfad(3,ll+1)/xx &
-&                    -sbfad(3,ll+2)
- end do
+   do ll=llin,llin+1
+      sbfad(4,ll+1)= 2*ll*sbfad(1,ll+1)/xx**3 &
+      &               -2*ll*sbfad(2,ll+1)/xx**2 &
+      &                 +ll*sbfad(3,ll+1)/xx &
+      &                    -sbfad(3,ll+2)
+   end do
 
 ! fourth derivatives
- do ll=llin,llin
-  sbfad(5,ll+1)=-6*ll*sbfad(1,ll+1)/xx**4 &
-&               +6*ll*sbfad(2,ll+1)/xx**3 &
-&               -3*ll*sbfad(3,ll+1)/xx**2 &
-&                 +ll*sbfad(4,ll+1)/xx &
-&                    -sbfad(4,ll+2)
- end do
+   do ll=llin,llin
+      sbfad(5,ll+1)=-6*ll*sbfad(1,ll+1)/xx**4 &
+      &               +6*ll*sbfad(2,ll+1)/xx**3 &
+      &               -3*ll*sbfad(3,ll+1)/xx**2 &
+      &                 +ll*sbfad(4,ll+1)/xx &
+      &                    -sbfad(4,ll+2)
+   end do
 
- do ii=1,5
-  sbfder(ii)=sbfad(ii,llin+1)*qq**(ii-1)
- end do
+   do ii=1,5
+      sbfder(ii)=sbfad(ii,llin+1)*qq**(ii-1)
+   end do
 
- return
- end subroutine sbf_rc_der
+   return
+end subroutine sbf_rc_der

--- a/src/sr_so_r.f90
+++ b/src/sr_so_r.f90
@@ -2,21 +2,21 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- subroutine sr_so_r(lmax,irc,nproj,rr,mmax,mxprj,evkb,vkb, &
+subroutine sr_so_r(lmax,irc,nproj,rr,mmax,mxprj,evkb,vkb, &
 &                       vsr,esr,vso,eso)
 
 ! reformulates non-local potentials based on j = l +/- 1/2 to scalar-
@@ -38,240 +38,240 @@
 !vso  normalized spin-orbig projectors
 !esol  energy  coefficients of vso
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !Input variables
- integer :: lmax,lloc,lpopt,mmax,mxprj
- integer :: irc(6),nproj(6)
- real(dp) :: rr(mmax),vkb(mmax,mxprj,4,2),evkb(mxprj,4,2)
+   integer :: lmax,lloc,lpopt,mmax,mxprj
+   integer :: irc(6),nproj(6)
+   real(dp) :: rr(mmax),vkb(mmax,mxprj,4,2),evkb(mxprj,4,2)
 
 !Output variables
- real(dp) :: vsr(mmax,2*mxprj,4),esr(2*mxprj,4)
- real(dp) :: vso(mmax,2*mxprj,4),eso(2*mxprj,4)
+   real(dp) :: vsr(mmax,2*mxprj,4),esr(2*mxprj,4)
+   real(dp) :: vso(mmax,2*mxprj,4),eso(2*mxprj,4)
 
 !Local variables
- integer :: ii,jj,kk,ierr,ik1,ik2,ip1,ip2,ipk,ll,l1,info,nn
- real(dp) :: apk,sn,tt,qq1mxprj
- real(dp) :: sovl(2*mxprj,2*mxprj),sovlev(2*mxprj),ascl(2*mxprj,2*mxprj),aso(2*mxprj,2*mxprj)
- real(dp) :: asclst(2*mxprj,2*mxprj),wsclst(2*mxprj),asost(2*mxprj,2*mxprj),wsost(2*mxprj)
- real(dp) :: asclt(2*mxprj,2*mxprj),asot(2*mxprj,2*mxprj)
- real(dp) :: sphalf(2*mxprj,2*mxprj),smhalf(2*mxprj,2*mxprj)
- real(dp) :: fscl(mxprj),fso(mxprj),work(10*mxprj)
- real(dp), allocatable :: vkbt(:,:),vkbst(:,:)
- logical :: sorted
+   integer :: ii,jj,kk,ierr,ik1,ik2,ip1,ip2,ipk,ll,l1,info,nn
+   real(dp) :: apk,sn,tt,qq1mxprj
+   real(dp) :: sovl(2*mxprj,2*mxprj),sovlev(2*mxprj),ascl(2*mxprj,2*mxprj),aso(2*mxprj,2*mxprj)
+   real(dp) :: asclst(2*mxprj,2*mxprj),wsclst(2*mxprj),asost(2*mxprj,2*mxprj),wsost(2*mxprj)
+   real(dp) :: asclt(2*mxprj,2*mxprj),asot(2*mxprj,2*mxprj)
+   real(dp) :: sphalf(2*mxprj,2*mxprj),smhalf(2*mxprj,2*mxprj)
+   real(dp) :: fscl(mxprj),fso(mxprj),work(10*mxprj)
+   real(dp), allocatable :: vkbt(:,:),vkbst(:,:)
+   logical :: sorted
 
- allocate(vkbt(mmax,2*mxprj),vkbst(mmax,2*mxprj))
+   allocate(vkbt(mmax,2*mxprj),vkbst(mmax,2*mxprj))
 
- do l1=1,lmax+1
-  ll=l1-1
+   do l1=1,lmax+1
+      ll=l1-1
 
-  if(ll==0) then
-   vsr(:,:,l1)=0.0d0
-   vso(:,:,l1)=0.0d0
-   esr(:,l1)=0.0d0
-   eso(:,l1)=0.0d0
-   if(nproj(l1)>=1) then
-    do ii=1,nproj(l1)
-     vsr(:,ii,l1)=vkb(:,ii,l1,1)
-     esr(ii,l1)=evkb(ii,l1,1)
-    end do
-   end if
-   cycle
-  end if
+      if(ll==0) then
+         vsr(:,:,l1)=0.0d0
+         vso(:,:,l1)=0.0d0
+         esr(:,l1)=0.0d0
+         eso(:,l1)=0.0d0
+         if(nproj(l1)>=1) then
+            do ii=1,nproj(l1)
+               vsr(:,ii,l1)=vkb(:,ii,l1,1)
+               esr(ii,l1)=evkb(ii,l1,1)
+            end do
+         end if
+         cycle
+      end if
 
-  nn=2*nproj(l1)
+      nn=2*nproj(l1)
 
-  fscl(1)=(ll+1)/dble(2*ll+1)
-  fscl(2)=ll/dble(2*ll+1)
-  fso(1)=2/dble(2*ll+1)
-  fso(2)=-2/dble(2*ll+1)
+      fscl(1)=(ll+1)/dble(2*ll+1)
+      fscl(2)=ll/dble(2*ll+1)
+      fso(1)=2/dble(2*ll+1)
+      fso(2)=-2/dble(2*ll+1)
 
 ! construct overlap matrix and diagonal energy matrices
 
-   sovl(:,:)=0.0d0 
-   ascl(:,:)=0.0d0 
-   aso(:,:)=0.0d0
-   vkbt(:,:)=0.0d0
+      sovl(:,:)=0.0d0
+      ascl(:,:)=0.0d0
+      aso(:,:)=0.0d0
+      vkbt(:,:)=0.0d0
 
-   do ik1=1,2
-    do ip1=1,nproj(l1)
-     ii=ip1+(ik1-1)*nproj(l1)
-     
-     ascl(ii,ii)=fscl(ik1)*evkb(ip1,l1,ik1)
-     aso(ii,ii)=fso(ik1)*evkb(ip1,l1,ik1)
+      do ik1=1,2
+         do ip1=1,nproj(l1)
+            ii=ip1+(ik1-1)*nproj(l1)
 
-     vkbt(:,ii)=vkb(:,ip1,l1,ik1)
+            ascl(ii,ii)=fscl(ik1)*evkb(ip1,l1,ik1)
+            aso(ii,ii)=fso(ik1)*evkb(ip1,l1,ik1)
 
-     do ik2=1,2
-      do ip2=1,nproj(l1)
-       jj=ip2+(ik2-1)*nproj(l1)
+            vkbt(:,ii)=vkb(:,ip1,l1,ik1)
 
-       call vpinteg(vkb(1,ip1,l1,ik1),vkb(1,ip2,l1,ik2),irc(l1),2*l1, &
-&                   sovl(ii,jj),rr)
+            do ik2=1,2
+               do ip2=1,nproj(l1)
+                  jj=ip2+(ik2-1)*nproj(l1)
 
+                  call vpinteg(vkb(1,ip1,l1,ik1),vkb(1,ip2,l1,ik2),irc(l1),2*l1, &
+                  &                   sovl(ii,jj),rr)
+
+               end do
+            end do
+         end do
       end do
-     end do
-    end do
-   end do
 
-   call dsyev( 'V', 'U', nn, sovl, 2*mxprj, sovlev, work, 10*mxprj, info )
+      call dsyev( 'V', 'U', nn, sovl, 2*mxprj, sovlev, work, 10*mxprj, info )
 
-   if(info .ne. 0) then
-    write(6,'(a,i4)') 'sr_so_r: S matrix eigenvalue ERROR, info=',info
-    stop
-   end if
+      if(info /= 0) then
+         write(6,'(a,i4)') 'sr_so_r: S matrix eigenvalue ERROR, info=',info
+         stop
+      end if
 
 ! construct S^(-1/2) AND s^(1/2)
 
-   do jj=1,nn
-    tt=sqrt(sovlev(jj))
-    do ii=1,nn
-     sphalf(ii,jj)=tt*sovl(ii,jj)
-     smhalf(ii,jj)=sovl(ii,jj)/tt
-    end do
-   end do
+      do jj=1,nn
+         tt=sqrt(sovlev(jj))
+         do ii=1,nn
+            sphalf(ii,jj)=tt*sovl(ii,jj)
+            smhalf(ii,jj)=sovl(ii,jj)/tt
+         end do
+      end do
 
 ! take linear combinations to form orthonormal basis functions
 
-   vkbst(:,:)=0.0d0
+      vkbst(:,:)=0.0d0
 
-   do jj=1,nn
-    do ii=1,nn
-     vkbst(:,jj)=vkbst(:,jj) + smhalf(ii,jj)*vkbt(:,ii)
-    end do
-   end do
+      do jj=1,nn
+         do ii=1,nn
+            vkbst(:,jj)=vkbst(:,jj) + smhalf(ii,jj)*vkbt(:,ii)
+         end do
+      end do
 
 ! construct A^(-1)* = S^(1/2)^T A^(-1) S^(1/2)
 
-     asclt(:,:)=0.0d0
-     asclst(:,:)=0.0d0
-     asot(:,:)=0.0d0
-     asost(:,:)=0.0d0
+      asclt(:,:)=0.0d0
+      asclst(:,:)=0.0d0
+      asot(:,:)=0.0d0
+      asost(:,:)=0.0d0
 
-     do ii=1,nn
-      do jj=1,nn
-       do kk=1,nn
-        asclt(ii,jj)=asclt(ii,jj)+ascl(ii,kk)*sphalf(kk,jj)
-        asot(ii,jj) =asot(ii,jj) + aso(ii,kk)*sphalf(kk,jj)
-       end do
+      do ii=1,nn
+         do jj=1,nn
+            do kk=1,nn
+               asclt(ii,jj)=asclt(ii,jj)+ascl(ii,kk)*sphalf(kk,jj)
+               asot(ii,jj) =asot(ii,jj) + aso(ii,kk)*sphalf(kk,jj)
+            end do
+         end do
       end do
-     end do
 
-     do ii=1,nn
-      do jj=1,nn
-       do kk=1,nn
-        asclst(ii,jj)=asclst(ii,jj)+asclt(kk,jj)*sphalf(kk,ii)
-        asost(ii,jj) =asost(ii,jj) + asot(kk,jj)*sphalf(kk,ii)
-       end do
+      do ii=1,nn
+         do jj=1,nn
+            do kk=1,nn
+               asclst(ii,jj)=asclst(ii,jj)+asclt(kk,jj)*sphalf(kk,ii)
+               asost(ii,jj) =asost(ii,jj) + asot(kk,jj)*sphalf(kk,ii)
+            end do
+         end do
       end do
-     end do
 
 ! find eigenvalues and eigenvectors of the A* matrices
 
 !      SUBROUTINE DSYEV( JOBZ, UPLO, N, A, LDA, W, WORK, LWORK, INFO )
 
-     call dsyev( 'V', 'U', nn, asclst, 2*mxprj, wsclst, work, 10*mxprj, info )
+      call dsyev( 'V', 'U', nn, asclst, 2*mxprj, wsclst, work, 10*mxprj, info )
 
-     if(info .ne. 0) then
-      write(6,'(a,i4)') 'sr_so_r: A* matrix eigenvalue ERROR, info=',info
-      stop
-     end if
+      if(info /= 0) then
+         write(6,'(a,i4)') 'sr_so_r: A* matrix eigenvalue ERROR, info=',info
+         stop
+      end if
 
-     call dsyev( 'V', 'U', nn,  asost, 2*mxprj,  wsost, work, 10*mxprj, info )
+      call dsyev( 'V', 'U', nn,  asost, 2*mxprj,  wsost, work, 10*mxprj, info )
 
 
-     if(info .ne. 0) then
-      write(6,'(a,i4)') 'sr_so_r: A* matrix eigenvalue ERROR, info=',info
-      stop
-     end if
+      if(info /= 0) then
+         write(6,'(a,i4)') 'sr_so_r: A* matrix eigenvalue ERROR, info=',info
+         stop
+      end if
 
 ! take linear combinations to form orthonormal projectors
 
-     vsr(:,:,l1)=0.0d0
-     vso(:,:,l1)=0.0d0
-     esr(:,l1)=0.0d0
-     eso(:,l1)=0.0d0
+      vsr(:,:,l1)=0.0d0
+      vso(:,:,l1)=0.0d0
+      esr(:,l1)=0.0d0
+      eso(:,l1)=0.0d0
 
-     do ii=1,nn
-      esr(ii,l1)=wsclst(ii)
-      eso(ii,l1)=  wsost(ii)
-      do jj=1,nn
-       vsr(:,ii,l1)=vsr(:,ii,l1) + asclst(jj,ii)*vkbst(:,jj)
-       vso(:,ii,l1)= vso(:,ii,l1) +   asost(jj,ii)*vkbst(:,jj)
+      do ii=1,nn
+         esr(ii,l1)=wsclst(ii)
+         eso(ii,l1)=  wsost(ii)
+         do jj=1,nn
+            vsr(:,ii,l1)=vsr(:,ii,l1) + asclst(jj,ii)*vkbst(:,jj)
+            vso(:,ii,l1)= vso(:,ii,l1) +   asost(jj,ii)*vkbst(:,jj)
+         end do
       end do
-     end do
 
 ! bubble-sort on coefficient magnitudes for scalar and then s-o
 ! (Yes, I know bubble-sort is the least-efficient sorting algorithm.)
 
-     do ii=1,100
-      sorted=.true.
-      do jj=2,nn
-       if(abs(esr(jj-1,l1))<abs(esr(jj,l1))) then
-        tt=esr(jj,l1)
-        vkbt(:,1)=vsr(:,jj,l1)
-        esr(jj,l1)=esr(jj-1,l1)
-        vsr(:,jj,l1)=vsr(:,jj-1,l1)
-        esr(jj-1,l1)=tt
-        vsr(:,jj-1,l1)=vkbt(:,1)
-        sorted=.false.
-       end if
+      do ii=1,100
+         sorted=.true.
+         do jj=2,nn
+            if(abs(esr(jj-1,l1))<abs(esr(jj,l1))) then
+               tt=esr(jj,l1)
+               vkbt(:,1)=vsr(:,jj,l1)
+               esr(jj,l1)=esr(jj-1,l1)
+               vsr(:,jj,l1)=vsr(:,jj-1,l1)
+               esr(jj-1,l1)=tt
+               vsr(:,jj-1,l1)=vkbt(:,1)
+               sorted=.false.
+            end if
+         end do
+         if(sorted) exit
       end do
-      if(sorted) exit
-     end do
-  
-     do ii=1,100
-      sorted=.true.
-      do jj=2,nn
-       if(abs(eso(jj-1,l1))<abs(eso(jj,l1))) then
-        tt=eso(jj,l1)
-        vkbt(:,1)=vso(:,jj,l1)
-        eso(jj,l1)=eso(jj-1,l1)
-        vso(:,jj,l1)=vso(:,jj-1,l1)
-        eso(jj-1,l1)=tt
-        vso(:,jj-1,l1)=vkbt(:,1)
-        sorted=.false.
-       end if
-      end do
-      if(sorted) exit
-     end do
 
-     write(6,'(/a,i2)') &
-&         ' Orthonormal scalar projector coefficients, l = ',ll
-     write(6,'(1p,6e12.4)') (esr(jj,l1),jj=1,nn)
-     write(6,'(/a,i2)') &
-&         ' Orthonormal spin-orbit projector coefficients, l = ',ll
-     write(6,'(1p,6e12.4)') (eso(jj,l1),jj=1,nn)
+      do ii=1,100
+         sorted=.true.
+         do jj=2,nn
+            if(abs(eso(jj-1,l1))<abs(eso(jj,l1))) then
+               tt=eso(jj,l1)
+               vkbt(:,1)=vso(:,jj,l1)
+               eso(jj,l1)=eso(jj-1,l1)
+               vso(:,jj,l1)=vso(:,jj-1,l1)
+               eso(jj-1,l1)=tt
+               vso(:,jj-1,l1)=vkbt(:,1)
+               sorted=.false.
+            end if
+         end do
+         if(sorted) exit
+      end do
+
+      write(6,'(/a,i2)') &
+      &         ' Orthonormal scalar projector coefficients, l = ',ll
+      write(6,'(1p,6e12.4)') (esr(jj,l1),jj=1,nn)
+      write(6,'(/a,i2)') &
+      &         ' Orthonormal spin-orbit projector coefficients, l = ',ll
+      write(6,'(1p,6e12.4)') (eso(jj,l1),jj=1,nn)
 
 ! Set sign of projectors (physically irrelevant) so that they are positive
 ! at their peak (needed for compaisons apparently)
 
-     do jj=1,nn
-       apk=0.0d0
-       do ii=1,mmax
-         if(abs(vso(ii,jj,l1))>apk) then
-           apk=abs(vso(ii,jj,l1))
-           ipk=ii
+      do jj=1,nn
+         apk=0.0d0
+         do ii=1,mmax
+            if(abs(vso(ii,jj,l1))>apk) then
+               apk=abs(vso(ii,jj,l1))
+               ipk=ii
+            end if
+         end do
+         if(vso(ipk,jj,l1)<0.0d0) then
+            vso(:,jj,l1)=-vso(:,jj,l1)
          end if
-       end do
-       if(vso(ipk,jj,l1)<0.0d0) then
-         vso(:,jj,l1)=-vso(:,jj,l1)
-       end if
-       apk=0.0d0
-       do ii=1,mmax
-         if(abs(vsr(ii,jj,l1))>apk) then
-           apk=abs(vsr(ii,jj,l1))
-           ipk=ii
+         apk=0.0d0
+         do ii=1,mmax
+            if(abs(vsr(ii,jj,l1))>apk) then
+               apk=abs(vsr(ii,jj,l1))
+               ipk=ii
+            end if
+         end do
+         if(vsr(ipk,jj,l1)<0.0d0) then
+            vsr(:,jj,l1)=-vsr(:,jj,l1)
          end if
-       end do
-       if(vsr(ipk,jj,l1)<0.0d0) then
-         vsr(:,jj,l1)=-vsr(:,jj,l1)
-       end if
-     end do
+      end do
 
- end do ! l1
+   end do  ! l1
 
- deallocate(vkbt,vkbst)
- return
- end subroutine sr_so_r
+   deallocate(vkbt,vkbst)
+   return
+end subroutine sr_so_r

--- a/src/sratom.f90
+++ b/src/sratom.f90
@@ -2,21 +2,21 @@
 ! Copyright (c) 1989-201r by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- subroutine sratom(na,la,ea,fa,rpk,nc,ncv,it,rhoc,rho, &
+subroutine sratom(na,la,ea,fa,rpk,nc,ncv,it,rhoc,rho, &
 &           rr,vi,zz,mmax,iexc,etot,ierr,srel)
 
 ! self-consistent scalar-relativistic all-electron atom
@@ -39,173 +39,173 @@
 !ierr  error flag
 !srel  .true. for scalar-relativistic, .false. for non-relativistic
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !Input variables
- 
- integer :: mmax,iexc,nc,ncv
- integer :: na(ncv),la(ncv)
- real(dp) :: zz
- real(dp) :: fa(ncv),rr(mmax)
- logical :: srel
+
+   integer :: mmax,iexc,nc,ncv
+   integer :: na(ncv),la(ncv)
+   real(dp) :: zz
+   real(dp) :: fa(ncv),rr(mmax)
+   logical :: srel
 
 !Output variables
- integer :: it,ierr
- real(dp) :: etot
- real(dp) :: ea(ncv),rpk(ncv)
- real(dp) :: rho(mmax),rhoc(mmax),vi(mmax)
+   integer :: it,ierr
+   real(dp) :: etot
+   real(dp) :: ea(ncv),rpk(ncv)
+   real(dp) :: rho(mmax),rhoc(mmax),vi(mmax)
 
 !Local function
- real(dp) :: tfapot
+   real(dp) :: tfapot
 
 !Local variables
- integer :: nin,mch
- real(dp) :: amesh,al
- real(dp) :: dr,eeel,eexc,et,rl,rl1,sd,sf,sn,eeig
- real(dp) :: thl,vn,zion
- integer :: ii,jj
- logical :: convg
+   integer :: nin,mch
+   real(dp) :: amesh,al
+   real(dp) :: dr,eeel,eexc,et,rl,rl1,sd,sf,sn,eeig
+   real(dp) :: thl,vn,zion
+   integer :: ii,jj
+   logical :: convg
 
- real(dp), allocatable :: u(:),up(:)
- real(dp), allocatable :: vo(:),vi1(:),vo1(:),vxc(:)
+   real(dp), allocatable :: u(:),up(:)
+   real(dp), allocatable :: vo(:),vi1(:),vo1(:),vxc(:)
 
 ! blend parameter for Anderson iterative potential mixing
- real(dp), parameter ::  bl=0.5d0
+   real(dp), parameter ::  bl=0.5d0
 
- allocate(u(mmax),up(mmax))
- allocate(vo(mmax),vi1(mmax),vo1(mmax),vxc(mmax))
+   allocate(u(mmax),up(mmax))
+   allocate(vo(mmax),vi1(mmax),vo1(mmax),vxc(mmax))
 
 ! why all this is necessary is unclear, but it seems to be
- u(:)=0.d0; up(:)=0.d0; vo(:)=0.d0; vi1(:)=0.d0; vo1(:)=0.d0; vxc(:)=0.d0
- dr=0.d0; eeel=0.d0; eexc=0.d0; et=0.d0; rl=0.d0; rl1=0.d0
- sd=0.d0; sf=0.d0; sn=0.d0; eeig=0.d0; thl=0.d0; vn=0.d0; zion=0.d0 
- nin=0; mch=0
+   u(:)=0.d0; up(:)=0.d0; vo(:)=0.d0; vi1(:)=0.d0; vo1(:)=0.d0; vxc(:)=0.d0
+   dr=0.d0; eeel=0.d0; eexc=0.d0; et=0.d0; rl=0.d0; rl1=0.d0
+   sd=0.d0; sf=0.d0; sn=0.d0; eeig=0.d0; thl=0.d0; vn=0.d0; zion=0.d0
+   nin=0; mch=0
 
- al = 0.01d0 * dlog(rr(101) / rr(1))
- amesh = dexp(al)
+   al = 0.01d0 * dlog(rr(101) / rr(1))
+   amesh = dexp(al)
 
- do ii=1,mmax
-  vi(ii)=tfapot(rr(ii),zz)
- end do
+   do ii=1,mmax
+      vi(ii)=tfapot(rr(ii),zz)
+   end do
 
 ! starting approximation for energies
- sf=0.0d0
- do ii=1,ncv
-   sf=sf+fa(ii)
-   zion=zz+1.0d0-sf
-   ea(ii)=-0.5d0*(zion/na(ii))**2
-   if(ea(ii)>vi(mmax)) ea(ii)=2.0d0*vi(mmax)
- end do
+   sf=0.0d0
+   do ii=1,ncv
+      sf=sf+fa(ii)
+      zion=zz+1.0d0-sf
+      ea(ii)=-0.5d0*(zion/na(ii))**2
+      if(ea(ii)>vi(mmax)) ea(ii)=2.0d0*vi(mmax)
+   end do
 
 ! big self  self-consietency loop
 
- do it=1,100
-   convg=.true.
+   do it=1,100
+      convg=.true.
 
-   rhoc(:) = 0.0d0
-   rho(:)=0.0d0
+      rhoc(:) = 0.0d0
+      rho(:)=0.0d0
 
 ! solve for bound states in turn
-   eeig=0.0d0
-   do ii=1,ncv
+      eeig=0.0d0
+      do ii=1,ncv
 
 ! skip unoccupied states
-     if(fa(ii)==0.0d0) then
-       ea(ii)=0.0d0
-       cycle
-     end if
-     et=ea(ii)
-     ierr = 0
-     call lschfb(na(ii),la(ii),ierr,et, &
-&                rr,vi,u,up,zz,mmax,mch,srel)
-     if(ierr .ne. 0) then
-       write(6,'(/a,3i4)') 'sratom123: lschfb convergence ERROR n,l,iter=', &
-&       na(ii),la(ii),it
-       stop
-     end if
+         if(fa(ii)==0.0d0) then
+            ea(ii)=0.0d0
+            cycle
+         end if
+         et=ea(ii)
+         ierr = 0
+         call lschfb(na(ii),la(ii),ierr,et, &
+         &                rr,vi,u,up,zz,mmax,mch,srel)
+         if(ierr /= 0) then
+            write(6,'(/a,3i4)') 'sratom123: lschfb convergence ERROR n,l,iter=', &
+            &       na(ii),la(ii),it
+            stop
+         end if
 
 ! overall convergence criterion based on eps within lschfb
-     if(ea(ii)/= et) convg=.false.
-     ea(ii)=et
+         if(ea(ii)/= et) convg=.false.
+         ea(ii)=et
 
 ! accumulate charge and eigenvalues
-     eeig = eeig + fa(ii) * ea(ii)
-     rho(:)=rho(:) + fa(ii)*(u(:)/rr(:))**2
-     if(ii<=nc) then
-       rhoc(:)=rhoc(:) + fa(ii)*(u(:)/rr(:))**2
-     end if
+         eeig = eeig + fa(ii) * ea(ii)
+         rho(:)=rho(:) + fa(ii)*(u(:)/rr(:))**2
+         if(ii<=nc) then
+            rhoc(:)=rhoc(:) + fa(ii)*(u(:)/rr(:))**2
+         end if
 
 
 ! find outermost peak of wavefunction
-     do jj=mch-1,1,-1
-       if(up(jj)*up(jj+1)<0.0d0) then
-         rpk(ii)=rr(jj)
+         do jj=mch-1,1,-1
+            if(up(jj)*up(jj+1)<0.0d0) then
+               rpk(ii)=rr(jj)
+               exit
+            end if
+         end do
+
+      end do
+
+      if(ierr/=0) then
          exit
-       end if
-     end do
-
-   end do
-
-   if(ierr/=0) then
-    exit
-   end if
+      end if
 
 
 ! output potential
-   call vout(0,rho,rhoc,vo,vxc,sf-zz,eeel,eexc, &
-&            rr,mmax,iexc)
+      call vout(0,rho,rhoc,vo,vxc,sf-zz,eeel,eexc, &
+      &            rr,mmax,iexc)
 
-  etot =  eeig + eexc - 0.5d0*eeel
+      etot =  eeig + eexc - 0.5d0*eeel
 
 ! generate next iteration using d. g. anderson''s
 ! method
-   thl=0.0d0
-   if(it>1) then
-     sn=0.0d0
-     sd=0.0d0
-     do ii=1,mmax
-       rl=vo(ii)-vi(ii)
-       rl1=vo1(ii)-vi1(ii)
-       dr=rl-rl1
-       sn=sn + rl*dr*rr(ii)**2
-       sd=sd + dr*dr*rr(ii)**2
-     end do
-     thl=sn/sd
+      thl=0.0d0
+      if(it>1) then
+         sn=0.0d0
+         sd=0.0d0
+         do ii=1,mmax
+            rl=vo(ii)-vi(ii)
+            rl1=vo1(ii)-vi1(ii)
+            dr=rl-rl1
+            sn=sn + rl*dr*rr(ii)**2
+            sd=sd + dr*dr*rr(ii)**2
+         end do
+         thl=sn/sd
+      end if
+
+      do ii=1,mmax
+         vn=(1.0d0-bl)*((1.0d0-thl)*vi(ii) + thl*vi1(ii)) &
+         &   + bl*((1.0d0-thl)*vo(ii) + thl*vo1(ii))
+         vi1(ii)=vi(ii)
+         vo1(ii)=vo(ii)
+         vi(ii)=vn
+      end do
+
+      if(convg) exit
+
+      if(it==100 .and. .not. convg) then
+         write(6,'(/a)') 'sratom: WARNING failed to converge'
+      end if
+
+   end do  !it
+
+   if(.not. convg .and. ierr==0) then
+      ierr=100
    end if
-
-   do ii=1,mmax
-     vn=(1.0d0-bl)*((1.0d0-thl)*vi(ii) + thl*vi1(ii)) &
-  &   + bl*((1.0d0-thl)*vo(ii) + thl*vo1(ii))
-     vi1(ii)=vi(ii)
-     vo1(ii)=vo(ii)
-     vi(ii)=vn
-   end do
-
-   if(convg) exit
-
-   if(it==100 .and. .not. convg) then
-     write(6,'(/a)') 'sratom: WARNING failed to converge'
-   end if
-
- end do !it
-
- if(.not. convg .and. ierr==0) then
-   ierr=100
- end if
 
 ! total energy output
 
 ! output potential for e-e interactions
 
- call vout(0,rho,rhoc,vo,vxc,sf,eeel,eexc, &
-&          rr,mmax,iexc)
+   call vout(0,rho,rhoc,vo,vxc,sf,eeel,eexc, &
+   &          rr,mmax,iexc)
 
- etot =  eeig + eexc - 0.5d0*eeel
+   etot =  eeig + eexc - 0.5d0*eeel
 
 
- deallocate(u,up)
- deallocate(vo,vi1,vo1,vxc)
- return
+   deallocate(u,up)
+   deallocate(vo,vi1,vo1,vxc)
+   return
 
- end subroutine sratom
+end subroutine sratom

--- a/src/tfapot.f90
+++ b/src/tfapot.f90
@@ -2,57 +2,55 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
 ! tfapot
- function tfapot(rr,zz)
+function tfapot(rr,zz)
 
 ! generalized Thomas-Fermi atomic potential
 
-!...to an article of N. H. March ( "The Thomas-Fermi Approximation in 
+!...to an article of N. H. March ( "The Thomas-Fermi Approximation in
 ! Quantum Mechanics", Adv. Phys. 6, 1 (1957)). He has the formula,
-! but it is not the result of his work. The original publication is: 
+! but it is not the result of his work. The original publication is:
 !     R. Latter, Phys. Rev. 99, 510 (1955).
-! He says that it''s an analytic fit to an improved calculation of the 
-! potential distribution of a Thomas-Fermi atom without exchange first 
+! He says that it''s an analytic fit to an improved calculation of the
+! potential distribution of a Thomas-Fermi atom without exchange first
 ! performed by Miranda (C. Miranda, Mem. Acc. Italia 5, 285 (1934)).
 !                                 Alexander Seidl, TU Munich
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !Input variables
- real(dp) :: rr,zz
- 
+   real(dp) :: rr,zz
+
 !Output function
- real(dp) :: tfapot
+   real(dp) :: tfapot
 
 !Local variables
- real(dp) :: bb,tt,xx,xs
+   real(dp) :: bb,tt,xx,xs
 
- bb=(0.69395656d0/zz)**.33333333d0
- xx=rr/bb
- xs=sqrt(xx)
+   bb=(0.69395656d0/zz)**.33333333d0
+   xx=rr/bb
+   xs=sqrt(xx)
 
- tt=zz/(1.0d0+xs*(0.02747d0 - xx*(0.1486d0 - 0.007298d0*xx)) &
-&   + xx*(1.243d0 + xx*(0.2302d0 + 0.006944d0*xx)))
+   tt=zz/(1.0d0+xs*(0.02747d0 - xx*(0.1486d0 - 0.007298d0*xx)) &
+   &   + xx*(1.243d0 + xx*(0.2302d0 + 0.006944d0*xx)))
 
- if(tt<1.0d0) tt=1.0d0
- tfapot=-tt/rr
+   if(tt<1.0d0) tt=1.0d0
+   tfapot=-tt/rr
 
- return
- end function tfapot
-
-
+   return
+end function tfapot

--- a/src/upfout.f90
+++ b/src/upfout.f90
@@ -2,24 +2,24 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
 ! interpolates various arrays onto linear radial mesh to create file
 ! for PWSCF input using the UPF file format
 
- subroutine upfout(lmax,lloc,rc,vkb,evkb,nproj,rr,vpuns,rho,rhomod, &
+subroutine upfout(lmax,lloc,rc,vkb,evkb,nproj,rr,vpuns,rho,rhomod, &
 &                  zz,zion,mmax,mxprj,iexc,icmod,nrl,drl,atsym,epstot, &
 &                  na,la,ncon,nbas,nvcnf,nacnf,lacnf,nc,nv,lpopt,ncnf, &
 &                  fa,rc0,ep,qcut,debl,facnf,dvloc0,fcfact,rcfact, &
@@ -33,7 +33,7 @@
 !evkb  coefficients of VKB projectors
 !nproj  number of vkb projectors for each l
 !rr  log radial grid
-!vpuns  unscreened semi-local pseudopotentials (vp(:,5) is local potential 
+!vpuns  unscreened semi-local pseudopotentials (vp(:,5) is local potential
 !  if linear combination is used)
 !rho  valence pseudocharge
 !rhomod  model core charge
@@ -55,288 +55,288 @@
 !uupsa  pseudo-atomic orbital array
 !ea  psuedo-orbital eigenvalues
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
- real(dp), parameter :: pi=3.141592653589793238462643383279502884197_dp
+   real(dp), parameter :: pi=3.141592653589793238462643383279502884197_dp
 
 !Input variables
- integer :: lmax,lloc,iexc,mmax,mxprj,nrl,icmod
- integer :: nproj(6)
- real(dp) :: drl,fcfact,rcfact,zz,zion,epstot
- real(dp) :: rr(mmax),vpuns(mmax,5),rho(mmax),vkb(mmax,mxprj,4)
- real(dp) :: rhomod(mmax,5)
- real(dp):: rc(6),evkb(mxprj,4)
- character*2 :: atsym
- real(dp) :: uupsa(mmax,nv)
+   integer :: lmax,lloc,iexc,mmax,mxprj,nrl,icmod
+   integer :: nproj(6)
+   real(dp) :: drl,fcfact,rcfact,zz,zion,epstot
+   real(dp) :: rr(mmax),vpuns(mmax,5),rho(mmax),vkb(mmax,mxprj,4)
+   real(dp) :: rhomod(mmax,5)
+   real(dp):: rc(6),evkb(mxprj,4)
+   character(len=2) :: atsym
+   real(dp) :: uupsa(mmax,nv)
 
 !additional input for upf output to echo input file, all as defined
 ! in the main progam
- integer :: na(30),la(30),ncon(6),nbas(6)
- integer :: nvcnf(5),nacnf(30,5),lacnf(30,5)
- integer :: nc,nv,lpopt,ncnf
- real(dp) :: fa(30),rc0(6),ep(6),qcut(6),debl(6),facnf(30,5),ea(30)
- real(dp) :: dvloc0,epsh1,epsh2,depsh,rlmax
- character*4 :: psfile
+   integer :: na(30),la(30),ncon(6),nbas(6)
+   integer :: nvcnf(5),nacnf(30,5),lacnf(30,5)
+   integer :: nc,nv,lpopt,ncnf
+   real(dp) :: fa(30),rc0(6),ep(6),qcut(6),debl(6),facnf(30,5),ea(30)
+   real(dp) :: dvloc0,epsh1,epsh2,depsh,rlmax
+   character(len=4) :: psfile
 
 !Output variables - printing only
 
 !Local variables
- integer :: ii,jj,ll,l1,iproj,ntotproj,nrlproj
- integer :: dtime(8)
- real(dp) :: al,nrmsum,uurcut
- real(dp), allocatable :: rhomodl(:,:),dmat(:,:)
- real(dp),allocatable :: rhol(:),rl(:),vkbl(:,:,:),vpl(:,:),uual(:,:)
- character*5 :: lnames
- character*2 :: pspd(3)
+   integer :: ii,jj,ll,l1,iproj,ntotproj,nrlproj
+   integer :: dtime(8)
+   real(dp) :: al,nrmsum,uurcut
+   real(dp), allocatable :: rhomodl(:,:),dmat(:,:)
+   real(dp),allocatable :: rhol(:),rl(:),vkbl(:,:,:),vpl(:,:),uual(:,:)
+   character(len=5) :: lnames
+   character(len=2) :: pspd(3)
 
- lnames = "SPDFG"
+   lnames = "SPDFG"
 
 ! adjust nrl to properly accomodate atomic orbitals
- al = dlog(rr(2)/rr(1))
- uurcut = 0.d0
- do ii=1,nv
-   nrmsum = 0.d0
-   do jj=mmax-1,1,-1
-     nrmsum = nrmsum + (uupsa(jj,ii)**2) * rr(jj)*al
-     if (nrmsum > 1.d-6) then
-       exit  ! Cutoff radius such that uu norm accurate to 10^-6
-     end if
+   al = dlog(rr(2)/rr(1))
+   uurcut = 0.d0
+   do ii=1,nv
+      nrmsum = 0.d0
+      do jj=mmax-1,1,-1
+         nrmsum = nrmsum + (uupsa(jj,ii)**2) * rr(jj)*al
+         if (nrmsum > 1.d-6) then
+            exit  ! Cutoff radius such that uu norm accurate to 10^-6
+         end if
+      end do
+      if (rr(jj) > uurcut) uurcut = rr(jj)
    end do
-   if (rr(jj) > uurcut) uurcut = rr(jj)  
- end do
- if (uurcut > drl*dble(nrl-1)) then
-   nrl = 1 + uurcut/drl
-   if(mod(nrl,2)/=0) nrl=nrl+1
-   write(6,'(a,i5,a,f10.5)') "Updating nrl = ", nrl, " for uurcut = ", uurcut
- end if
+   if (uurcut > drl*dble(nrl-1)) then
+      nrl = 1 + uurcut/drl
+      if(mod(nrl,2)/=0) nrl=nrl+1
+      write(6,'(a,i5,a,f10.5)') "Updating nrl = ", nrl, " for uurcut = ", uurcut
+   end if
 
- allocate(rhol(nrl),rl(nrl),vkbl(nrl,mxprj,4),vpl(nrl,5),rhomodl(nrl,5),uual(nrl,nv))
+   allocate(rhol(nrl),rl(nrl),vkbl(nrl,mxprj,4),vpl(nrl,5),rhomodl(nrl,5),uual(nrl,nv))
 
 ! interpolation of everything onto linear output mesh
 
- do  ii=1,nrl
-   rl(ii)=drl*dble(ii-1)
- end do
+   do  ii=1,nrl
+      rl(ii)=drl*dble(ii-1)
+   end do
 !
- do l1=1,max(lmax+1,lloc+1)
-   call dpnint(rr,vpuns(1,l1),mmax,rl,vpl(1,l1),nrl)
+   do l1=1,max(lmax+1,lloc+1)
+      call dpnint(rr,vpuns(1,l1),mmax,rl,vpl(1,l1),nrl)
 ! override dpnint extrapolation to zero for vpl
-   vpl(1,l1)=vpuns(1,l1)
-   if(l1 .ne. lloc + 1) then
+      vpl(1,l1)=vpuns(1,l1)
+      if(l1 /= lloc + 1) then
 
-     call dpnint(rr,vkb(1,1,l1),mmax,rl,vkbl(1,1,l1),nrl)
-     call dpnint(rr,vkb(1,2,l1),mmax,rl,vkbl(1,2,l1),nrl)
+         call dpnint(rr,vkb(1,1,l1),mmax,rl,vkbl(1,1,l1),nrl)
+         call dpnint(rr,vkb(1,2,l1),mmax,rl,vkbl(1,2,l1),nrl)
 
+      end if
+   end do
+
+   call dpnint(rr,rho,mmax,rl,rhol,nrl)
+
+   do jj=1,5
+      call dpnint(rr,rhomod(1,jj),mmax,rl,rhomodl(1,jj),nrl)
+   end do
+
+   do ii=1,nv
+      call dpnint(rr,uupsa(1,ii),mmax,rl,uual(1,ii),nrl)
+   end do
+
+   call date_and_time(VALUES=dtime)
+   ii=dtime(1)-2000
+   if(ii<10) then
+      write(pspd(1),'(a,i1)') '0',ii
+   else
+      write(pspd(1),'(i2)') ii
    end if
- end do
-
- call dpnint(rr,rho,mmax,rl,rhol,nrl)
-
- do jj=1,5
-   call dpnint(rr,rhomod(1,jj),mmax,rl,rhomodl(1,jj),nrl)
- end do
-
- do ii=1,nv
-   call dpnint(rr,uupsa(1,ii),mmax,rl,uual(1,ii),nrl)
- end do
-
- call date_and_time(VALUES=dtime)
- ii=dtime(1)-2000
- if(ii<10) then
-   write(pspd(1),'(a,i1)') '0',ii
- else
-   write(pspd(1),'(i2)') ii
- end if
- ii=dtime(2)
- if(ii<10) then
-   write(pspd(2),'(a,i1)') '0',ii
- else
-   write(pspd(2),'(i2)') ii
- end if
- ii=dtime(3)
- if(ii<10) then
-   write(pspd(3),'(a,i1)') '0',ii
- else
-   write(pspd(3),'(i2)') ii
- end if
+   ii=dtime(2)
+   if(ii<10) then
+      write(pspd(2),'(a,i1)') '0',ii
+   else
+      write(pspd(2),'(i2)') ii
+   end if
+   ii=dtime(3)
+   if(ii<10) then
+      write(pspd(3),'(a,i1)') '0',ii
+   else
+      write(pspd(3),'(i2)') ii
+   end if
 
 ! section for upf output for pwscf
 
- write(6,'(/a)') 'Begin PSP_UPF'
+   write(6,'(/a)') 'Begin PSP_UPF'
 
- write(6,'(a,/a)') &
-&      '<UPF version="2.0.1">', &
-&      '  <PP_INFO>'
- write(6,'(/t2,a/t2,a/t2,a/t2,a/t2,a/t2,a//)') &
-       'This pseudopotential file has been produced using the code', &
-&      'ONCVPSP  (Optimized Norm-Conservinng Vanderbilt PSeudopotential)', &
-&      'scalar-relativistic version 4.0.1 06/20/2107 by D. R. Hamann', &
-&      'The code is available through a link at URL www.mat-simresearch.com.', &
-&      'Documentation with the package provides a full discription of the', &
-&      'input data below.'
+   write(6,'(a,/a)') &
+   &      '<UPF version="2.0.1">', &
+   &      '  <PP_INFO>'
+   write(6,'(/t2,a/t2,a/t2,a/t2,a/t2,a/t2,a//)') &
+      'This pseudopotential file has been produced using the code', &
+   &      'ONCVPSP  (Optimized Norm-Conservinng Vanderbilt PSeudopotential)', &
+   &      'scalar-relativistic version 4.0.1 06/20/2107 by D. R. Hamann', &
+   &      'The code is available through a link at URL www.mat-simresearch.com.', &
+   &      'Documentation with the package provides a full discription of the', &
+   &      'input data below.'
 
- write(6,'(t2,a/t2,a/t2,a/t2,a//)') &
-&      'While it is not required under the terms of the GNU GPL, it is',&
-&      'suggested that you cite D. R. Hamann, Phys. Rev. B 88, 085117 (2013)',&
-&      'in any publication using these pseudopotentials.' 
+   write(6,'(t2,a/t2,a/t2,a/t2,a//)') &
+   &      'While it is not required under the terms of the GNU GPL, it is',&
+   &      'suggested that you cite D. R. Hamann, Phys. Rev. B 88, 085117 (2013)',&
+   &      'in any publication using these pseudopotentials.'
 
- write(6,'(a)') &
-&      '    <PP_INPUTFILE>'
+   write(6,'(a)') &
+   &      '    <PP_INPUTFILE>'
 
 ! output printing (echos input data)
 
- write(6,'(a)') '# ATOM AND REFERENCE CONFIGURATION'
- write(6,'(a)') '# atsym  z   nc   nv     iexc    psfile'
- write(6,'(a,a,f6.2,2i5,i8,2a)') '  ',trim(atsym),zz,nc,nv,iexc, &
-&      '      ',trim(psfile)
- write(6,'(a/a)') '#','#   n    l    f        energy (Ha)'
- do ii=1,nc+nv
-   write(6,'(2i5,f8.2)') na(ii),la(ii),fa(ii)
- end do
-
- write(6,'(a/a/a)') '#','# PSEUDOPOTENTIAL AND OPTIMIZATION','# lmax'
- write(6,'(i5)')  lmax
- write(6,'(a/a)') '#','#   l,   rc,      ep,       ncon, nbas, qcut'
- do l1=1,lmax+1
-   write(6,'(i5,2f10.5,2i5,f10.5)') l1-1,rc0(l1),ep(l1),ncon(l1),&
-&        nbas(l1),qcut(l1)
- end do
-
- write(6,'(a/a/a,a)') '#','# LOCAL POTENTIAL','# lloc, lpopt,  rc(5),', &
-&      '   dvloc0'
- write(6,'(2i5,f10.5,a,f10.5)') lloc,lpopt,rc0(5),'   ',dvloc0
-
- write(6,'(a/a/a)') '#','# VANDERBILT-KLEINMAN-BYLANDER PROJECTORs', &
-&      '# l, nproj, debl'
- do l1=1,lmax+1
-   write(6,'(2i5,f10.5)') l1-1,nproj(l1),debl(l1)
- end do
-
- write(6,'(a/a/a)') '#','# MODEL CORE CHARGE', &
-&      '# icmod, fcfact, rcfact'
- write(6,'(i5,2f10.5)') icmod,fcfact,rcfact
-
- write(6,'(a/a/a)') '#','# LOG DERIVATIVE ANALYSIS', &
-&      '# epsh1, epsh2, depsh'
- write(6,'(3f8.2)') epsh1,epsh2,depsh
-
- write(6,'(a/a/a)') '#','# OUTPUT GRID','# rlmax, drl'
- write(6,'(2f8.2)') rlmax,drl
-
- write(6,'(a/a/a)') '#','# TEST CONFIGURATIONS','# ncnf'
- write(6,'(i5)') ncnf
- write(6,'(a/a)') '# nvcnf','#   n    l    f'
- do jj=2,ncnf+1
-   write(6,'(i5)') nvcnf(jj)
-   do ii=nc+1,nc+nvcnf(jj)
-     write(6,'(2i5,f8.2)') nacnf(ii,jj),lacnf(ii,jj),facnf(ii,jj)
+   write(6,'(a)') '# ATOM AND REFERENCE CONFIGURATION'
+   write(6,'(a)') '# atsym  z   nc   nv     iexc    psfile'
+   write(6,'(a,a,f6.2,2i5,i8,2a)') '  ',trim(atsym),zz,nc,nv,iexc, &
+   &      '      ',trim(psfile)
+   write(6,'(a/a)') '#','#   n    l    f        energy (Ha)'
+   do ii=1,nc+nv
+      write(6,'(2i5,f8.2)') na(ii),la(ii),fa(ii)
    end do
-   write(6,'(a)') '#'
- end do
- write(6,'(a)') &
-&      '    </PP_INPUTFILE>'
 
- write(6,'(a,3(/a))') &
-&      '  </PP_INFO>', &
-&      '  <!--                               -->', &
-&      '  <!-- END OF HUMAN READABLE SECTION -->', &
-&      '  <!--                               -->'
+   write(6,'(a/a/a)') '#','# PSEUDOPOTENTIAL AND OPTIMIZATION','# lmax'
+   write(6,'(i5)')  lmax
+   write(6,'(a/a)') '#','#   l,   rc,      ep,       ncon, nbas, qcut'
+   do l1=1,lmax+1
+      write(6,'(i5,2f10.5,2i5,f10.5)') l1-1,rc0(l1),ep(l1),ncon(l1),&
+      &        nbas(l1),qcut(l1)
+   end do
 
- write(6,'(a)') &
-&      '    <PP_HEADER'
+   write(6,'(a/a/a,a)') '#','# LOCAL POTENTIAL','# lloc, lpopt,  rc(5),', &
+   &      '   dvloc0'
+   write(6,'(2i5,f10.5,a,f10.5)') lloc,lpopt,rc0(5),'   ',dvloc0
+
+   write(6,'(a/a/a)') '#','# VANDERBILT-KLEINMAN-BYLANDER PROJECTORs', &
+   &      '# l, nproj, debl'
+   do l1=1,lmax+1
+      write(6,'(2i5,f10.5)') l1-1,nproj(l1),debl(l1)
+   end do
+
+   write(6,'(a/a/a)') '#','# MODEL CORE CHARGE', &
+   &      '# icmod, fcfact, rcfact'
+   write(6,'(i5,2f10.5)') icmod,fcfact,rcfact
+
+   write(6,'(a/a/a)') '#','# LOG DERIVATIVE ANALYSIS', &
+   &      '# epsh1, epsh2, depsh'
+   write(6,'(3f8.2)') epsh1,epsh2,depsh
+
+   write(6,'(a/a/a)') '#','# OUTPUT GRID','# rlmax, drl'
+   write(6,'(2f8.2)') rlmax,drl
+
+   write(6,'(a/a/a)') '#','# TEST CONFIGURATIONS','# ncnf'
+   write(6,'(i5)') ncnf
+   write(6,'(a/a)') '# nvcnf','#   n    l    f'
+   do jj=2,ncnf+1
+      write(6,'(i5)') nvcnf(jj)
+      do ii=nc+1,nc+nvcnf(jj)
+         write(6,'(2i5,f8.2)') nacnf(ii,jj),lacnf(ii,jj),facnf(ii,jj)
+      end do
+      write(6,'(a)') '#'
+   end do
+   write(6,'(a)') &
+   &      '    </PP_INPUTFILE>'
+
+   write(6,'(a,3(/a))') &
+   &      '  </PP_INFO>', &
+   &      '  <!--                               -->', &
+   &      '  <!-- END OF HUMAN READABLE SECTION -->', &
+   &      '  <!--                               -->'
+
+   write(6,'(a)') &
+   &      '    <PP_HEADER'
 
    write(6,'(t8,a)') &
-&        'generated="Generated using ONCVPSP code by D. R. Hamann"'
+   &        'generated="Generated using ONCVPSP code by D. R. Hamann"'
    write(6,'(t8,a)') &
-&        'author="anonymous"'
+   &        'author="anonymous"'
    write(6,'(t8,5a)') &
-&        'date="',pspd(:),'"'
+   &        'date="',pspd(:),'"'
    write(6,'(t8,a)') &
-&        'comment=""'
+   &        'comment=""'
    write(6,'(t8,a,a2,a)') &
-&        'element="',atsym,'"'
+   &        'element="',atsym,'"'
    write(6,'(t8,a)') &
-&        'pseudo_type="NC"'
+   &        'pseudo_type="NC"'
    write(6,'(t8,a)') &
-&        'relativistic="scalar"'
+   &        'relativistic="scalar"'
    write(6,'(t8,a)') &
-&        'is_ultrasoft="F"'
+   &        'is_ultrasoft="F"'
    write(6,'(t8,a)') &
-&        'is_paw="F"'
+   &        'is_paw="F"'
    write(6,'(t8,a)') &
-&        'is_coulomb="F"'
+   &        'is_coulomb="F"'
    write(6,'(t8,a)') &
-&        'has_so="F"'
+   &        'has_so="F"'
    write(6,'(t8,a)') &
-&        'has_wfc="F"'
+   &        'has_wfc="F"'
    write(6,'(t8,a)') &
-&        'has_gipaw="F"'
+   &        'has_gipaw="F"'
 
    if(icmod>=1) then
-     write(6,'(t8,a)') &
-&        'core_correction="T"'
+      write(6,'(t8,a)') &
+      &        'core_correction="T"'
    else
-     write(6,'(t8,a)') &
-&        'core_correction="F"'
+      write(6,'(t8,a)') &
+      &        'core_correction="F"'
    end if
 
    if(iexc==3 .or. iexc==-001009) then
-     write(6,'(t8,a)') &
-&        'functional="PZ"'
+      write(6,'(t8,a)') &
+      &        'functional="PZ"'
 
    else if(iexc==4 .or. iexc==-101130) then
-     write(6,'(t8,a)') &
-&        'functional="PBE"'
+      write(6,'(t8,a)') &
+      &        'functional="PBE"'
 
    else if(iexc==-109134) then
-     write(6,'(t8,a)') &
-&        'functional="PW91"'
+      write(6,'(t8,a)') &
+      &        'functional="PW91"'
 
    else if(iexc==-116133) then
-     write(6,'(t8,a)') &
-&        'functional="PBESOL"'
+      write(6,'(t8,a)') &
+      &        'functional="PBESOL"'
 
    else if(iexc==-102130) then
-     write(6,'(t8,a)') &
-&        'functional="REVPBE"'
+      write(6,'(t8,a)') &
+      &        'functional="REVPBE"'
 
    else if(iexc==-106132) then
-     write(6,'(t8,a)') &
-&        'functional="BP"'
+      write(6,'(t8,a)') &
+      &        'functional="BP"'
 
    else if(iexc==-106131) then
-     write(6,'(t8,a)') &
-&        'functional="BLYP"'
+      write(6,'(t8,a)') &
+      &        'functional="BLYP"'
 
    else if(iexc==-118130) then
-     write(6,'(t8,a)') &
-&        'functional="WC"'
+      write(6,'(t8,a)') &
+      &        'functional="WC"'
 
    else
-     write(6,'(t8,a)') &
-&        'upfout: ERROR iexc = ',iexc,' is presently unsupported for UPF output'
-     stop
+      write(6,'(t8,a)') &
+      &        'upfout: ERROR iexc = ',iexc,' is presently unsupported for UPF output'
+      stop
    end if
 
    write(6,'(t8,a,f8.2,a)') &
-&        'z_valence="',zion,'"'
+   &        'z_valence="',zion,'"'
 
    write(6,'(t8,a,1p,e20.11,a)') &
-&        'total_psenergy="',2*epstot,'"'
+   &        'total_psenergy="',2*epstot,'"'
 
    write(6,'(t8,a,1p,e20.11,a)') &
-&        'rho_cutoff="',rl(nrl),'"'
+   &        'rho_cutoff="',rl(nrl),'"'
 
    write(6,'(t8,a,i1,a)') &
-&        'l_max="',lmax,'"'
+   &        'l_max="',lmax,'"'
 
    if(lloc==4) then
-     write(6,'(t8,a)') &
-&        'l_local="-1"'
+      write(6,'(t8,a)') &
+      &        'l_local="-1"'
    else
-     write(6,'(t8,a,i1,a)') &
-&        'l_local="',lloc,'"'
+      write(6,'(t8,a,i1,a)') &
+      &        'l_local="',lloc,'"'
    end if
 
 ! calculate total number of projectors and maximum linear mesh point for
@@ -345,10 +345,10 @@
    ntotproj=0
    nrlproj=0
    do l1=1,lmax+1
-     if(l1/=lloc+1) then
-       ntotproj=ntotproj+nproj(l1)
-     end if
-     nrlproj=max(nrlproj,4+int(rc(l1)/drl))
+      if(l1/=lloc+1) then
+         ntotproj=ntotproj+nproj(l1)
+      end if
+      nrlproj=max(nrlproj,4+int(rc(l1)/drl))
    end do
 
    allocate(dmat(ntotproj,ntotproj))
@@ -357,165 +357,165 @@
    if(mod(nrlproj,4)/=0) nrlproj=nrlproj+2  !make divisible by 4 to use for 0 compression below
 
    write(6,'(t8,a,i6,a)') &
-&        'mesh_size="',nrl,'"'
+   &        'mesh_size="',nrl,'"'
 
    write(6,'(t8,a,i1,a)') &
-&        'number_of_wfc="',nv,'"'
+   &        'number_of_wfc="',nv,'"'
 
    write(6,'(t8,a,i1,a)') &
-&        'number_of_proj="',ntotproj,'"/>' !end of PP_HEADER
+   &        'number_of_proj="',ntotproj,'"/>'  !end of PP_HEADER
 
    write(6,'(t2,a)') &
-&        '<PP_MESH>'
+   &        '<PP_MESH>'
 
- write(6,'(t4,a,i4,a)') &
-&      '<PP_R type="real"  size="',nrl,'" columns="8">'
+   write(6,'(t4,a,i4,a)') &
+   &      '<PP_R type="real"  size="',nrl,'" columns="8">'
 
- write(6,'(8f10.4)') (rl(ii),ii=1,nrl)
+   write(6,'(8f10.4)') (rl(ii),ii=1,nrl)
 
- write(6,'(t4,a)') &
-&      '</PP_R>'
+   write(6,'(t4,a)') &
+   &      '</PP_R>'
 
- write(6,'(t4,a,i4,a)') &
-&      '<PP_RAB type="real"  size="',nrl,'" columns="8">'
+   write(6,'(t4,a,i4,a)') &
+   &      '<PP_RAB type="real"  size="',nrl,'" columns="8">'
 
- write(6,'(8f10.4)') (drl,ii=1,nrl)
+   write(6,'(8f10.4)') (drl,ii=1,nrl)
 
- write(6,'(t4,a)') &
-&      '</PP_RAB>'
+   write(6,'(t4,a)') &
+   &      '</PP_RAB>'
 
    write(6,'(t2,a)') &
-&        '</PP_MESH>'
+   &        '</PP_MESH>'
 
 ! write local potential with factor of 2 for Rydberg units
- write(6,'(a,i4,a)') &
-&      '  <PP_LOCAL type="real"  size="',nrl,'" columns="4">'
+   write(6,'(a,i4,a)') &
+   &      '  <PP_LOCAL type="real"  size="',nrl,'" columns="4">'
 
- write(6,'(1p,4e20.10)') (2.0d0*vpl(ii,lloc+1),ii=1,nrl)
+   write(6,'(1p,4e20.10)') (2.0d0*vpl(ii,lloc+1),ii=1,nrl)
 
- write(6,'(a)') &
-&      '  </PP_LOCAL>'
+   write(6,'(a)') &
+   &      '  </PP_LOCAL>'
 
 ! loop on angular mommentum for projector outputs
 
- write(6,'(t2,a)') &
-&      '<PP_NONLOCAL>'
+   write(6,'(t2,a)') &
+   &      '<PP_NONLOCAL>'
 
- dmat(:,:)=0.0d0
- iproj=0
+   dmat(:,:)=0.0d0
+   iproj=0
 
- do l1=1,lmax+1
-   if(l1==lloc+1) cycle
-   do jj=1,nproj(l1)
-     iproj=iproj+1
-     dmat(iproj,iproj)=2.0d0*evkb(jj,l1) !2 for Rydbergs
-     if(iproj<=9) then
-       write(6,'(t4,a,i1)') &
-&            '<PP_BETA.',iproj
-     else
-       write(6,'(t4,a,i2)') &
-&            '<PP_BETA.',iproj
-     end if
-     write(6,'(t8,a)') &
-&          'type="real"'
-     write(6,'(t8,a,i4,a)') &
-&          'size="',nrl,'"'
+   do l1=1,lmax+1
+      if(l1==lloc+1) cycle
+      do jj=1,nproj(l1)
+         iproj=iproj+1
+         dmat(iproj,iproj)=2.0d0*evkb(jj,l1)  !2 for Rydbergs
+         if(iproj<=9) then
+            write(6,'(t4,a,i1)') &
+            &            '<PP_BETA.',iproj
+         else
+            write(6,'(t4,a,i2)') &
+            &            '<PP_BETA.',iproj
+         end if
+         write(6,'(t8,a)') &
+         &          'type="real"'
+         write(6,'(t8,a,i4,a)') &
+         &          'size="',nrl,'"'
 !&          'size="',nrlproj,'"'
-     write(6,'(t8,a)') &
-&          'columns="4"'
-     write(6,'(t8,a,i1,a)') &
-&          'index="',iproj,'"'
+         write(6,'(t8,a)') &
+         &          'columns="4"'
+         write(6,'(t8,a,i1,a)') &
+         &          'index="',iproj,'"'
 !     write(6,'(t8,a)') &
 !&          'label="3P"'
-     write(6,'(t8,a,i1,a)') &
-&          'angular_momentum="',l1-1,'"'
-     write(6,'(t8,a,i4,a)') &
-&          'cutoff_radius_index="',nrlproj,'"'
-     write(6,'(t8,a,1p,e20.10,a)') &
-&          'cutoff_radius="',(nrlproj-1)*drl,'" >'
+         write(6,'(t8,a,i1,a)') &
+         &          'angular_momentum="',l1-1,'"'
+         write(6,'(t8,a,i4,a)') &
+         &          'cutoff_radius_index="',nrlproj,'"'
+         write(6,'(t8,a,1p,e20.10,a)') &
+         &          'cutoff_radius="',(nrlproj-1)*drl,'" >'
 
-     write(6,'(1p,4e20.10)') (vkbl(ii,jj,l1),ii=1,nrlproj)
-     write(6,'(1p,4f3.0)') (0.d0,ii=nrlproj+1,nrl)
+         write(6,'(1p,4e20.10)') (vkbl(ii,jj,l1),ii=1,nrlproj)
+         write(6,'(1p,4f3.0)') (0.d0,ii=nrlproj+1,nrl)
 
-     if(iproj<=9) then
-       write(6,'(t4,a,i1,a)') &
-&            '</PP_BETA.',iproj,'>'
-     else
-       write(6,'(t4,a,i2,a)') &
-&            '</PP_BETA.',iproj,'>'
-     end if
+         if(iproj<=9) then
+            write(6,'(t4,a,i1,a)') &
+            &            '</PP_BETA.',iproj,'>'
+         else
+            write(6,'(t4,a,i2,a)') &
+            &            '</PP_BETA.',iproj,'>'
+         end if
+      end do
    end do
- end do
 
- write(6,'(t4,a,i4,a)') &
-&      '<PP_DIJ type="real"  size="',ntotproj**2,'" columns="4">'
+   write(6,'(t4,a,i4,a)') &
+   &      '<PP_DIJ type="real"  size="',ntotproj**2,'" columns="4">'
 
- write(6,'(1p,4e20.10)') ((dmat(ii,jj),ii=1,ntotproj),jj=1,ntotproj)
+   write(6,'(1p,4e20.10)') ((dmat(ii,jj),ii=1,ntotproj),jj=1,ntotproj)
 
- write(6,'(t4,a)') &
-&      '</PP_DIJ>'
-
- write(6,'(t2,a)') &
-&      '</PP_NONLOCAL>'
-
- write(6,'(t2,a)') &
-&      '<PP_PSWFC>'
- do ii=1,nv
-  l1 = la(nc+ii)
-  write(6,'(t4,a,i1)') &
-&       '<PP_CHI.',ii
-  write(6,'(t8,a)') &
-&       'type="real"'
-  write(6,'(t8,a,i4,a)') &
-&       'size="',nrl,'"'
-  write(6,'(t8,a)') &
-&       'columns="4"'
-  write(6,'(t8,a,i1,a)') &
-&       'index="',ii,'"'
-  write(6,'(t8,a,f6.3,a)') &
-&       'occupation="',fa(nc+ii),'"'
-  write(6,'(t8,a,e20.10,a)') &
-&       'pseudo_energy="',2*ea(nc+ii),'"'
-  write(6,'(t8,a,i1,a,a)') &
-&       'label="',na(nc+ii),lnames(l1+1:l1+1),'"'
-     write(6,'(t8,a,i1,a)') &
-&          'l="',l1,'" >'
-  
-  write(6,'(1p,4e20.10)') (uual(jj,ii),jj=1,nrl)
-  
-  write(6,'(t4,a,i1,a)') &
-&       '</PP_CHI.',ii,'>'
-
- end do
- write(6,'(t2,a)') &
-&      '</PP_PSWFC>'
-
- if(icmod>=1) then
-   write(6,'(t2,a,i4,a)') &
-&        '<PP_NLCC type="real"  size="',nrl,'" columns="4">'
-
-   write(6,'(1p,4e20.10)') (rhomodl(ii,1)/(4.0d0*pi),ii=1,nrl)
+   write(6,'(t4,a)') &
+   &      '</PP_DIJ>'
 
    write(6,'(t2,a)') &
-&        '</PP_NLCC>'
- end if
+   &      '</PP_NONLOCAL>'
 
- write(6,'(t2,a,i4,a)') &
-&      '<PP_RHOATOM type="real"  size="',nrl,'" columns="4">'
+   write(6,'(t2,a)') &
+   &      '<PP_PSWFC>'
+   do ii=1,nv
+      l1 = la(nc+ii)
+      write(6,'(t4,a,i1)') &
+      &       '<PP_CHI.',ii
+      write(6,'(t8,a)') &
+      &       'type="real"'
+      write(6,'(t8,a,i4,a)') &
+      &       'size="',nrl,'"'
+      write(6,'(t8,a)') &
+      &       'columns="4"'
+      write(6,'(t8,a,i1,a)') &
+      &       'index="',ii,'"'
+      write(6,'(t8,a,f6.3,a)') &
+      &       'occupation="',fa(nc+ii),'"'
+      write(6,'(t8,a,e20.10,a)') &
+      &       'pseudo_energy="',2*ea(nc+ii),'"'
+      write(6,'(t8,a,i1,a,a)') &
+      &       'label="',na(nc+ii),lnames(l1+1:l1+1),'"'
+      write(6,'(t8,a,i1,a)') &
+      &          'l="',l1,'" >'
 
- write(6,'(1p,4e20.10)') ((rl(ii)**2)*rhol(ii),ii=1,nrl)
+      write(6,'(1p,4e20.10)') (uual(jj,ii),jj=1,nrl)
 
- write(6,'(t2,a)') &
-&      '</PP_RHOATOM>'
+      write(6,'(t4,a,i1,a)') &
+      &       '</PP_CHI.',ii,'>'
 
- write(6,'(a)') &
-&      '</UPF>'
+   end do
+   write(6,'(t2,a)') &
+   &      '</PP_PSWFC>'
 
-  
- deallocate(rhol,rl,vkbl,vpl,rhomodl,dmat)
+   if(icmod>=1) then
+      write(6,'(t2,a,i4,a)') &
+      &        '<PP_NLCC type="real"  size="',nrl,'" columns="4">'
+
+      write(6,'(1p,4e20.10)') (rhomodl(ii,1)/(4.0d0*pi),ii=1,nrl)
+
+      write(6,'(t2,a)') &
+      &        '</PP_NLCC>'
+   end if
+
+   write(6,'(t2,a,i4,a)') &
+   &      '<PP_RHOATOM type="real"  size="',nrl,'" columns="4">'
+
+   write(6,'(1p,4e20.10)') ((rl(ii)**2)*rhol(ii),ii=1,nrl)
+
+   write(6,'(t2,a)') &
+   &      '</PP_RHOATOM>'
+
+   write(6,'(a)') &
+   &      '</UPF>'
+
+
+   deallocate(rhol,rl,vkbl,vpl,rhomodl,dmat)
 
 ! write termination flag
- write(6,'(/a)') 'END_PSP'
+   write(6,'(/a)') 'END_PSP'
 
- return
- end subroutine upfout
+   return
+end subroutine upfout

--- a/src/upfout_r.f90
+++ b/src/upfout_r.f90
@@ -2,24 +2,24 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
 ! interpolates various arrays onto linear radial mesh to create file
 ! for PWSCF input using the UPF file format, fully-relativistic case
 
- subroutine upfout_r(lmax,lloc,rc,vkb,evkb,nproj,rr,vpuns,rho,rhomod, &
+subroutine upfout_r(lmax,lloc,rc,vkb,evkb,nproj,rr,vpuns,rho,rhomod, &
 &                  zz,zion,mmax,mxprj,iexc,icmod,nrl,drl,atsym,epstot, &
 &                  na,la,ncon,nbas,nvcnf,nacnf,lacnf,nc,nv,lpopt,ncnf, &
 &                  fa,rc0,ep,qcut,debl,facnf,dvloc0,fcfact,rcfact, &
@@ -33,7 +33,7 @@
 !evkb  coefficients of VKB projectors
 !nproj  number of vkb projectors for each l
 !rr  log radial grid
-!vpuns  unscreened semi-local pseudopotentials (vp(:,5) is local potential 
+!vpuns  unscreened semi-local pseudopotentials (vp(:,5) is local potential
 !  if linear combination is used)
 !rho  valence pseudocharge
 !rhomod  model core charge
@@ -54,315 +54,315 @@
 !uua pseudo-atomic orbital array
 !ea  psuedo-orbital eigenvalues
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
- real(dp), parameter :: pi=3.141592653589793238462643383279502884197_dp
+   real(dp), parameter :: pi=3.141592653589793238462643383279502884197_dp
 
 !Input variables
- integer :: lmax,lloc,iexc,mmax,mxprj,nrl,icmod
- integer :: nproj(6)
- real(dp) :: drl,fcfact,rcfact,zz,zion,epstot
- real(dp) :: rr(mmax),vpuns(mmax,5),rho(mmax),vkb(mmax,mxprj,4,2)
- real(dp) :: rhomod(mmax,5)
- real(dp):: rc(6),evkb(mxprj,4,2)
- character*2 :: atsym
- real(dp) :: uua(mmax,2,nv)
+   integer :: lmax,lloc,iexc,mmax,mxprj,nrl,icmod
+   integer :: nproj(6)
+   real(dp) :: drl,fcfact,rcfact,zz,zion,epstot
+   real(dp) :: rr(mmax),vpuns(mmax,5),rho(mmax),vkb(mmax,mxprj,4,2)
+   real(dp) :: rhomod(mmax,5)
+   real(dp):: rc(6),evkb(mxprj,4,2)
+   character(len=2) :: atsym
+   real(dp) :: uua(mmax,2,nv)
 
 !additional input for upf output to echo input file, all as defined
 ! in the main progam
- integer :: na(30),la(30),ncon(6),nbas(6)
- integer :: nvcnf(5),nacnf(30,5),lacnf(30,5)
- integer :: nc,nv,lpopt,ncnf
- real(dp) :: fa(30),rc0(6),ep(6,2),qcut(6),debl(6,2),facnf(30,5),ea(30,2)
- real(dp) :: dvloc0,epsh1,epsh2,depsh,rlmax
- character*4 :: psfile
+   integer :: na(30),la(30),ncon(6),nbas(6)
+   integer :: nvcnf(5),nacnf(30,5),lacnf(30,5)
+   integer :: nc,nv,lpopt,ncnf
+   real(dp) :: fa(30),rc0(6),ep(6,2),qcut(6),debl(6,2),facnf(30,5),ea(30,2)
+   real(dp) :: dvloc0,epsh1,epsh2,depsh,rlmax
+   character(len=4) :: psfile
 
 !Output variables - printing only
 
 !Local variables
- integer :: ii,jj,ll,l1,iproj,ntotproj,nrlproj,nwfc
- integer :: ikap,mkap
- integer :: dtime(8)
- real(dp) :: djjj
- real(dp) :: al,nrmsum,uurcut,fj
- real(dp), allocatable :: rhomodl(:,:),dmat(:,:)
- real(dp),allocatable :: rhol(:),rl(:),vkbl(:,:,:,:),vpl(:,:),uual(:,:,:)
- character*5 :: lnames
- character*2 :: pspd(3)
+   integer :: ii,jj,ll,l1,iproj,ntotproj,nrlproj,nwfc
+   integer :: ikap,mkap
+   integer :: dtime(8)
+   real(dp) :: djjj
+   real(dp) :: al,nrmsum,uurcut,fj
+   real(dp), allocatable :: rhomodl(:,:),dmat(:,:)
+   real(dp),allocatable :: rhol(:),rl(:),vkbl(:,:,:,:),vpl(:,:),uual(:,:,:)
+   character(len=5) :: lnames
+   character(len=2) :: pspd(3)
 
- lnames = "SPDFG"
- 
- ! adjust nrl to properly accomodate atomic orbitals
- al = dlog(rr(2)/rr(1))
- uurcut = 0.d0
- do ii=1,nv
-   l1 = la(nc+ii)
-   if(l1==0) then
-     mkap=1
-   else
-     mkap=2
-   end if
-   do ikap=1,mkap
-     nrmsum = 0.d0
-     do jj=mmax,1,-1
-       nrmsum = nrmsum + (uua(jj,ikap,ii)**2) * rr(jj)*al
-       if (nrmsum > 1.d-6) then
-         exit  ! Cutoff radius such that uu norm accurate to 10^-6
-       end if
-     end do
-     if (rr(jj) > uurcut) uurcut = rr(jj)  
+   lnames = "SPDFG"
+
+   ! adjust nrl to properly accomodate atomic orbitals
+   al = dlog(rr(2)/rr(1))
+   uurcut = 0.d0
+   do ii=1,nv
+      l1 = la(nc+ii)
+      if(l1==0) then
+         mkap=1
+      else
+         mkap=2
+      end if
+      do ikap=1,mkap
+         nrmsum = 0.d0
+         do jj=mmax,1,-1
+            nrmsum = nrmsum + (uua(jj,ikap,ii)**2) * rr(jj)*al
+            if (nrmsum > 1.d-6) then
+               exit  ! Cutoff radius such that uu norm accurate to 10^-6
+            end if
+         end do
+         if (rr(jj) > uurcut) uurcut = rr(jj)
+      end do
    end do
- end do
- if (uurcut > drl*dble(nrl-1)) then
-   nrl = 1 + uurcut/drl
-   if(mod(nrl,2)/=0) nrl=nrl+1
-   write(6,'(a,i5,a,f10.5)') "Updating nrl = ", nrl, " for uurcut = ", uurcut
- end if
+   if (uurcut > drl*dble(nrl-1)) then
+      nrl = 1 + uurcut/drl
+      if(mod(nrl,2)/=0) nrl=nrl+1
+      write(6,'(a,i5,a,f10.5)') "Updating nrl = ", nrl, " for uurcut = ", uurcut
+   end if
 
- allocate(rhol(nrl),rl(nrl),vkbl(nrl,mxprj,4,2),vpl(nrl,5),rhomodl(nrl,5),uual(nrl,2,nv))
+   allocate(rhol(nrl),rl(nrl),vkbl(nrl,mxprj,4,2),vpl(nrl,5),rhomodl(nrl,5),uual(nrl,2,nv))
 
 ! interpolation of everything onto linear output mesh
- 
- do  ii=1,nrl
-   rl(ii)=drl*dble(ii-1)
- end do
-!
- vpl(:,:)=0.0d0
- call dpnint(rr,vpuns(1,lloc+1),mmax,rl,vpl(1,lloc+1),nrl)
 
- do l1=1,lmax+1
-  if(l1==lloc+1) cycle
-  ll=l1-1
-  if(ll==0) then
-   mkap=1
-  else
-   mkap=2
-  end if
-! loop on J = ll +/- 1/2
-  do ikap=1,mkap
-   do jj=1,nproj(l1)
-
-     call dpnint(rr,vkb(1,jj,l1,ikap),mmax,rl,vkbl(1,jj,l1,ikap),nrl)
-
-   end do !jj
-  end do !ikap
- end do !l1
-
- call dpnint(rr,rho,mmax,rl,rhol,nrl)
-
- do jj=1,5
-   call dpnint(rr,rhomod(1,jj),mmax,rl,rhomodl(1,jj),nrl)
- end do
-
- nwfc = 0
- do ii=1,nv
-   l1 = la(nc+ii)
-   if(l1==0) then
-     mkap=1
-   else
-     mkap=2
-   end if
-   nwfc = nwfc + mkap
-   do ikap=1,mkap
-     call dpnint(rr,uua(1,ikap,ii),mmax,rl,uual(1,ikap,ii),nrl)
+   do  ii=1,nrl
+      rl(ii)=drl*dble(ii-1)
    end do
- end do
+!
+   vpl(:,:)=0.0d0
+   call dpnint(rr,vpuns(1,lloc+1),mmax,rl,vpl(1,lloc+1),nrl)
 
- call date_and_time(VALUES=dtime)
- ii=dtime(1)-2000
- if(ii<10) then
-   write(pspd(1),'(a,i1)') '0',ii
- else
-   write(pspd(1),'(i2)') ii
- end if
- ii=dtime(2)
- if(ii<10) then
-   write(pspd(2),'(a,i1)') '0',ii
- else
-   write(pspd(2),'(i2)') ii
- end if
- ii=dtime(3)
- if(ii<10) then
-   write(pspd(3),'(a,i1)') '0',ii
- else
-   write(pspd(3),'(i2)') ii
- end if
+   do l1=1,lmax+1
+      if(l1==lloc+1) cycle
+      ll=l1-1
+      if(ll==0) then
+         mkap=1
+      else
+         mkap=2
+      end if
+! loop on J = ll +/- 1/2
+      do ikap=1,mkap
+         do jj=1,nproj(l1)
+
+            call dpnint(rr,vkb(1,jj,l1,ikap),mmax,rl,vkbl(1,jj,l1,ikap),nrl)
+
+         end do  !jj
+      end do  !ikap
+   end do  !l1
+
+   call dpnint(rr,rho,mmax,rl,rhol,nrl)
+
+   do jj=1,5
+      call dpnint(rr,rhomod(1,jj),mmax,rl,rhomodl(1,jj),nrl)
+   end do
+
+   nwfc = 0
+   do ii=1,nv
+      l1 = la(nc+ii)
+      if(l1==0) then
+         mkap=1
+      else
+         mkap=2
+      end if
+      nwfc = nwfc + mkap
+      do ikap=1,mkap
+         call dpnint(rr,uua(1,ikap,ii),mmax,rl,uual(1,ikap,ii),nrl)
+      end do
+   end do
+
+   call date_and_time(VALUES=dtime)
+   ii=dtime(1)-2000
+   if(ii<10) then
+      write(pspd(1),'(a,i1)') '0',ii
+   else
+      write(pspd(1),'(i2)') ii
+   end if
+   ii=dtime(2)
+   if(ii<10) then
+      write(pspd(2),'(a,i1)') '0',ii
+   else
+      write(pspd(2),'(i2)') ii
+   end if
+   ii=dtime(3)
+   if(ii<10) then
+      write(pspd(3),'(a,i1)') '0',ii
+   else
+      write(pspd(3),'(i2)') ii
+   end if
 
 ! section for upf output for pwscf
 
- write(6,'(/a)') 'Begin PSP_UPF'
+   write(6,'(/a)') 'Begin PSP_UPF'
 
- write(6,'(a,/a)') &
-&      '<UPF version="2.0.1">', &
-&      '  <PP_INFO>'
- write(6,'(/t2,a/t2,a/t2,a/t2,a/t2,a/t2,a//)') &
-       'This pseudopotential file has been produced using the code', &
-&      'ONCVPSP  (Optimized Norm-Conservinng Vanderbilt PSeudopotential)', &
-&      'fully-relativistic version 4.0.1 06/20/2107 by D. R. Hamann', &
-&      'The code is available through a link at URL www.mat-simresearch.com.', &
-&      'Documentation with the package provides a full discription of the', &
-&      'input data below.'
+   write(6,'(a,/a)') &
+   &      '<UPF version="2.0.1">', &
+   &      '  <PP_INFO>'
+   write(6,'(/t2,a/t2,a/t2,a/t2,a/t2,a/t2,a//)') &
+      'This pseudopotential file has been produced using the code', &
+   &      'ONCVPSP  (Optimized Norm-Conservinng Vanderbilt PSeudopotential)', &
+   &      'fully-relativistic version 4.0.1 06/20/2107 by D. R. Hamann', &
+   &      'The code is available through a link at URL www.mat-simresearch.com.', &
+   &      'Documentation with the package provides a full discription of the', &
+   &      'input data below.'
 
- write(6,'(t2,a/t2,a/t2,a/t2,a//)') &
-&      'While it is not required under the terms of the GNU GPL, it is',&
-&      'suggested that you cite D. R. Hamann, Phys. Rev. B 88, 085117 (2013)',&
-&      'in any publication using these pseudopotentials.'
+   write(6,'(t2,a/t2,a/t2,a/t2,a//)') &
+   &      'While it is not required under the terms of the GNU GPL, it is',&
+   &      'suggested that you cite D. R. Hamann, Phys. Rev. B 88, 085117 (2013)',&
+   &      'in any publication using these pseudopotentials.'
 
- write(6,'(a)') &
-&      '    <PP_INPUTFILE>'
+   write(6,'(a)') &
+   &      '    <PP_INPUTFILE>'
 
 ! output printing (echos input data)
 
- write(6,'(a)') '# ATOM AND REFERENCE CONFIGURATION'
- write(6,'(a)') '# atsym  z   nc   nv     iexc    psfile'
- write(6,'(a,a,f6.2,2i5,i8,2a)') '  ',trim(atsym),zz,nc,nv,iexc, &
-&      '      ',trim(psfile)
- write(6,'(a/a)') '#','#   n    l    f        energy (Ha)'
- do ii=1,nc+nv
-   write(6,'(2i5,f8.2)') na(ii),la(ii),fa(ii)
- end do
- write(6,'(a/a/a)') '#','# PSEUDOPOTENTIAL AND OPTIMIZATION','# lmax'
- write(6,'(i5)')  lmax
- write(6,'(a/a)') '#','#   l,   rc,     ep,   ncon, nbas, qcut'
- do l1=1,lmax+1
-   write(6,'(i5,2f10.5,2i5,f10.5)') l1-1,rc0(l1),ep(l1,1),ncon(l1),nbas(l1),qcut(l1)
- end do
-
- write(6,'(a/a/a,a)') '#','# LOCAL POTENTIAL','# lloc, lpopt,  rc(5),', &
-&      '   dvloc0'
- write(6,'(2i5,f10.5,a,f10.5)') lloc,lpopt,rc0(5),'   ',dvloc0
-
- write(6,'(a/a/a)') '#','# VANDERBILT-KLEINMAN-BYLANDER PROJECTORs', &
-&      '# l, nproj, debl'
- do l1=1,lmax+1
-   write(6,'(2i5,f10.5)') l1-1,nproj(l1),debl(l1,1)
- end do
-
-write(6,'(a/a/a)') '#','# MODEL CORE CHARGE', &
-&      '# icmod, fcfact, rcfact'
- write(6,'(i5,2f10.5)') icmod,fcfact,rcfact
-
- write(6,'(a/a/a)') '#','# LOG DERIVATIVE ANALYSIS', &
-&      '# epsh1, epsh2, depsh'
- write(6,'(3f8.2)') epsh1,epsh2,depsh
-
- write(6,'(a/a/a)') '#','# OUTPUT GRID','# rlmax, drl'
- write(6,'(2f8.2)') rlmax,drl
-
- write(6,'(a/a/a)') '#','# TEST CONFIGURATIONS','# ncnf'
- write(6,'(i5)') ncnf
- write(6,'(a/a)') '# nvcnf','#   n    l    f'
- do jj=2,ncnf+1
-   write(6,'(i5)') nvcnf(jj)
-   do ii=nc+1,nc+nvcnf(jj)
-     write(6,'(2i5,f8.2)') nacnf(ii,jj),lacnf(ii,jj),facnf(ii,jj)
+   write(6,'(a)') '# ATOM AND REFERENCE CONFIGURATION'
+   write(6,'(a)') '# atsym  z   nc   nv     iexc    psfile'
+   write(6,'(a,a,f6.2,2i5,i8,2a)') '  ',trim(atsym),zz,nc,nv,iexc, &
+   &      '      ',trim(psfile)
+   write(6,'(a/a)') '#','#   n    l    f        energy (Ha)'
+   do ii=1,nc+nv
+      write(6,'(2i5,f8.2)') na(ii),la(ii),fa(ii)
    end do
-   write(6,'(a)') '#'
- end do
- write(6,'(a)') &
-&      '    </PP_INPUTFILE>'
+   write(6,'(a/a/a)') '#','# PSEUDOPOTENTIAL AND OPTIMIZATION','# lmax'
+   write(6,'(i5)')  lmax
+   write(6,'(a/a)') '#','#   l,   rc,     ep,   ncon, nbas, qcut'
+   do l1=1,lmax+1
+      write(6,'(i5,2f10.5,2i5,f10.5)') l1-1,rc0(l1),ep(l1,1),ncon(l1),nbas(l1),qcut(l1)
+   end do
 
- write(6,'(a,3(/a))') &
-&      '  </PP_INFO>', &
-&      '  <!--                               -->', &
-&      '  <!-- END OF HUMAN READABLE SECTION -->', &
-&      '  <!--                               -->'
+   write(6,'(a/a/a,a)') '#','# LOCAL POTENTIAL','# lloc, lpopt,  rc(5),', &
+   &      '   dvloc0'
+   write(6,'(2i5,f10.5,a,f10.5)') lloc,lpopt,rc0(5),'   ',dvloc0
 
- write(6,'(a)') &
-&      '    <PP_HEADER'
+   write(6,'(a/a/a)') '#','# VANDERBILT-KLEINMAN-BYLANDER PROJECTORs', &
+   &      '# l, nproj, debl'
+   do l1=1,lmax+1
+      write(6,'(2i5,f10.5)') l1-1,nproj(l1),debl(l1,1)
+   end do
+
+   write(6,'(a/a/a)') '#','# MODEL CORE CHARGE', &
+   &      '# icmod, fcfact, rcfact'
+   write(6,'(i5,2f10.5)') icmod,fcfact,rcfact
+
+   write(6,'(a/a/a)') '#','# LOG DERIVATIVE ANALYSIS', &
+   &      '# epsh1, epsh2, depsh'
+   write(6,'(3f8.2)') epsh1,epsh2,depsh
+
+   write(6,'(a/a/a)') '#','# OUTPUT GRID','# rlmax, drl'
+   write(6,'(2f8.2)') rlmax,drl
+
+   write(6,'(a/a/a)') '#','# TEST CONFIGURATIONS','# ncnf'
+   write(6,'(i5)') ncnf
+   write(6,'(a/a)') '# nvcnf','#   n    l    f'
+   do jj=2,ncnf+1
+      write(6,'(i5)') nvcnf(jj)
+      do ii=nc+1,nc+nvcnf(jj)
+         write(6,'(2i5,f8.2)') nacnf(ii,jj),lacnf(ii,jj),facnf(ii,jj)
+      end do
+      write(6,'(a)') '#'
+   end do
+   write(6,'(a)') &
+   &      '    </PP_INPUTFILE>'
+
+   write(6,'(a,3(/a))') &
+   &      '  </PP_INFO>', &
+   &      '  <!--                               -->', &
+   &      '  <!-- END OF HUMAN READABLE SECTION -->', &
+   &      '  <!--                               -->'
+
+   write(6,'(a)') &
+   &      '    <PP_HEADER'
 
    write(6,'(t8,a)') &
-&        'generated="Generated using ONCVPSP code by D. R. Hamann"'
+   &        'generated="Generated using ONCVPSP code by D. R. Hamann"'
    write(6,'(t8,a)') &
-&        'author="anonymous"'
+   &        'author="anonymous"'
    write(6,'(t8,5a)') &
-&        'date="',pspd(:),'"'
+   &        'date="',pspd(:),'"'
    write(6,'(t8,a)') &
-&        'comment=""'
+   &        'comment=""'
    write(6,'(t8,a,a2,a)') &
-&        'element="',atsym,'"'
+   &        'element="',atsym,'"'
    write(6,'(t8,a)') &
-&        'pseudo_type="NC"'
+   &        'pseudo_type="NC"'
    write(6,'(t8,a)') &
-&        'relativistic="full"'
+   &        'relativistic="full"'
    write(6,'(t8,a)') &
-&        'is_ultrasoft="F"'
+   &        'is_ultrasoft="F"'
    write(6,'(t8,a)') &
-&        'is_paw="F"'
+   &        'is_paw="F"'
    write(6,'(t8,a)') &
-&        'is_coulomb="F"'
+   &        'is_coulomb="F"'
    write(6,'(t8,a)') &
-&        'has_so="T"'
+   &        'has_so="T"'
    write(6,'(t8,a)') &
-&        'has_wfc="F"'
+   &        'has_wfc="F"'
    write(6,'(t8,a)') &
-&        'has_gipaw="F"'
+   &        'has_gipaw="F"'
 
    if(icmod>=1) then
-     write(6,'(t8,a)') &
-&        'core_correction="T"'
+      write(6,'(t8,a)') &
+      &        'core_correction="T"'
    else
-     write(6,'(t8,a)') &
-&        'core_correction="F"'
+      write(6,'(t8,a)') &
+      &        'core_correction="F"'
    end if
 
    if(iexc==3 .or. iexc==-001009) then
-     write(6,'(t8,a)') &
-&        'functional="PZ"'
+      write(6,'(t8,a)') &
+      &        'functional="PZ"'
 
    else if(iexc==4 .or. iexc==-101130) then
-     write(6,'(t8,a)') &
-&        'functional="PBE"'
+      write(6,'(t8,a)') &
+      &        'functional="PBE"'
 
    else if(iexc==-109134) then
-     write(6,'(t8,a)') &
-&        'functional="PW91"'
+      write(6,'(t8,a)') &
+      &        'functional="PW91"'
 
    else if(iexc==-116133) then
-     write(6,'(t8,a)') &
-&        'functional="PBESOL"'
+      write(6,'(t8,a)') &
+      &        'functional="PBESOL"'
 
    else if(iexc==-102130) then
-     write(6,'(t8,a)') &
-&        'functional="REVPBE"'
+      write(6,'(t8,a)') &
+      &        'functional="REVPBE"'
 
    else if(iexc==-106132) then
-     write(6,'(t8,a)') &
-&        'functional="BP"'
+      write(6,'(t8,a)') &
+      &        'functional="BP"'
 
    else if(iexc==-106131) then
-     write(6,'(t8,a)') &
-&        'functional="BLYP"'
+      write(6,'(t8,a)') &
+      &        'functional="BLYP"'
 
    else if(iexc==-118130) then
-     write(6,'(t8,a)') &
-&        'functional="WC"'
+      write(6,'(t8,a)') &
+      &        'functional="WC"'
 
    else
-     write(6,'(t8,a)') &
-&        'upfout: ERROR iexc = ',iexc,' is presently unsupported for UPF output'
-     stop
+      write(6,'(t8,a)') &
+      &        'upfout: ERROR iexc = ',iexc,' is presently unsupported for UPF output'
+      stop
    end if
 
    write(6,'(t8,a,f8.2,a)') &
-&        'z_valence="',zion,'"'
+   &        'z_valence="',zion,'"'
 
    write(6,'(t8,a,1p,e20.11,a)') &
-&        'total_psenergy="',2*epstot,'"'
+   &        'total_psenergy="',2*epstot,'"'
 
    write(6,'(t8,a,1p,e20.11,a)') &
-&        'rho_cutoff="',rl(nrl),'"'
+   &        'rho_cutoff="',rl(nrl),'"'
 
    write(6,'(t8,a,i1,a)') &
-&        'l_max="',lmax,'"'
+   &        'l_max="',lmax,'"'
 
    if(lloc==4) then
-     write(6,'(t8,a)') &
-&        'l_local="-1"'
+      write(6,'(t8,a)') &
+      &        'l_local="-1"'
    else
-     write(6,'(t8,a,i1,a)') &
-&        'l_local="',lloc,'"'
+      write(6,'(t8,a,i1,a)') &
+      &        'l_local="',lloc,'"'
    end if
 
 ! calculate total number of projectors and maximum linear mesh point for
@@ -371,14 +371,14 @@ write(6,'(a/a/a)') '#','# MODEL CORE CHARGE', &
    ntotproj=0
    nrlproj=0
    do l1=1,lmax+1
-     if(l1/=lloc+1) then
-       if(l1==1) then
-         ntotproj=ntotproj+nproj(l1)
-       else
-         ntotproj=ntotproj+2*nproj(l1)
-       end if
-     end if
-     nrlproj=max(nrlproj,4+int(rc(l1)/drl))
+      if(l1/=lloc+1) then
+         if(l1==1) then
+            ntotproj=ntotproj+nproj(l1)
+         else
+            ntotproj=ntotproj+2*nproj(l1)
+         end if
+      end if
+      nrlproj=max(nrlproj,4+int(rc(l1)/drl))
    end do
    allocate(dmat(ntotproj,ntotproj))
 
@@ -386,277 +386,277 @@ write(6,'(a/a/a)') '#','# MODEL CORE CHARGE', &
    if(mod(nrlproj,4)/=0) nrlproj=nrlproj+2  !make divisible by 4 to use for 0 compression below
 
    write(6,'(t8,a,i6,a)') &
-&        'mesh_size="',nrl,'"'
+   &        'mesh_size="',nrl,'"'
 
    if(nwfc<=9) then
-     write(6,'(t8,a,i1,a)') &
-&          'number_of_wfc="',nwfc,'"'
+      write(6,'(t8,a,i1,a)') &
+      &          'number_of_wfc="',nwfc,'"'
    else
-     write(6,'(t8,a,i2,a)') &
-&          'number_of_wfc="',nwfc,'"'
+      write(6,'(t8,a,i2,a)') &
+      &          'number_of_wfc="',nwfc,'"'
    end if
 
    if(ntotproj<=9) then
-     write(6,'(t8,a,i1,a)') &
-&          'number_of_proj="',ntotproj,'"/>' !end of PP_HEADER
+      write(6,'(t8,a,i1,a)') &
+      &          'number_of_proj="',ntotproj,'"/>'  !end of PP_HEADER
    else
-     write(6,'(t8,a,i2,a)') &
-&          'number_of_proj="',ntotproj,'"/>' !end of PP_HEADER
+      write(6,'(t8,a,i2,a)') &
+      &          'number_of_proj="',ntotproj,'"/>'  !end of PP_HEADER
    end if
 
    write(6,'(t2,a)') &
-&        '<PP_MESH>'
+   &        '<PP_MESH>'
 
- write(6,'(t4,a,i4,a)') &
-&      '<PP_R type="real"  size="',nrl,'" columns="8">'
+   write(6,'(t4,a,i4,a)') &
+   &      '<PP_R type="real"  size="',nrl,'" columns="8">'
 
- write(6,'(8f10.4)') (rl(ii),ii=1,nrl)
+   write(6,'(8f10.4)') (rl(ii),ii=1,nrl)
 
- write(6,'(t4,a)') &
-&      '</PP_R>'
+   write(6,'(t4,a)') &
+   &      '</PP_R>'
 
- write(6,'(t4,a,i4,a)') &
-&      '<PP_RAB type="real"  size="',nrl,'" columns="8">'
+   write(6,'(t4,a,i4,a)') &
+   &      '<PP_RAB type="real"  size="',nrl,'" columns="8">'
 
- write(6,'(8f10.4)') (drl,ii=1,nrl)
+   write(6,'(8f10.4)') (drl,ii=1,nrl)
 
- write(6,'(t4,a)') &
-&      '</PP_RAB>'
+   write(6,'(t4,a)') &
+   &      '</PP_RAB>'
 
    write(6,'(t2,a)') &
-&        '</PP_MESH>'
+   &        '</PP_MESH>'
 
 ! write local potential with factor of 2 for Rydberg units
- write(6,'(a,i4,a)') &
-&      '  <PP_LOCAL type="real"  size="',nrl,'" columns="4">'
+   write(6,'(a,i4,a)') &
+   &      '  <PP_LOCAL type="real"  size="',nrl,'" columns="4">'
 
- write(6,'(1p,4e20.10)') (2.0d0*vpl(ii,lloc+1),ii=1,nrl)
+   write(6,'(1p,4e20.10)') (2.0d0*vpl(ii,lloc+1),ii=1,nrl)
 
- write(6,'(a)') &
-&      '  </PP_LOCAL>'
+   write(6,'(a)') &
+   &      '  </PP_LOCAL>'
 
 ! loop on angular mommentum for projector outputs
 
- write(6,'(t2,a)') &
-&      '<PP_NONLOCAL>'
+   write(6,'(t2,a)') &
+   &      '<PP_NONLOCAL>'
 
- dmat(:,:)=0.0d0
- iproj=0
+   dmat(:,:)=0.0d0
+   iproj=0
 
- do l1=1,lmax+1
-  if(l1==lloc+1) cycle
-  ll=l1-1
-  if(ll==0) then
-   mkap=1
-  else
-   mkap=2
-  end if
-  do jj=1,nproj(l1)
+   do l1=1,lmax+1
+      if(l1==lloc+1) cycle
+      ll=l1-1
+      if(ll==0) then
+         mkap=1
+      else
+         mkap=2
+      end if
+      do jj=1,nproj(l1)
 ! loop on J = ll +/- 1/2
-   do ikap=mkap,1,-1
-    if(ikap==1) then
-      djjj=ll+0.5d0
-    else
-      djjj=ll-0.5d0
-    end if
-     iproj=iproj+1
-     dmat(iproj,iproj)=2.0d0*evkb(jj,l1,ikap) !2 for Rydbergs
-     if(iproj<=9) then
-       write(6,'(t4,a,i1)') &
-&            '<PP_BETA.',iproj
-     else
-       write(6,'(t4,a,i2)') &
-&            '<PP_BETA.',iproj
-     end if
-     write(6,'(t8,a)') &
-&          'type="real"'
-     write(6,'(t8,a,i4,a)') &
-&          'size="',nrl,'"'
-     write(6,'(t8,a)') &
-&          'columns="4"'
-     if(iproj<=9) then
-       write(6,'(t8,a,i1,a)') &
-&           'index="',iproj,'"'
-     else
-       write(6,'(t8,a,i2,a)') &
-&           'index="',iproj,'"'
-     end if
-     write(6,'(t8,a,i1,a)') &
-&          'angular_momentum="',l1-1,'"'
-     write(6,'(t8,a,i4,a)') &
-&          'cutoff_radius_index="',nrlproj,'"'
-     write(6,'(t8,a,1p,e20.10,a)') &
-&          'cutoff_radius="',(nrlproj-1)*drl,'" >'
+         do ikap=mkap,1,-1
+            if(ikap==1) then
+               djjj=ll+0.5d0
+            else
+               djjj=ll-0.5d0
+            end if
+            iproj=iproj+1
+            dmat(iproj,iproj)=2.0d0*evkb(jj,l1,ikap)  !2 for Rydbergs
+            if(iproj<=9) then
+               write(6,'(t4,a,i1)') &
+               &            '<PP_BETA.',iproj
+            else
+               write(6,'(t4,a,i2)') &
+               &            '<PP_BETA.',iproj
+            end if
+            write(6,'(t8,a)') &
+            &          'type="real"'
+            write(6,'(t8,a,i4,a)') &
+            &          'size="',nrl,'"'
+            write(6,'(t8,a)') &
+            &          'columns="4"'
+            if(iproj<=9) then
+               write(6,'(t8,a,i1,a)') &
+               &           'index="',iproj,'"'
+            else
+               write(6,'(t8,a,i2,a)') &
+               &           'index="',iproj,'"'
+            end if
+            write(6,'(t8,a,i1,a)') &
+            &          'angular_momentum="',l1-1,'"'
+            write(6,'(t8,a,i4,a)') &
+            &          'cutoff_radius_index="',nrlproj,'"'
+            write(6,'(t8,a,1p,e20.10,a)') &
+            &          'cutoff_radius="',(nrlproj-1)*drl,'" >'
 
-     write(6,'(1p,4e20.10)') (vkbl(ii,jj,l1,ikap),ii=1,nrlproj)
-     write(6,'(1p,4f3.0)') (0.d0,ii=nrlproj+1,nrl)
+            write(6,'(1p,4e20.10)') (vkbl(ii,jj,l1,ikap),ii=1,nrlproj)
+            write(6,'(1p,4f3.0)') (0.d0,ii=nrlproj+1,nrl)
 
-     if(iproj<=9) then
-       write(6,'(t4,a,i1,a)') &
-&            '</PP_BETA.',iproj,'>'
-     else
-       write(6,'(t4,a,i2,a)') &
-&            '</PP_BETA.',iproj,'>'
-     end if
-   end do !ikap
-  end do !jj (1,nproj(l1))
- end do !l1
+            if(iproj<=9) then
+               write(6,'(t4,a,i1,a)') &
+               &            '</PP_BETA.',iproj,'>'
+            else
+               write(6,'(t4,a,i2,a)') &
+               &            '</PP_BETA.',iproj,'>'
+            end if
+         end do  !ikap
+      end do  !jj (1,nproj(l1))
+   end do  !l1
 
- write(6,'(t4,a,i4,a)') &
-&      '<PP_DIJ type="real"  size="',ntotproj**2,'" columns="4">'
+   write(6,'(t4,a,i4,a)') &
+   &      '<PP_DIJ type="real"  size="',ntotproj**2,'" columns="4">'
 
- write(6,'(1p,4e20.10)') ((dmat(ii,jj),ii=1,ntotproj),jj=1,ntotproj)
+   write(6,'(1p,4e20.10)') ((dmat(ii,jj),ii=1,ntotproj),jj=1,ntotproj)
 
- write(6,'(t4,a)') &
-&      '</PP_DIJ>'
-
- write(6,'(t2,a)') &
-&      '</PP_NONLOCAL>'
-
- write(6,'(t2,a)') &
-&      '<PP_PSWFC>'
- nwfc = 0
- do ii=1,nv
-  l1 = la(nc+ii)
-  if(l1==0) then
-    mkap=1
-  else
-    mkap=2
-  end if
-  do ikap=1,mkap
-    nwfc = nwfc + 1
-    if(ikap==1) then
-      fj=dble(l1+1)*fa(nc+ii)/dble(2*l1+1)
-    else
-      fj=dble(l1)*fa(nc+ii)/dble(2*l1+1)
-    end if
-    if(nwfc <= 9) then
-      write(6,'(t4,a,i1)') &
-&           '<PP_CHI.',nwfc
-    else
-      write(6,'(t4,a,i2)') &
-&           '<PP_CHI.',nwfc
-    end if
-    write(6,'(t8,a)') &
-&         'type="real"'
-    write(6,'(t8,a,i4,a)') &
-&         'size="',nrl,'"'
-    write(6,'(t8,a)') &
-&         'columns="4"'
-    write(6,'(t8,a,i1,a)') &
-&         'index="',nwfc,'"'
-    write(6,'(t8,a,f6.3,a)') &
-&         'occupation="',fj,'"'
-    write(6,'(t8,a,e20.10,a)') &
-&         'pseudo_energy="',2*ea(nc+ii,ikap),'"'
-    write(6,'(t8,a,i1,a,a)') &
-&         'label="',na(nc+ii),lnames(l1+1:l1+1),'"'
-    write(6,'(t8,a,i1,a)') &
-&            'l="',l1,'" >'
-    
-    write(6,'(1p,4e20.10)') (uual(jj,ikap,ii),jj=1,nrl)
-    
-    if(nwfc <= 9) then
-      write(6,'(t4,a,i1,a)') &
-&           '</PP_CHI.',nwfc,'>'
-    else
-      write(6,'(t4,a,i1,a)') &
-&           '</PP_CHI.',nwfc,'>'
-    end if
-  end do
- end do
- write(6,'(t2,a)') &
-&      '</PP_PSWFC>'
-
- if(icmod>=1) then
-   write(6,'(t2,a,i4,a)') &
-&        '<PP_NLCC type="real"  size="',nrl,'" columns="4">'
-
-   write(6,'(1p,4e20.10)') (rhomodl(ii,1)/(4.0d0*pi),ii=1,nrl)
+   write(6,'(t4,a)') &
+   &      '</PP_DIJ>'
 
    write(6,'(t2,a)') &
-&        '</PP_NLCC>'
- end if
+   &      '</PP_NONLOCAL>'
 
- write(6,'(t2,a,i4,a)') &
-&      '<PP_RHOATOM type="real"  size="',nrl,'" columns="4">'
+   write(6,'(t2,a)') &
+   &      '<PP_PSWFC>'
+   nwfc = 0
+   do ii=1,nv
+      l1 = la(nc+ii)
+      if(l1==0) then
+         mkap=1
+      else
+         mkap=2
+      end if
+      do ikap=1,mkap
+         nwfc = nwfc + 1
+         if(ikap==1) then
+            fj=dble(l1+1)*fa(nc+ii)/dble(2*l1+1)
+         else
+            fj=dble(l1)*fa(nc+ii)/dble(2*l1+1)
+         end if
+         if(nwfc <= 9) then
+            write(6,'(t4,a,i1)') &
+            &           '<PP_CHI.',nwfc
+         else
+            write(6,'(t4,a,i2)') &
+            &           '<PP_CHI.',nwfc
+         end if
+         write(6,'(t8,a)') &
+         &         'type="real"'
+         write(6,'(t8,a,i4,a)') &
+         &         'size="',nrl,'"'
+         write(6,'(t8,a)') &
+         &         'columns="4"'
+         write(6,'(t8,a,i1,a)') &
+         &         'index="',nwfc,'"'
+         write(6,'(t8,a,f6.3,a)') &
+         &         'occupation="',fj,'"'
+         write(6,'(t8,a,e20.10,a)') &
+         &         'pseudo_energy="',2*ea(nc+ii,ikap),'"'
+         write(6,'(t8,a,i1,a,a)') &
+         &         'label="',na(nc+ii),lnames(l1+1:l1+1),'"'
+         write(6,'(t8,a,i1,a)') &
+         &            'l="',l1,'" >'
 
- write(6,'(1p,4e20.10)') ((rl(ii)**2)*rhol(ii),ii=1,nrl)
+         write(6,'(1p,4e20.10)') (uual(jj,ikap,ii),jj=1,nrl)
 
- write(6,'(t2,a)') &
-&      '</PP_RHOATOM>'
+         if(nwfc <= 9) then
+            write(6,'(t4,a,i1,a)') &
+            &           '</PP_CHI.',nwfc,'>'
+         else
+            write(6,'(t4,a,i1,a)') &
+            &           '</PP_CHI.',nwfc,'>'
+         end if
+      end do
+   end do
+   write(6,'(t2,a)') &
+   &      '</PP_PSWFC>'
 
- write(6,'(t2,a)') &
-&      '<PP_SPIN_ORB>'
+   if(icmod>=1) then
+      write(6,'(t2,a,i4,a)') &
+      &        '<PP_NLCC type="real"  size="',nrl,'" columns="4">'
 
- iproj=0
- do l1=1,lmax+1
-  if(l1==lloc+1) cycle
-  ll=l1-1
-  if(ll==0) then
-   mkap=1
-  else
-   mkap=2
-  end if
+      write(6,'(1p,4e20.10)') (rhomodl(ii,1)/(4.0d0*pi),ii=1,nrl)
+
+      write(6,'(t2,a)') &
+      &        '</PP_NLCC>'
+   end if
+
+   write(6,'(t2,a,i4,a)') &
+   &      '<PP_RHOATOM type="real"  size="',nrl,'" columns="4">'
+
+   write(6,'(1p,4e20.10)') ((rl(ii)**2)*rhol(ii),ii=1,nrl)
+
+   write(6,'(t2,a)') &
+   &      '</PP_RHOATOM>'
+
+   write(6,'(t2,a)') &
+   &      '<PP_SPIN_ORB>'
+
+   iproj=0
+   do l1=1,lmax+1
+      if(l1==lloc+1) cycle
+      ll=l1-1
+      if(ll==0) then
+         mkap=1
+      else
+         mkap=2
+      end if
 ! loop on J = ll +/- 1/2
-  do jj=1,nproj(l1)
-   do ikap=mkap,1,-1
-    if(ikap==1) then
-      djjj=ll+0.5d0
-    else
-      djjj=ll-0.5d0
-    end if
-     iproj=iproj+1
-     if(iproj<=9) then
-       write(6,'(t4,a,i1,a,i1,a,i1,a,f3.1,a)') &
-&            '<PP_RELBETA.',iproj,'  index="',iproj,'"  lll="',ll, &
-&            '" jjj="',djjj,'"/>'
-     else
-       write(6,'(t4,a,i2,a,i2,a,i1,a,f3.1,a)') &
-&            '<PP_RELBETA.',iproj,' index="',iproj,'" lll="',ll, &
-&            '" jjj="',djjj,'"/>'
-     end if
-   end do !ikap
-  end do !jj (1,nproj(l1))
- end do !l1
+      do jj=1,nproj(l1)
+         do ikap=mkap,1,-1
+            if(ikap==1) then
+               djjj=ll+0.5d0
+            else
+               djjj=ll-0.5d0
+            end if
+            iproj=iproj+1
+            if(iproj<=9) then
+               write(6,'(t4,a,i1,a,i1,a,i1,a,f3.1,a)') &
+               &            '<PP_RELBETA.',iproj,'  index="',iproj,'"  lll="',ll, &
+               &            '" jjj="',djjj,'"/>'
+            else
+               write(6,'(t4,a,i2,a,i2,a,i1,a,f3.1,a)') &
+               &            '<PP_RELBETA.',iproj,' index="',iproj,'" lll="',ll, &
+               &            '" jjj="',djjj,'"/>'
+            end if
+         end do  !ikap
+      end do  !jj (1,nproj(l1))
+   end do  !l1
 
- nwfc = 0
- do ii=1,nv
-  l1 = la(nc+ii)
-  if(l1==0) then
-    mkap=1
-  else
-    mkap=2
-  end if
-  do ikap=1,mkap
-    nwfc = nwfc + 1
-    if(ikap==1) then
-      djjj=l1+0.5d0
-    else
-      djjj=l1-0.5d0
-    end if
-    if(nwfc <= 9) then
-       write(6,'(t4,a,i1,a,i1,a,i1,a,f3.1,a,i1,a)') &
-&            '<PP_RELWFC.',nwfc,'  index="',nwfc,'"  lchi="',l1, &
-&            '" jchi="',djjj,'" nn="',ii,'"/>'
-    else
-       write(6,'(t4,a,i2,a,i2,a,i1,a,f3.1,a,i1,a)') &
-&            '<PP_RELWFC.',nwfc,'  index="',nwfc,'"  lchi="',l1, &
-&            '" jchi="',djjj,'" nn="',ii,'"/>'
-    end if
-  end do
- end do
+   nwfc = 0
+   do ii=1,nv
+      l1 = la(nc+ii)
+      if(l1==0) then
+         mkap=1
+      else
+         mkap=2
+      end if
+      do ikap=1,mkap
+         nwfc = nwfc + 1
+         if(ikap==1) then
+            djjj=l1+0.5d0
+         else
+            djjj=l1-0.5d0
+         end if
+         if(nwfc <= 9) then
+            write(6,'(t4,a,i1,a,i1,a,i1,a,f3.1,a,i1,a)') &
+            &            '<PP_RELWFC.',nwfc,'  index="',nwfc,'"  lchi="',l1, &
+            &            '" jchi="',djjj,'" nn="',ii,'"/>'
+         else
+            write(6,'(t4,a,i2,a,i2,a,i1,a,f3.1,a,i1,a)') &
+            &            '<PP_RELWFC.',nwfc,'  index="',nwfc,'"  lchi="',l1, &
+            &            '" jchi="',djjj,'" nn="',ii,'"/>'
+         end if
+      end do
+   end do
 
- write(6,'(t2,a)') &
-&      '</PP_SPIN_ORB>'
+   write(6,'(t2,a)') &
+   &      '</PP_SPIN_ORB>'
 
- write(6,'(a)') &
-&      '</UPF>'
+   write(6,'(a)') &
+   &      '</UPF>'
 
 ! write termination signal
- write(6,'(/a)') 'END_PSP'
-  
- deallocate(rhol,rl,vkbl,vpl,rhomodl,dmat)
+   write(6,'(/a)') 'END_PSP'
 
- return
- end subroutine upfout_r
+   deallocate(rhol,rl,vkbl,vpl,rhomodl,dmat)
+
+   return
+end subroutine upfout_r

--- a/src/vkboutwf.f90
+++ b/src/vkboutwf.f90
@@ -2,21 +2,21 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- subroutine vkboutwf(ll,nvkb,ep,vkb,evkb,rr,vloc,uu,up,node,mmax,mch)
+subroutine vkboutwf(ll,nvkb,ep,vkb,evkb,rr,vloc,uu,up,node,mmax,mch)
 
 ! computes Vanderbilt / Kleinman-Bylander outward-integrated wave functions
 
@@ -33,103 +33,103 @@
 !mmax  dimension of log mesh
 !mch  index of radius to which wave function is to be integrated
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !Input variables
- real(dp) :: rr(mmax),vloc(mmax),vkb(mmax,nvkb),evkb(nvkb)
- real(dp) :: ep
- integer nvkb,ll,mmax,mch
+   real(dp) :: rr(mmax),vloc(mmax),vkb(mmax,nvkb),evkb(nvkb)
+   real(dp) :: ep
+   integer :: nvkb,ll,mmax,mch
 
 !Output variables
- real(dp) :: uu(mmax),up(mmax)
- integer node
+   real(dp) :: uu(mmax),up(mmax)
+   integer :: node
 
 !Local variables
-real(dp) :: rc,rn
- real(dp), allocatable ::  phi(:,:),phip(:,:),phi0(:),phi0p(:)
- real(dp), allocatable ::  gg0(:),gg(:,:)
- integer, allocatable :: ipiv(:)
+   real(dp) :: rc,rn
+   real(dp), allocatable ::  phi(:,:),phip(:,:),phi0(:),phi0p(:)
+   real(dp), allocatable ::  gg0(:),gg(:,:)
+   integer, allocatable :: ipiv(:)
 
- integer ii,jj,kk,ierr,info
+   integer :: ii,jj,kk,ierr,info
 
- uu(:)=0.0d0
- up(:)=0.0d0
+   uu(:)=0.0d0
+   up(:)=0.0d0
 
 ! homogeneous solution
- call lschps(ll+1,ll,ierr,ep,rr,vloc,uu,up,mmax,mch)
+   call lschps(ll+1,ll,ierr,ep,rr,vloc,uu,up,mmax,mch)
 
- rc=0.0d0
- if(nvkb/=0) then
+   rc=0.0d0
+   if(nvkb/=0) then
 ! find cutoff radius for projectors
-  do ii=mmax,1,-1
-    if(abs(vkb(ii,1))>0.0d0) then
-      rc=rr(ii)
-      exit
-    end if
-  end do
+      do ii=mmax,1,-1
+         if(abs(vkb(ii,1))>0.0d0) then
+            rc=rr(ii)
+            exit
+         end if
+      end do
 
-  allocate(phi(mmax,nvkb),phip(mmax,nvkb))
-  allocate(gg(nvkb,nvkb),gg0(nvkb))
-  allocate(ipiv(nvkb))
+      allocate(phi(mmax,nvkb),phip(mmax,nvkb))
+      allocate(gg(nvkb,nvkb),gg0(nvkb))
+      allocate(ipiv(nvkb))
 
-  phi(:,:)=0.0d0
-  phip(:,:)=0.0d0
-  gg(:,:)=0.0d0
-  gg0(:)=0.0d0
+      phi(:,:)=0.0d0
+      phip(:,:)=0.0d0
+      gg(:,:)=0.0d0
+      gg0(:)=0.0d0
 
 ! inhomogeneous solutions
-  do ii=1,nvkb
-   call lschkb(ll+1,ll,ierr,ep,vkb(1,ii),rr,vloc,phi(1,ii),phip(1,ii),mmax,mch)
-  end do
+      do ii=1,nvkb
+         call lschkb(ll+1,ll,ierr,ep,vkb(1,ii),rr,vloc,phi(1,ii),phip(1,ii),mmax,mch)
+      end do
 
 
 ! projector matrix elements and coefficient matrix
-  do jj=1,nvkb
-   call vpinteg(uu,vkb(1,jj),mch,2*ll+2,gg0(jj),rr)
-   gg0(jj)=evkb(jj)*gg0(jj)
-   do ii=1,nvkb
-    call vpinteg(phi(1,ii),vkb(1,jj),mch,2*ll+2,gg(jj,ii),rr)
-    gg(jj,ii)=-evkb(jj)*gg(jj,ii)
-   end do
-   gg(jj,jj)=1.0d0+gg(jj,jj)
-  end do
+      do jj=1,nvkb
+         call vpinteg(uu,vkb(1,jj),mch,2*ll+2,gg0(jj),rr)
+         gg0(jj)=evkb(jj)*gg0(jj)
+         do ii=1,nvkb
+            call vpinteg(phi(1,ii),vkb(1,jj),mch,2*ll+2,gg(jj,ii),rr)
+            gg(jj,ii)=-evkb(jj)*gg(jj,ii)
+         end do
+         gg(jj,jj)=1.0d0+gg(jj,jj)
+      end do
 
 ! solve linear equations for coefficients
 
 !    SUBROUTINE DGESV( N, NRHS, A, LDA, IPIV, B, LDB, INFO )
 
-   call dgesv(nvkb, 1, gg, nvkb, ipiv, gg0, nvkb, info)
-   if(info/=0) then
-    write(6,'(/a,i4)') 'vkbout: dgesv ERROR, stopping info =',info
-    stop
-   end if
+      call dgesv(nvkb, 1, gg, nvkb, ipiv, gg0, nvkb, info)
+      if(info/=0) then
+         write(6,'(/a,i4)') 'vkbout: dgesv ERROR, stopping info =',info
+         stop
+      end if
 
 ! output wave functions
-   do jj=1,nvkb
-    uu(:)=uu(:)+gg0(jj)*phi(:,jj)
-    up(:)=up(:)+gg0(jj)*phip(:,jj)
-   end do
+      do jj=1,nvkb
+         uu(:)=uu(:)+gg0(jj)*phi(:,jj)
+         up(:)=up(:)+gg0(jj)*phip(:,jj)
+      end do
 
-  deallocate(phi,phip)
-  deallocate(gg,gg0)
-  deallocate(ipiv)
- end if
+      deallocate(phi,phip)
+      deallocate(gg,gg0)
+      deallocate(ipiv)
+   end if
 
 ! lower cutoff for node counting to avoid small-r noise
- rn=dmax1(0.10d0*rc, 0.05d0)
+   rn=dmax1(0.10d0*rc, 0.05d0)
 
- node=0
- do ii=6,mch
+   node=0
+   do ii=6,mch
 ! note historic evolution!
 !  if(rr(ii)>0.5d0 .and. uu(ii-1)*uu(ii)<0.0d0) then
 !  if(rr(ii)>0.25d0 .and. uu(ii-1)*uu(ii)<0.0d0) then
 !  if(rr(ii)>0.10d0 .and. uu(ii-1)*uu(ii)<0.0d0) then
 !  if(rr(ii)>0.07d0 .and. uu(ii-1)*uu(ii)<0.0d0) then
-   if(rr(ii)>rn .and. uu(ii-1)*uu(ii)<0.0d0) then
-    node=node+1
-   end if
- end do
+      if(rr(ii)>rn .and. uu(ii-1)*uu(ii)<0.0d0) then
+         node=node+1
+      end if
+   end do
 
- return
- end subroutine vkboutwf
+   return
+end subroutine vkboutwf

--- a/src/vkbphsft.f90
+++ b/src/vkbphsft.f90
@@ -2,21 +2,21 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- subroutine vkbphsft(ll,ivkb,epsh2,depsh,ep,pshf,pshp, &
+subroutine vkbphsft(ll,ivkb,epsh2,depsh,ep,pshf,pshp, &
 & rr,vloc,vkb,evkb,mmax,mch,npsh)
 
 ! computes Vanderfilt / Kleinman-Bylander scattering log derivatives
@@ -39,124 +39,124 @@
 !mch  index of radius for log der test
 !npsh  number of energy points in scan
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
- real(dp), parameter :: pi=3.141592653589793238462643383279502884197_dp
- real(dp), parameter :: pi2=2.0d0*pi
- real(dp), parameter :: eps=1.0d-8
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
+   real(dp), parameter :: pi=3.141592653589793238462643383279502884197_dp
+   real(dp), parameter :: pi2=2.0d0*pi
+   real(dp), parameter :: eps=1.0d-8
 
 !Input variables
- integer :: ll,ivkb,mmax,npsh,mch,mcht
- real(dp) :: rr(mmax),vloc(mmax),vkb(mmax,*),evkb(*)
- real(dp) :: pshf(npsh)
- real(dp) :: depsh,epsh2,ep
+   integer :: ll,ivkb,mmax,npsh,mch,mcht
+   real(dp) :: rr(mmax),vloc(mmax),vkb(mmax,*),evkb(*)
+   real(dp) :: pshf(npsh)
+   real(dp) :: depsh,epsh2,ep
 
 !Output variables
- real(dp) :: pshp(npsh)
+   real(dp) :: pshp(npsh)
 
 !Local variables
- real(dp) :: al,dnpi,epsh,phi,phip,pshoff
- real(dp) :: dmin,dmax,dtst,emin,emax,et,psmin,psmax,pst,shift,shift2
- integer :: ii,jj,ierr,node,n2
- logical :: jump
+   real(dp) :: al,dnpi,epsh,phi,phip,pshoff
+   real(dp) :: dmin,dmax,dtst,emin,emax,et,psmin,psmax,pst,shift,shift2
+   integer :: ii,jj,ierr,node,n2
+   logical :: jump
 
- real(dp), allocatable :: uu(:),up(:)
+   real(dp), allocatable :: uu(:),up(:)
 
 
 
- allocate(uu(mmax),up(mmax))
+   allocate(uu(mmax),up(mmax))
 
- al = 0.01d0 * dlog(rr(101) / rr(1))
+   al = 0.01d0 * dlog(rr(101) / rr(1))
 
- pshoff = 0.0d0
+   pshoff = 0.0d0
 
- do ii = 1,npsh
-   epsh = epsh2-(ii-1)*depsh
+   do ii = 1,npsh
+      epsh = epsh2-(ii-1)*depsh
 
-   call vkboutwf(ll,ivkb,epsh,vkb,evkb,rr,vloc,uu,up,node,mmax,mch)
+      call vkboutwf(ll,ivkb,epsh,vkb,evkb,rr,vloc,uu,up,node,mmax,mch)
 
-   phi = uu(mch)/rr(mch)
-   phip = (up(mch)-al*uu(mch))/(al*rr(mch)**2)
-   pshp(ii) = atan2(rr(mch)*phip,phi) + pshoff
+      phi = uu(mch)/rr(mch)
+      phip = (up(mch)-al*uu(mch))/(al*rr(mch)**2)
+      pshp(ii) = atan2(rr(mch)*phip,phi) + pshoff
 
 ! Shift for continuity and to avoid false jumps suggesting ghost states
 
 ! -2 pi jump is harmless cycling from pi to -pi
-   if(ii>1) then
-      if(pshp(ii)<pshp(ii-1)-4.0d0) then
-        pshoff = pshoff+pi2
-        pshp(ii) = pshp(ii)+pi2
-   ! +/- pi jump can be actual bound semi-core state, ghost state, or spurious
-   ! jump from sudden change of sign of both uu and up with no real change
-   ! of shape.
-      else if(abs(pshp(ii)-pshp(ii-1))>2.0d0) then
-        shift=sign(pi,pshp(ii)-pshp(ii-1))
+      if(ii>1) then
+         if(pshp(ii)<pshp(ii-1)-4.0d0) then
+            pshoff = pshoff+pi2
+            pshp(ii) = pshp(ii)+pi2
+            ! +/- pi jump can be actual bound semi-core state, ghost state, or spurious
+            ! jump from sudden change of sign of both uu and up with no real change
+            ! of shape.
+         else if(abs(pshp(ii)-pshp(ii-1))>2.0d0) then
+            shift=sign(pi,pshp(ii)-pshp(ii-1))
 
-   ! interval-halving search to determine if this is a discontinuous pi jump
-   ! or varies continuously on some scale, indicating a real or ghost
-   ! bound state / resonance
-        jump=.true.
-        emin=epsh
-        emax=epsh+depsh
-        psmin=pshp(ii)
-        psmax=pshp(ii-1)
+            ! interval-halving search to determine if this is a discontinuous pi jump
+            ! or varies continuously on some scale, indicating a real or ghost
+            ! bound state / resonance
+            jump=.true.
+            emin=epsh
+            emax=epsh+depsh
+            psmin=pshp(ii)
+            psmax=pshp(ii-1)
 !       if((psmax-psmin)>pi) psmin=psmin+pi2
-        if((psmax-psmin)>2.9d0) psmin=psmin+pi2
+            if((psmax-psmin)>2.9d0) psmin=psmin+pi2
 
-        do jj=1,25
+            do jj=1,25
 
-          if(.not. jump) cycle
-          et=0.5d0*(emin+emax)
-          shift2=0.0d0
+               if(.not. jump) cycle
+               et=0.5d0*(emin+emax)
+               shift2=0.0d0
 
-          call vkboutwf(ll,ivkb,et,vkb,evkb,rr,vloc,uu,up,node,mmax,mch)
-          phi = uu(mch)/rr(mch)
-          phip = (up(mch)-al*uu(mch))/(al*rr(mch)**2)
-          pst = atan2(rr(mch)*phip,phi) + pshoff
-          if((psmax-pst)>2.9d0) then
-            pst=pst+pi2
-            shift2=pi2
-          end if
+               call vkboutwf(ll,ivkb,et,vkb,evkb,rr,vloc,uu,up,node,mmax,mch)
+               phi = uu(mch)/rr(mch)
+               phip = (up(mch)-al*uu(mch))/(al*rr(mch)**2)
+               pst = atan2(rr(mch)*phip,phi) + pshoff
+               if((psmax-pst)>2.9d0) then
+                  pst=pst+pi2
+                  shift2=pi2
+               end if
 
-          dmin=abs(pst-psmin)
-          dmax=abs(psmax-pst)
+               dmin=abs(pst-psmin)
+               dmax=abs(psmax-pst)
 
-          if(dmin>dmax) then
-            emax=et
-            psmax=pst
-          else
-            emin=et
-            psmin=pst
-          end if
+               if(dmin>dmax) then
+                  emax=et
+                  psmax=pst
+               else
+                  emin=et
+                  psmin=pst
+               end if
 
-   ! this is the test to see if an interval of change less than pi had been
-   ! reached
-          if(dmax<0.5d0 .and. dmin<0.5d0) jump=.false.
+               ! this is the test to see if an interval of change less than pi had been
+               ! reached
+               if(dmax<0.5d0 .and. dmin<0.5d0) jump=.false.
 
-        end do
+            end do
 
-   ! if this is a spurious abrupt jump, restore +/- pi
-        if(jump) then
-          pshoff = pshoff-shift
-          pshp(ii) = pshp(ii)-shift
-   ! if this is a real continuous transition, check for 2 pi issue and fix
-        else if(pshp(ii)<pshp(ii-1)-2.5d0) then
-          pshoff = pshoff+pi2
-          pshp(ii) = pshp(ii)+pi2
-        end if
+            ! if this is a spurious abrupt jump, restore +/- pi
+            if(jump) then
+               pshoff = pshoff-shift
+               pshp(ii) = pshp(ii)-shift
+               ! if this is a real continuous transition, check for 2 pi issue and fix
+            else if(pshp(ii)<pshp(ii-1)-2.5d0) then
+               pshoff = pshoff+pi2
+               pshp(ii) = pshp(ii)+pi2
+            end if
 
+         end if
       end if
-   end if
 
 ! calculate shift to align with all-electron results
-   if(abs(ep-epsh)-0.5d0*depsh<eps) then
-     dnpi = pi*(nint((pshf(ii)-pshp(ii))/pi))
-   end if
+      if(abs(ep-epsh)-0.5d0*depsh<eps) then
+         dnpi = pi*(nint((pshf(ii)-pshp(ii))/pi))
+      end if
 
- end do
+   end do
 
- pshp(:)=pshp(:)+dnpi
+   pshp(:)=pshp(:)+dnpi
 
- deallocate(uu,up)
- return
- end subroutine vkbphsft
+   deallocate(uu,up)
+   return
+end subroutine vkbphsft

--- a/src/vout.f90
+++ b/src/vout.f90
@@ -2,24 +2,24 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
 ! calculates Hartree and exchange-correlation potentials and total-energy
 ! term to add to eigenvalue sum
 
- subroutine vout(mode,rho,rhoc,vo,vxc,zion,eeel,eexc, &
+subroutine vout(mode,rho,rhoc,vo,vxc,zion,eeel,eexc, &
 &                rr,mmax,iexc)
 
 !mode  1=> add rhoc to rho, 0 => don't
@@ -33,162 +33,162 @@
 !rr  log radial mesh
 !output electrostatic and exchange-correlation potential
 
- implicit none
+   implicit none
 
- integer, parameter :: dp=kind(1.0d0)
- real(dp), parameter :: pi=3.141592653589793238462643383279502884197_dp
- real(dp), parameter :: pi4=4.0_dp*pi
+   integer, parameter :: dp=kind(1.0d0)
+   real(dp), parameter :: pi=3.141592653589793238462643383279502884197_dp
+   real(dp), parameter :: pi4=4.0_dp*pi
 
 !Input vaiables
- integer :: iexc,mmax,mode
- real(dp) :: rho(mmax),rhoc(mmax),rr(mmax)
- real(dp) :: zion
+   integer :: iexc,mmax,mode
+   real(dp) :: rho(mmax),rhoc(mmax),rr(mmax)
+   real(dp) :: zion
 
 !Output variables
- real(dp) :: vo(mmax),vxc(mmax)
- real(dp) :: eeel,eexc
+   real(dp) :: vo(mmax),vxc(mmax)
+   real(dp) :: eeel,eexc
 
 !Local variables
- integer ii
- real(dp) :: al,tv
+   integer :: ii
+   real(dp) :: al,tv
 
 !Function
- real(dp) :: aii
+   real(dp) :: aii
 
- real(dp), allocatable :: rvp(:),rv(:),excca(:),difxc(:)
- real(dp), allocatable :: exca(:),vxcd(:),rhot(:)
- real(dp), allocatable :: foutv(:),foutx(:),foutfc(:)
+   real(dp), allocatable :: rvp(:),rv(:),excca(:),difxc(:)
+   real(dp), allocatable :: exca(:),vxcd(:),rhot(:)
+   real(dp), allocatable :: foutv(:),foutx(:),foutfc(:)
 
- allocate(rvp(mmax),rv(mmax),excca(mmax),difxc(mmax))
- allocate(exca(mmax),vxcd(mmax),rhot(mmax))
- allocate(foutv(mmax),foutx(mmax),foutfc(mmax))
+   allocate(rvp(mmax),rv(mmax),excca(mmax),difxc(mmax))
+   allocate(exca(mmax),vxcd(mmax),rhot(mmax))
+   allocate(foutv(mmax),foutx(mmax),foutfc(mmax))
 
 
- al = 0.01d0 * dlog(rr(101) / rr(1))
+   al = 0.01d0 * dlog(rr(101) / rr(1))
 
- foutfc(:)=0.0d0
+   foutfc(:)=0.0d0
 
 ! integration for electrostatic potential
- do ii=1,mmax
-   rvp(ii)=rho(ii)*al*rr(ii)**3
- end do
+   do ii=1,mmax
+      rvp(ii)=rho(ii)*al*rr(ii)**3
+   end do
 
- rv(mmax)=zion
- rv(mmax-1)=zion
- rv(mmax-2)=zion
+   rv(mmax)=zion
+   rv(mmax-1)=zion
+   rv(mmax-2)=zion
 
- do ii=mmax-2,2,-1
-   rv(ii-1)=rv(ii)+aii(rvp,ii)
- end do
+   do ii=mmax-2,2,-1
+      rv(ii-1)=rv(ii)+aii(rvp,ii)
+   end do
 
- do ii=1,mmax
-   rvp(ii)=rho(ii)*al*rr(ii)**2
- end do
+   do ii=1,mmax
+      rvp(ii)=rho(ii)*al*rr(ii)**2
+   end do
 
- tv=0.0d0
- do ii=mmax-2,2,-1
-   tv=tv+aii(rvp,ii)
-   rv(ii-1)=rv(ii-1)-rr(ii-1)*tv
- end do
+   tv=0.0d0
+   do ii=mmax-2,2,-1
+      tv=tv+aii(rvp,ii)
+      rv(ii-1)=rv(ii-1)-rr(ii-1)*tv
+   end do
 
- do ii=1,mmax
-   vo(ii)=rv(ii)/rr(ii)
- end do
+   do ii=1,mmax
+      vo(ii)=rv(ii)/rr(ii)
+   end do
 
 ! electron-electron interaction for total energy
- do ii=1,mmax
-  foutv(ii)=rho(ii)*vo(ii)*rr(ii)**3
- end do
-
- eeel=(9.0d0*foutv(1) + 28.0d0*foutv(2) &
-&   + 23.0d0*foutv(3))/24.0d0
- do ii=4,mmax
-   eeel=eeel + foutv(ii)
- end do
- eeel=al*eeel + foutv(1)/3.0d0
-
- if(mode .eq. 0) then
-   do ii = 1, mmax
-     rhot(ii) = rho(ii)
+   do ii=1,mmax
+      foutv(ii)=rho(ii)*vo(ii)*rr(ii)**3
    end do
- else if(mode .eq. 1) then
-   do ii = 1, mmax
-     rhot(ii) = rho(ii) + rhoc(ii)
+
+   eeel=(9.0d0*foutv(1) + 28.0d0*foutv(2) &
+   &   + 23.0d0*foutv(3))/24.0d0
+   do ii=4,mmax
+      eeel=eeel + foutv(ii)
    end do
- else
-   write(6,'(/a,i4)') 'vout: ERROR bad input mode =',mode
-   stop
- end if
+   eeel=al*eeel + foutv(1)/3.0d0
+
+   if(mode == 0) then
+      do ii = 1, mmax
+         rhot(ii) = rho(ii)
+      end do
+   else if(mode == 1) then
+      do ii = 1, mmax
+         rhot(ii) = rho(ii) + rhoc(ii)
+      end do
+   else
+      write(6,'(/a,i4)') 'vout: ERROR bad input mode =',mode
+      stop
+   end if
 
 ! exchange-correlation potential added
 
- if(iexc .eq. 1) then
-   call excwig(rhot,vxc,exca,mmax)
- else if(iexc .eq. 2) then
-   call exchdl(rhot,vxc,exca,mmax)
- else if(iexc .eq. 3) then
-   call excpzca(rhot,vxc,exca,mmax)
- else if(iexc .eq. 4) then
-   call excggc(rhot,vxc,exca,rr,mmax)
- else if (iexc < 0) then
-   call exc_libxc(iexc,al,rhot,vxc,exca,rr,mmax)
- else
-   write(6,'(/a,i4)') 'vout: ERROR bad input iexc =',iexc
-   stop
- end if
+   if(iexc == 1) then
+      call excwig(rhot,vxc,exca,mmax)
+   else if(iexc == 2) then
+      call exchdl(rhot,vxc,exca,mmax)
+   else if(iexc == 3) then
+      call excpzca(rhot,vxc,exca,mmax)
+   else if(iexc == 4) then
+      call excggc(rhot,vxc,exca,rr,mmax)
+   else if (iexc < 0) then
+      call exc_libxc(iexc,al,rhot,vxc,exca,rr,mmax)
+   else
+      write(6,'(/a,i4)') 'vout: ERROR bad input iexc =',iexc
+      stop
+   end if
 
- do ii = 1, mmax
-   difxc(ii)=exca(ii) - vxc(ii)
-   vo(ii)=vo(ii) + vxc(ii)
- end do
+   do ii = 1, mmax
+      difxc(ii)=exca(ii) - vxc(ii)
+      vo(ii)=vo(ii) + vxc(ii)
+   end do
 
 ! exchange-correlation correction for total energy
 
- do ii=1,mmax
-  foutx(ii)=rho(ii)*difxc(ii)*rr(ii)**3
- end do
- eexc=(9.0d0*foutx(1) + 28.0d0*foutx(2) &
-&   + 23.0d0*foutx(3))/24.0d0
- do ii=4,mmax
-   eexc=eexc + foutx(ii)
- end do
+   do ii=1,mmax
+      foutx(ii)=rho(ii)*difxc(ii)*rr(ii)**3
+   end do
+   eexc=(9.0d0*foutx(1) + 28.0d0*foutx(2) &
+   &   + 23.0d0*foutx(3))/24.0d0
+   do ii=4,mmax
+      eexc=eexc + foutx(ii)
+   end do
 
- if(mode .eq. 1 .and. rhoc(1) .ne. 0.0d0) then
-   if(iexc .eq. 1) then
-     call excwig(rhoc,vxcd,excca,mmax)
-   else if(iexc .eq. 2) then
-     call exchdl(rhoc,vxcd,excca,mmax)
-   else if(iexc .eq. 3) then
-     call excpzca(rhoc,vxcd,excca,mmax)
-   else if(iexc .eq. 4) then
-     call excggc(rhoc,vxcd,excca,rr,mmax)
-   else if (iexc < 0) then
-     call exc_libxc(iexc,al,rhoc,vxcd,excca,rr,mmax)
-   else
-     write(6,'(/a,i4)') 'vout: ERROR bad input iexc =',iexc
-     stop
+   if(mode == 1 .and. rhoc(1) /= 0.0d0) then
+      if(iexc == 1) then
+         call excwig(rhoc,vxcd,excca,mmax)
+      else if(iexc == 2) then
+         call exchdl(rhoc,vxcd,excca,mmax)
+      else if(iexc == 3) then
+         call excpzca(rhoc,vxcd,excca,mmax)
+      else if(iexc == 4) then
+         call excggc(rhoc,vxcd,excca,rr,mmax)
+      else if (iexc < 0) then
+         call exc_libxc(iexc,al,rhoc,vxcd,excca,rr,mmax)
+      else
+         write(6,'(/a,i4)') 'vout: ERROR bad input iexc =',iexc
+         stop
+      end if
+
+      do ii=1,mmax
+         foutfc(ii)=rhoc(ii)*(exca(ii) - excca(ii))*rr(ii)**3
+      end do
+      eexc=eexc + (9.0d0*foutfc(1) + 28.0d0*foutfc(2) &
+      &     + 23.0d0*foutfc(3))/24.0d0
+      do ii=4,mmax
+         eexc=eexc + foutfc(ii)
+      end do
    end if
 
-   do ii=1,mmax
-    foutfc(ii)=rhoc(ii)*(exca(ii) - excca(ii))*rr(ii)**3
-   end do
-   eexc=eexc + (9.0d0*foutfc(1) + 28.0d0*foutfc(2) &
-&     + 23.0d0*foutfc(3))/24.0d0
-   do ii=4,mmax
-     eexc=eexc + foutfc(ii)
-   end do
- end if
-
- eexc=al*eexc + foutx(1)/3.0d0
+   eexc=al*eexc + foutx(1)/3.0d0
 
 
- if(mode .eq. 1) then
-   eexc=eexc + foutfc(1)/3.0d0
- end if
+   if(mode == 1) then
+      eexc=eexc + foutfc(1)/3.0d0
+   end if
 
- deallocate(rvp,rv,excca,difxc)
- deallocate(exca,vxcd,rhot)
- deallocate(foutv,foutx,foutfc)
- return
+   deallocate(rvp,rv,excca,difxc)
+   deallocate(exca,vxcd,rhot)
+   deallocate(foutv,foutx,foutfc)
+   return
 
- end subroutine vout
+end subroutine vout

--- a/src/vpinteg.f90
+++ b/src/vpinteg.f90
@@ -2,24 +2,24 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- subroutine vpinteg(gg,hh,nn,mm,ss,rr)
+subroutine vpinteg(gg,hh,nn,mm,ss,rr)
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 ! integrals that go into construction of Vanderbilt separable pseudopotential
 
@@ -27,30 +27,30 @@
 ! integral on usual log mesh from 1 to nn
 
 !Input variables
- real(dp) :: gg(nn),hh(nn),rr(nn)
- integer :: nn,mm
+   real(dp) :: gg(nn),hh(nn),rr(nn)
+   integer :: nn,mm
 
 !Output variable
- real(dp) :: ss
+   real(dp) :: ss
 
 !Local variables
- real(dp) :: r0,amesh,al
- integer :: ii
+   real(dp) :: r0,amesh,al
+   integer :: ii
 
- al = 0.01d0 * dlog(rr(101)/rr(1))
- amesh = exp(al)
+   al = 0.01d0 * dlog(rr(101)/rr(1))
+   amesh = exp(al)
 
- r0=rr(1)/dsqrt(amesh)
- ss=r0**(mm+1)*(gg(1)*hh(1)/rr(1)**mm)/dfloat(mm+1)
+   r0=rr(1)/dsqrt(amesh)
+   ss=r0**(mm+1)*(gg(1)*hh(1)/rr(1)**mm)/dfloat(mm+1)
 
- do ii = 4, nn - 3
-   ss =  ss + al*gg(ii)*hh(ii)*rr(ii)
- end do
+   do ii = 4, nn - 3
+      ss =  ss + al*gg(ii)*hh(ii)*rr(ii)
+   end do
 
- ss=ss + al*(23.d0*rr(nn-2)*gg(nn-2)*hh(nn-2) &
-&        + 28.d0*rr(nn-1)*gg(nn-1)*hh(nn-1) &
-&        +  9.d0*rr(nn  )*gg(nn  )*hh(nn  ))/24.d0
+   ss=ss + al*(23.d0*rr(nn-2)*gg(nn-2)*hh(nn-2) &
+   &        + 28.d0*rr(nn-1)*gg(nn-1)*hh(nn-1) &
+   &        +  9.d0*rr(nn  )*gg(nn  )*hh(nn  ))/24.d0
 
 
- return
- end subroutine vpinteg
+   return
+end subroutine vpinteg

--- a/src/vploc.f90
+++ b/src/vploc.f90
@@ -2,21 +2,21 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- subroutine vploc(rr,vv,vp,dvloc0,irc,mmax,lpopt)
+subroutine vploc(rr,vv,vp,dvloc0,irc,mmax,lpopt)
 
 !polynomial extrapolation of all-electron potential to rr=0
 
@@ -33,125 +33,125 @@
 !  4) match 3 derivatives, r**0,4,6,8
 !  5) match 3 derivatives, r**0,2,4,6
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 ! Input variables
- integer :: irc,mmax,lpopt
- real(dp) :: dvloc0
- real(dp) :: rr(mmax),vv(mmax)
+   integer :: irc,mmax,lpopt
+   real(dp) :: dvloc0
+   real(dp) :: rr(mmax),vv(mmax)
 
 ! Output variables
- real(dp) :: vp(mmax,5)
+   real(dp) :: vp(mmax,5)
 
 !Local variables
- integer :: ii
- real(dp) :: aco,al,bco,cco,dco,cl,d3vv,fnp,x
+   integer :: ii
+   real(dp) :: aco,al,bco,cco,dco,cl,d3vv,fnp,x
 
- real(dp), allocatable :: dvv(:),d2vv(:)
+   real(dp), allocatable :: dvv(:),d2vv(:)
 
- allocate(dvv(mmax),d2vv(mmax))
+   allocate(dvv(mmax),d2vv(mmax))
 
- al = 0.01d0 * dlog(rr(101) / rr(1))
+   al = 0.01d0 * dlog(rr(101) / rr(1))
 
 ! derivatives of vv
- 
- do ii = irc - 4, irc + 4
-   dvv(ii)=(2.d0*vv(ii-2)-16.d0*vv(ii-1)+16.d0*vv(ii+1) &
-&         -2.d0*vv(ii+2))/(24.d0*al*rr(ii))
- end do
 
- 
- do ii = irc - 2, irc + 2
-   d2vv(ii)=(2.d0*dvv(ii-2)-16.d0*dvv(ii-1)+16.d0*dvv(ii+1) &
-&         -2.d0*dvv(ii+2))/(24.d0*al*rr(ii))
- end do
+   do ii = irc - 4, irc + 4
+      dvv(ii)=(2.d0*vv(ii-2)-16.d0*vv(ii-1)+16.d0*vv(ii+1) &
+      &         -2.d0*vv(ii+2))/(24.d0*al*rr(ii))
+   end do
 
- ii = irc
- d3vv=(2.d0*d2vv(ii-2)-16.d0*d2vv(ii-1)+16.d0*d2vv(ii+1) &
-&       -2.d0*d2vv(ii+2))/(24.d0*al*rr(ii))
 
- 
- if(lpopt .eq. 1) then
+   do ii = irc - 2, irc + 2
+      d2vv(ii)=(2.d0*dvv(ii-2)-16.d0*dvv(ii-1)+16.d0*dvv(ii+1) &
+      &         -2.d0*dvv(ii+2))/(24.d0*al*rr(ii))
+   end do
 
-   bco=(3*dvv(ii)-d2vv(ii)*rr(ii))/(4*rr(ii))
-   cco=( -dvv(ii)+d2vv(ii)*rr(ii))/(8*rr(ii)**3)
-   aco=vv(ii)-bco*rr(ii)**2-cco*rr(ii)**4
+   ii = irc
+   d3vv=(2.d0*d2vv(ii-2)-16.d0*d2vv(ii-1)+16.d0*d2vv(ii+1) &
+   &       -2.d0*d2vv(ii+2))/(24.d0*al*rr(ii))
 
- else if (lpopt .eq. 2) then
 
-   bco=( 5*dvv(ii)-d2vv(ii)*rr(ii))/(8*rr(ii)**3)
-   cco=(-3*dvv(ii)+d2vv(ii)*rr(ii))/(12*rr(ii)**5)
-   aco=vv(ii)-bco*rr(ii)**4-cco*rr(ii)**6
+   if(lpopt == 1) then
 
- else if(lpopt .eq. 3) then
+      bco=(3*dvv(ii)-d2vv(ii)*rr(ii))/(4*rr(ii))
+      cco=( -dvv(ii)+d2vv(ii)*rr(ii))/(8*rr(ii)**3)
+      aco=vv(ii)-bco*rr(ii)**2-cco*rr(ii)**4
 
-   bco=( 20*dvv(ii)-8*d2vv(ii)*rr(ii)+d3vv*rr(ii)**2)/(8*rr(ii)**3)
-   cco=(-15*dvv(ii)+7*d2vv(ii)*rr(ii)-d3vv*rr(ii)**2)/(5*rr(ii)**4)
-   dco=( 12*dvv(ii)-6*d2vv(ii)*rr(ii)+d3vv*rr(ii)**2)/(12*rr(ii)**5)
-   aco = vv(ii)-bco*rr(ii)**4-cco*rr(ii)**5-dco*rr(ii)**6
+   else if (lpopt == 2) then
 
- else if(lpopt .eq. 4) then
+      bco=( 5*dvv(ii)-d2vv(ii)*rr(ii))/(8*rr(ii)**3)
+      cco=(-3*dvv(ii)+d2vv(ii)*rr(ii))/(12*rr(ii)**5)
+      aco=vv(ii)-bco*rr(ii)**4-cco*rr(ii)**6
 
-   bco=(35*dvv(ii)-11*d2vv(ii)*rr(ii)+d3vv*rr(ii)**2)/(32*rr(ii)**3)
-   cco=(-21*dvv(ii)+9*d2vv(ii)*rr(ii)-d3vv*rr(ii)**2)/(24*rr(ii)**5)
-   dco=(15*dvv(ii)-7*d2vv(ii)*rr(ii)+d3vv*rr(ii)**2)/(64*rr(ii)**7)
-   aco = vv(ii)-bco*rr(ii)**4-cco*rr(ii)**6-dco*rr(ii)**8
+   else if(lpopt == 3) then
 
- else if(lpopt .eq. 5) then
+      bco=( 20*dvv(ii)-8*d2vv(ii)*rr(ii)+d3vv*rr(ii)**2)/(8*rr(ii)**3)
+      cco=(-15*dvv(ii)+7*d2vv(ii)*rr(ii)-d3vv*rr(ii)**2)/(5*rr(ii)**4)
+      dco=( 12*dvv(ii)-6*d2vv(ii)*rr(ii)+d3vv*rr(ii)**2)/(12*rr(ii)**5)
+      aco = vv(ii)-bco*rr(ii)**4-cco*rr(ii)**5-dco*rr(ii)**6
 
-   bco=(15*dvv(ii)-7*d2vv(ii)*rr(ii)+d3vv*rr(ii)**2)/(16*rr(ii))
-   cco=(-5*dvv(ii)+5*d2vv(ii)*rr(ii)-d3vv*rr(ii)**2)/(16*rr(ii)**3)
-   dco=( 3*dvv(ii)-3*d2vv(ii)*rr(ii)+d3vv*rr(ii)**2)/(48*rr(ii)**5)
-   aco = vv(ii)-bco*rr(ii)**2-cco*rr(ii)**4-dco*rr(ii)**6
+   else if(lpopt == 4) then
 
- end if
+      bco=(35*dvv(ii)-11*d2vv(ii)*rr(ii)+d3vv*rr(ii)**2)/(32*rr(ii)**3)
+      cco=(-21*dvv(ii)+9*d2vv(ii)*rr(ii)-d3vv*rr(ii)**2)/(24*rr(ii)**5)
+      dco=(15*dvv(ii)-7*d2vv(ii)*rr(ii)+d3vv*rr(ii)**2)/(64*rr(ii)**7)
+      aco = vv(ii)-bco*rr(ii)**4-cco*rr(ii)**6-dco*rr(ii)**8
+
+   else if(lpopt == 5) then
+
+      bco=(15*dvv(ii)-7*d2vv(ii)*rr(ii)+d3vv*rr(ii)**2)/(16*rr(ii))
+      cco=(-5*dvv(ii)+5*d2vv(ii)*rr(ii)-d3vv*rr(ii)**2)/(16*rr(ii)**3)
+      dco=( 3*dvv(ii)-3*d2vv(ii)*rr(ii)+d3vv*rr(ii)**2)/(48*rr(ii)**5)
+      aco = vv(ii)-bco*rr(ii)**2-cco*rr(ii)**4-dco*rr(ii)**6
+
+   end if
 
 ! create polynomial potential inside irc
 
 
- if(lpopt .eq. 1) then
-   do ii=1,irc
-     vp(ii,5)=aco+bco*rr(ii)**2+cco*rr(ii)**4
-   end do
- else if(lpopt .eq. 2) then
-   do ii=1,irc
-     vp(ii,5)=aco+bco*rr(ii)**4+cco*rr(ii)**6
-   end do
- else if(lpopt .eq. 3) then
-   do ii=1,irc
-     vp(ii,5)=aco+bco*rr(ii)**4+cco*rr(ii)**5+dco*rr(ii)**6
-   end do
- else if(lpopt .eq. 4) then
-   do ii=1,irc
-     vp(ii,5)=aco+bco*rr(ii)**4+cco*rr(ii)**6+dco*rr(ii)**8
-   end do
- else if(lpopt .eq. 5) then
-   do ii=1,irc
-     vp(ii,5)=aco+bco*rr(ii)**2+cco*rr(ii)**4+dco*rr(ii)**6
-   end do
- end if
+   if(lpopt == 1) then
+      do ii=1,irc
+         vp(ii,5)=aco+bco*rr(ii)**2+cco*rr(ii)**4
+      end do
+   else if(lpopt == 2) then
+      do ii=1,irc
+         vp(ii,5)=aco+bco*rr(ii)**4+cco*rr(ii)**6
+      end do
+   else if(lpopt == 3) then
+      do ii=1,irc
+         vp(ii,5)=aco+bco*rr(ii)**4+cco*rr(ii)**5+dco*rr(ii)**6
+      end do
+   else if(lpopt == 4) then
+      do ii=1,irc
+         vp(ii,5)=aco+bco*rr(ii)**4+cco*rr(ii)**6+dco*rr(ii)**8
+      end do
+   else if(lpopt == 5) then
+      do ii=1,irc
+         vp(ii,5)=aco+bco*rr(ii)**2+cco*rr(ii)**4+dco*rr(ii)**6
+      end do
+   end if
 
 ! add compatible supplementary function to change value at rr==0
 
- do ii = 1, irc
-   x=rr(ii)/rr(irc)
-   if(lpopt .eq. 1) then
-     vp(ii,5)=vp(ii,5) + dvloc0*(1.0d0 - x**2)**3
-   else if(lpopt .eq. 2) then
-     vp(ii,5)=vp(ii,5) + dvloc0*(1.0d0 - x**4)**3
-   else if(lpopt .eq. 3 .or. lpopt .eq. 4) then
-     vp(ii,5)=vp(ii,5) + dvloc0*(1.0d0 - x**4)**4
-   else if(lpopt .eq. 5) then
-     vp(ii,5)=vp(ii,5) + dvloc0*(1.0d0 - x**4)**4
-   end if
- end do
- 
- do ii=irc+1,mmax
-   vp(ii,5)=vv(ii)
- end do
+   do ii = 1, irc
+      x=rr(ii)/rr(irc)
+      if(lpopt == 1) then
+         vp(ii,5)=vp(ii,5) + dvloc0*(1.0d0 - x**2)**3
+      else if(lpopt == 2) then
+         vp(ii,5)=vp(ii,5) + dvloc0*(1.0d0 - x**4)**3
+      else if(lpopt == 3 .or. lpopt == 4) then
+         vp(ii,5)=vp(ii,5) + dvloc0*(1.0d0 - x**4)**4
+      else if(lpopt == 5) then
+         vp(ii,5)=vp(ii,5) + dvloc0*(1.0d0 - x**4)**4
+      end if
+   end do
 
- deallocate(dvv,d2vv)
+   do ii=irc+1,mmax
+      vp(ii,5)=vv(ii)
+   end do
 
- return
- end subroutine vploc
+   deallocate(dvv,d2vv)
+
+   return
+end subroutine vploc

--- a/src/vrel.f90
+++ b/src/vrel.f90
@@ -2,21 +2,21 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- subroutine vrel(ll,ee,rr,vv,vr,uu,up,zz,mmax,irc,srel)
+subroutine vrel(ll,ee,rr,vv,vr,uu,up,zz,mmax,irc,srel)
 
 ! Finds an effective potential representing the Pauli-type scalar-relativistic
 ! operators in the radial Schroedinger equation
@@ -34,101 +34,101 @@
 !mch matching mesh point for inward-outward integrations
 !srel .true. for scalar-relativistic, .false. for non-relativistic
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !Input variables
- real(dp) :: rr(mmax),vv(mmax)
- real(dp) :: uu(mmax),up(mmax)
- real(dp) :: zz
- integer :: nn,ll,irc
- integer :: mmax
- logical :: srel
+   real(dp) :: rr(mmax),vv(mmax)
+   real(dp) :: uu(mmax),up(mmax)
+   real(dp) :: zz
+   integer :: nn,ll,irc
+   integer :: mmax
+   logical :: srel
 
 !Output variables
- real(dp) :: vr(mmax)
- real(dp) :: ee
- integer :: ierr
+   real(dp) :: vr(mmax)
+   real(dp) :: ee
+   integer :: ierr
 
 !Local variables
 
- real(dp) :: aei,aeo,aii,aio,als !functions in aeo.f90
- real(dp) :: de,emax,emin
- real(dp) :: eps,fss,tfss,gamma,ro,sc
- real(dp) :: sls,sn,cn,uout,upin,upout,xkap
- real(dp) :: amesh,al,xx
- integer :: ii,it,nint,node,nin
+   real(dp) :: aei,aeo,aii,aio,als  !functions in aeo.f90
+   real(dp) :: de,emax,emin
+   real(dp) :: eps,fss,tfss,gamma,ro,sc
+   real(dp) :: sls,sn,cn,uout,upin,upout,xkap
+   real(dp) :: amesh,al,xx
+   integer :: ii,it,nint,node,nin
 
- real(dp), allocatable :: cf(:),dv(:),fr(:),frp(:)
+   real(dp), allocatable :: cf(:),dv(:),fr(:),frp(:)
 
 
- allocate(cf(mmax),dv(mmax),fr(mmax),frp(mmax))
+   allocate(cf(mmax),dv(mmax),fr(mmax),frp(mmax))
 
- vr(:)=0.0d0
+   vr(:)=0.0d0
 
 ! relativistic - non-relativistic switch
- if(.not. srel) return
+   if(.not. srel) return
 
- al = 0.01d0 * dlog(rr(101) / rr(1))
- amesh = dexp(al)
+   al = 0.01d0 * dlog(rr(101) / rr(1))
+   amesh = dexp(al)
 
 ! convergence factor for solution of schroedinger eq.  if calculated
 ! correction to eigenvalue is smaller in magnitude than eps times
 ! the magnitude of the current guess, the current guess is not changed.
- eps=1.0d-10
+   eps=1.0d-10
 
-  vr(:)=0.0d0
+   vr(:)=0.0d0
 
- fss=(1.0d0/137.036d0)**2
+   fss=(1.0d0/137.036d0)**2
 
- if(ll==0) gamma=dsqrt(1.0d0-fss*zz**2)
- if(ll>0) gamma=(ll*dsqrt(ll**2-fss*zz**2) + &
-& (ll+1)*dsqrt((ll+1)**2-fss*zz**2))/(2*ll+1)
+   if(ll==0) gamma=dsqrt(1.0d0-fss*zz**2)
+   if(ll>0) gamma=(ll*dsqrt(ll**2-fss*zz**2) + &
+   & (ll+1)*dsqrt((ll+1)**2-fss*zz**2))/(2*ll+1)
 
- sls=ll*(ll+1)
+   sls=ll*(ll+1)
 
- als=al**2
+   als=al**2
 
 ! coefficient array for u in differential eq.
    do ii=1,mmax
-     cf(ii)=als*sls + 2.0d0*als*(vv(ii)-ee)*rr(ii)**2
+      cf(ii)=als*sls + 2.0d0*als*(vv(ii)-ee)*rr(ii)**2
    end do
-  
+
 ! calculate dv/dr for darwin correction
    dv(:)=0.0d0
 
    dv(1)=(-50.d0*vv(1)+96.d0*vv(2)-72.d0*vv(3)+32.d0*vv(4) &
-&         -6.d0*vv(5))/(24.d0*al*rr(1))
+   &         -6.d0*vv(5))/(24.d0*al*rr(1))
    dv(2)=(-6.d0*vv(1)-20.d0*vv(2)+36.d0*vv(3)-12.d0*vv(4) &
-&         +2.d0*vv(5))/(24.d0*al*rr(2))
-  
+   &         +2.d0*vv(5))/(24.d0*al*rr(2))
+
    do ii=3,mmax-2
-     dv(ii)=(2.d0*vv(ii-2)-16.d0*vv(ii-1)+16.d0*vv(ii+1) &
-&          -2.d0*vv(ii+2))/(24.d0*al*rr(ii))
+      dv(ii)=(2.d0*vv(ii-2)-16.d0*vv(ii-1)+16.d0*vv(ii+1) &
+      &          -2.d0*vv(ii+2))/(24.d0*al*rr(ii))
    end do
-  
+
 !  relativistic coefficient arrays for u (fr) and up (frp).
    do ii=1,mmax
-     tfss=fss
-     fr(ii)=als*(rr(ii)**2)*(-tfss*(vv(ii)-ee)**2 + 0.5d0*tfss*dv(ii)/ &
-&     (rr(ii)*(1.0d0+0.5d0*tfss*(ee-vv(ii)))))
-     frp(ii)=-al*rr(ii)*0.5d0*tfss*dv(ii)/(1.0d0+0.5d0*tfss*(ee-vv(ii)))
-   end do
-  
-   do ii=1,mmax
-     if(rr(ii)<0.5d0*rr(irc) .or. rr(ii)>1.5d0*rr(irc)) cycle
-     if(rr(ii)<0.5d0*rr(irc) .or. rr(ii)>2.5d0*rr(irc)) cycle
-     if(dabs(uu(ii))>eps) then
-       vr(ii)=0.5d0*(fr(ii) + frp(ii)*up(ii)/uu(ii))/(als*rr(ii)**2)
-     end if
+      tfss=fss
+      fr(ii)=als*(rr(ii)**2)*(-tfss*(vv(ii)-ee)**2 + 0.5d0*tfss*dv(ii)/ &
+      &     (rr(ii)*(1.0d0+0.5d0*tfss*(ee-vv(ii)))))
+      frp(ii)=-al*rr(ii)*0.5d0*tfss*dv(ii)/(1.0d0+0.5d0*tfss*(ee-vv(ii)))
    end do
 
    do ii=1,mmax
-     if(rr(ii)<0.5d0*rr(irc) .or. rr(ii)>1.5d0*rr(irc)) cycle
-     if(vr(ii)==0.0d0) vr(ii)=0.5d0*(vr(ii-1)+vr(ii+1))
+      if(rr(ii)<0.5d0*rr(irc) .or. rr(ii)>1.5d0*rr(irc)) cycle
+      if(rr(ii)<0.5d0*rr(irc) .or. rr(ii)>2.5d0*rr(irc)) cycle
+      if(dabs(uu(ii))>eps) then
+         vr(ii)=0.5d0*(fr(ii) + frp(ii)*up(ii)/uu(ii))/(als*rr(ii)**2)
+      end if
    end do
 
- deallocate(cf,dv,fr,frp)
- return
+   do ii=1,mmax
+      if(rr(ii)<0.5d0*rr(irc) .or. rr(ii)>1.5d0*rr(irc)) cycle
+      if(vr(ii)==0.0d0) vr(ii)=0.5d0*(vr(ii-1)+vr(ii+1))
+   end do
 
- end subroutine vrel
+   deallocate(cf,dv,fr,frp)
+   return
+
+end subroutine vrel

--- a/src/wellstate.f90
+++ b/src/wellstate.f90
@@ -2,21 +2,21 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- subroutine wellstate(nnin,ll,irc,ep,rr,vfull,uu,up,zz,mmax,mch,srel)
+subroutine wellstate(nnin,ll,irc,ep,rr,vfull,uu,up,zz,mmax,mch,srel)
 
 !creates quantum well to confine positive-energy state, and calculates
 !the resulting all-electron wave function
@@ -30,183 +30,183 @@
 !uu  all-electron well-bound wave function
 !up  d(uu)/dr
 !zz  atomic number
-!mmax  size of log radial mesh 
+!mmax  size of log radial mesh
 !mch matching mesh point for inward-outward integrations
 !srel .true. for scalar-relativistic, .false. for non-relativistic
- 
- implicit none
 
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+
+   integer, parameter :: dp=kind(1.0d0)
 
 !Input variables
- real(dp) :: rr(mmax),vfull(mmax)
- real(dp) :: ep,zz
- integer :: nnin,ll,irc,mmax !(nnin is actually in/out)
- logical :: srel
+   real(dp) :: rr(mmax),vfull(mmax)
+   real(dp) :: ep,zz
+   integer :: nnin,ll,irc,mmax  !(nnin is actually in/out)
+   logical :: srel
 
 !Output variables
- real(dp) :: uu(mmax),up(mmax)
- integer :: mch
- 
-!Local variables
- real(dp), allocatable :: vwell(:)
- real(dp) :: al,cwell,et,xx,rwell,rwmax,rwmin,rwscale,umax
+   real(dp) :: uu(mmax),up(mmax)
+   integer :: mch
 
- real(dp),parameter :: eps=1.0d-8
- integer :: ii,iter,ierr,iumax,l1,itrwell,nn,nnloop
- logical :: convg
- 
- l1=ll+1
- al = 0.01d0 * dlog(rr(101) / rr(1))
+!Local variables
+   real(dp), allocatable :: vwell(:)
+   real(dp) :: al,cwell,et,xx,rwell,rwmax,rwmin,rwscale,umax
+
+   real(dp),parameter :: eps=1.0d-8
+   integer :: ii,iter,ierr,iumax,l1,itrwell,nn,nnloop
+   logical :: convg
+
+   l1=ll+1
+   al = 0.01d0 * dlog(rr(101) / rr(1))
 
 !check for bound state with specified ll and nnin
 
- uu(:)=0.0d0 ; up(:)=0.0d0
- et=-0.1d0
- call lschfb(nnin,ll,ierr,et,rr,vfull,uu,up,zz,mmax,mch,srel)
+   uu(:)=0.0d0 ; up(:)=0.0d0
+   et=-0.1d0
+   call lschfb(nnin,ll,ierr,et,rr,vfull,uu,up,zz,mmax,mch,srel)
 
 !if bound state is found, check its localization
- if(ierr==0) then
-   umax=0.0d0
-   do ii=mmax,1,-1
-     if(dabs(uu(ii))>=umax) then
-       umax=dabs(uu(ii))
-     else
-       iumax=ii+1
-       exit
-     end if
-   end do
+   if(ierr==0) then
+      umax=0.0d0
+      do ii=mmax,1,-1
+         if(dabs(uu(ii))>=umax) then
+            umax=dabs(uu(ii))
+         else
+            iumax=ii+1
+            exit
+         end if
+      end do
 
 !if bound state is localized compared to rc, use it and its energy
-   if(rr(iumax)<0.75d0*rr(irc)) then
-     ep=et
-     write(6,'(/a,i2,a,i2/a,f12.8/a)') &
-&          'WARNING wellstate: localized bound state found for n=', &
-&           nnin,' l=', ll,'WARNING this state with energy',ep, &
-&          'WARNING will be used for the first projector'
-     return
+      if(rr(iumax)<0.75d0*rr(irc)) then
+         ep=et
+         write(6,'(/a,i2,a,i2/a,f12.8/a)') &
+         &          'WARNING wellstate: localized bound state found for n=', &
+         &           nnin,' l=', ll,'WARNING this state with energy',ep, &
+         &          'WARNING will be used for the first projector'
+         return
 
 !if moderately delocalized use very low-energy scattering state
-   else if(rr(iumax)<1.5d0*rr(irc)) then
+      else if(rr(iumax)<1.5d0*rr(irc)) then
 
-     ep=0.05d0
-     write(6,'(/a,i2,a,i2/a,f12.8/a)') &
-&          'WARNING wellstate: moderately localized bound state found for n=', &
-&          nnin,' l= ',ll,'WARNING scattering state with energy',ep, &
-&          'WARNING will be used for the first projector'
+         ep=0.05d0
+         write(6,'(/a,i2,a,i2/a,f12.8/a)') &
+         &          'WARNING wellstate: moderately localized bound state found for n=', &
+         &          nnin,' l= ',ll,'WARNING scattering state with energy',ep, &
+         &          'WARNING will be used for the first projector'
+      end if
    end if
- end if
 
-!if specified ep is retained and is negative 
- if(ep<0.0d0) then
-   ep=0.25d0
-   write(6,'(/a,i2,a,i2/a,f12.8/a)') &
-&         'WARNING wellstate: negative energy specified for n=', &
-&         nnin,' l= ',ll, &
-&         'WARNING scattering state with energy',ep, &
-&         'WARNING will be used for the first projector'
- end if
+!if specified ep is retained and is negative
+   if(ep<0.0d0) then
+      ep=0.25d0
+      write(6,'(/a,i2,a,i2/a,f12.8/a)') &
+      &         'WARNING wellstate: negative energy specified for n=', &
+      &         nnin,' l= ',ll, &
+      &         'WARNING scattering state with energy',ep, &
+      &         'WARNING will be used for the first projector'
+   end if
 
- allocate(vwell(mmax))
+   allocate(vwell(mmax))
 
 !scale factor to decrease well width until trial energy exceeds target
- rwscale=0.8d0
+   rwscale=0.8d0
 
 !asymptotic potential value to give target bound state a "binding" energy
 !of 0.5 Ha
- cwell=ep+0.5d0
+   cwell=ep+0.5d0
 
 !loop which will increment number of nodes before well wall gets too steep
- do nnloop=0,10
-   nn=nnin+nnloop
+   do nnloop=0,10
+      nn=nnin+nnloop
 
-   rwell=8.0d0*rr(irc)
-   rwmax=0.0d0
-   rwmin=0.0d0
+      rwell=8.0d0*rr(irc)
+      rwmax=0.0d0
+      rwmin=0.0d0
 
-   convg=.false.
+      convg=.false.
 
-   do itrwell=1,100
+      do itrwell=1,100
 
 
 !create well potential
-     do ii=1,mmax
-      vwell(ii)=vfull(ii)
-     end do
+         do ii=1,mmax
+            vwell(ii)=vfull(ii)
+         end do
 
 !   start outside rc to keep numerical derivatives at rc accurate
-     do ii=irc+6,mmax
-      xx=(rr(ii)-rr(irc+5))/rwell
-      vwell(ii)=vwell(ii)+cwell*xx**3/(1.0d0+xx**3)
-     end do
+         do ii=irc+6,mmax
+            xx=(rr(ii)-rr(irc+5))/rwell
+            vwell(ii)=vwell(ii)+cwell*xx**3/(1.0d0+xx**3)
+         end do
 
 !find bound state in well
-     et=ep
-     call lschfb(nn,ll,ierr,et,rr,vwell,uu,up,zz,mmax,mch,srel)
-     if(ierr<0) then
-      write(6,'(a,i3,a,i3)') &
-&           'wellstate: ERROR lschfb convergence error, n=',nn,' l=',ll
-      stop
-     end if
+         et=ep
+         call lschfb(nn,ll,ierr,et,rr,vwell,uu,up,zz,mmax,mch,srel)
+         if(ierr<0) then
+            write(6,'(a,i3,a,i3)') &
+            &           'wellstate: ERROR lschfb convergence error, n=',nn,' l=',ll
+            stop
+         end if
 
-     if(abs(et-ep)<eps) then
-      ep=et
-      convg=.true.
-      exit
-     end if
+         if(abs(et-ep)<eps) then
+            ep=et
+            convg=.true.
+            exit
+         end if
 
 !Interval-halving search after proper rwell has been bracketed
-     if(rwmin>0.0d0 .and. rwmax>0.0d0) then
-       if(et>ep) then
-         rwmin=rwell
-       else
-         rwmax=rwell
-      end if
-      rwell=0.5d0*(rwmax+rwmin) 
-      cycle
-     end if
+         if(rwmin>0.0d0 .and. rwmax>0.0d0) then
+            if(et>ep) then
+               rwmin=rwell
+            else
+               rwmax=rwell
+            end if
+            rwell=0.5d0*(rwmax+rwmin)
+            cycle
+         end if
 
-     if(et>ep) then
-       rwmin=rwell
-       if(rwmax>0.0d0) then
-         rwell=0.5d0*(rwmax+rwmin) 
-       else
-         rwell=rwell/rwscale
-       end if
-       cycle
-     end if
+         if(et>ep) then
+            rwmin=rwell
+            if(rwmax>0.0d0) then
+               rwell=0.5d0*(rwmax+rwmin)
+            else
+               rwell=rwell/rwscale
+            end if
+            cycle
+         end if
 
-     if(et<ep) then
-       rwmax=rwell
-       if(rwmin>0.0d0) then
-         rwell=0.5d0*(rwmax+rwmin) 
-       else
-         rwell=rwell*rwscale
-         if(rwell<dmax1(1.0d0,0.5d0*rr(irc))) exit
-       end if
-       cycle
-     end if
+         if(et<ep) then
+            rwmax=rwell
+            if(rwmin>0.0d0) then
+               rwell=0.5d0*(rwmax+rwmin)
+            else
+               rwell=rwell*rwscale
+               if(rwell<dmax1(1.0d0,0.5d0*rr(irc))) exit
+            end if
+            cycle
+         end if
 
-   end do !itrwell
+      end do  !itrwell
 
-   if(convg) exit
- end do !nnloop
+      if(convg) exit
+   end do  !nnloop
 
- if(.not. convg) then
-   write(6,'(a,a,i3,a,i3,a,f8.4)') &
-&   'ERROR wellstate: well potential iteration failed', &
-&   ' to converge, n=',nn,' l=',ll,' ep=',ep
-  stop
- end if
+   if(.not. convg) then
+      write(6,'(a,a,i3,a,i3,a,f8.4)') &
+      &   'ERROR wellstate: well potential iteration failed', &
+      &   ' to converge, n=',nn,' l=',ll,' ep=',ep
+      stop
+   end if
 
- if(cwell>0.0d0) then
-  write(6,'(/a,i3,a,i3/a,f8.4,/a,f8.4/a,f8.4)') &
-&          '   Wellstate for l =',ll,'  n =',nn, &
-&          '     eigenvalue = ',et, &
-&          '     asymptotic potential = ',cwell, &
-&          '     half-point radius =',rr(irc)+rwell
- end if
+   if(cwell>0.0d0) then
+      write(6,'(/a,i3,a,i3/a,f8.4,/a,f8.4/a,f8.4)') &
+      &          '   Wellstate for l =',ll,'  n =',nn, &
+      &          '     eigenvalue = ',et, &
+      &          '     asymptotic potential = ',cwell, &
+      &          '     half-point radius =',rr(irc)+rwell
+   end if
 
- deallocate(vwell)
- return
- end subroutine wellstate
+   deallocate(vwell)
+   return
+end subroutine wellstate

--- a/src/wellstate_r.f90
+++ b/src/wellstate_r.f90
@@ -2,17 +2,17 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
@@ -33,190 +33,190 @@ subroutine wellstate_r(nnin,ll,kap,irc,ep,rr,vfull,vwell, &
 !uu  all-electron well-bound wave function
 !up  d(uu)/dr
 !zz  atomic number
-!mmax  size of log radial mesh 
+!mmax  size of log radial mesh
 !mch matching mesh point for inward-outward integrations
 !srel .true. for scalar-relativistic, .false. for non-relativistic
- 
- implicit none
 
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+
+   integer, parameter :: dp=kind(1.0d0)
 
 !Input variables
- real(dp) :: rr(mmax),vfull(mmax)
- real(dp) :: ep,zz
- integer :: nnin,ll,kap,irc,mmax !(nnin is actually in/out)
- logical :: srel
+   real(dp) :: rr(mmax),vfull(mmax)
+   real(dp) :: ep,zz
+   integer :: nnin,ll,kap,irc,mmax  !(nnin is actually in/out)
+   logical :: srel
 
 !Output variables
- real(dp) :: uu(mmax,2),up(mmax,2),vwell(mmax)
- integer :: mch
- 
-!Local variables
- real(dp) :: al,cwell,et,xx,rwell,rwmax,rwmin,rwscale,umax
+   real(dp) :: uu(mmax,2),up(mmax,2),vwell(mmax)
+   integer :: mch
 
- real(dp),parameter :: eps=1.0d-8
- integer :: ii,iter,ierr,iumax,l1,itrwell,nn,nnloop
- logical :: convg
- 
- l1=ll+1
- al = 0.01d0 * dlog(rr(101) / rr(1))
+!Local variables
+   real(dp) :: al,cwell,et,xx,rwell,rwmax,rwmin,rwscale,umax
+
+   real(dp),parameter :: eps=1.0d-8
+   integer :: ii,iter,ierr,iumax,l1,itrwell,nn,nnloop
+   logical :: convg
+
+   l1=ll+1
+   al = 0.01d0 * dlog(rr(101) / rr(1))
 
 !check for bound state with specified ll and nnin
 
- uu(:,:)=0.0d0 ; up(:,:)=0.0d0
- et=-0.1d0
- call ldiracfb(nnin,ll,kap,ierr,et,rr,zz,vfull,uu,up,mmax,mch)
+   uu(:,:)=0.0d0 ; up(:,:)=0.0d0
+   et=-0.1d0
+   call ldiracfb(nnin,ll,kap,ierr,et,rr,zz,vfull,uu,up,mmax,mch)
 
 !if bound state is found, check its localization
- if(ierr==0) then
-   umax=0.0d0
-   do ii=mmax,1,-1
-     if(dabs(uu(ii,1))>=umax) then
-       umax=dabs(uu(ii,1))
-     else
-       iumax=ii+1
-       exit
-     end if
-   end do
+   if(ierr==0) then
+      umax=0.0d0
+      do ii=mmax,1,-1
+         if(dabs(uu(ii,1))>=umax) then
+            umax=dabs(uu(ii,1))
+         else
+            iumax=ii+1
+            exit
+         end if
+      end do
 
 !if bound state is localized compared to rc, use it and its energy
-   if(rr(iumax)<0.75d0*rr(irc)) then
-     ep=et
-     write(6,'(/a,i2,a,i2/a,f12.8/a)') &
-&          'WARNING wellstate: localized bound state found for n=', &
-&           nnin,' l=', ll,'WARNING this state with energy',ep, &
-&          'WARNING will be used for the first projector'
+      if(rr(iumax)<0.75d0*rr(irc)) then
+         ep=et
+         write(6,'(/a,i2,a,i2/a,f12.8/a)') &
+         &          'WARNING wellstate: localized bound state found for n=', &
+         &           nnin,' l=', ll,'WARNING this state with energy',ep, &
+         &          'WARNING will be used for the first projector'
 
 !make sure vwell exists for ikap=2 calculation in this case
-     vwell(:)=vfull(:)
+         vwell(:)=vfull(:)
 
-     return
+         return
 
 !if moderately delocalized use very low-energy scattering state
-   else if(rr(iumax)<1.5d0*rr(irc)) then
+      else if(rr(iumax)<1.5d0*rr(irc)) then
 
-     ep=0.05d0
-     write(6,'(/a,i2,a,i2/a,f12.8/a)') &
-&          'WARNING wellstate: moderately localized bound state found for n=', &
-&          nnin,' l= ',ll,'WARNING scattering state with energy',ep, &
-&          'WARNING will be used for the first projector'
+         ep=0.05d0
+         write(6,'(/a,i2,a,i2/a,f12.8/a)') &
+         &          'WARNING wellstate: moderately localized bound state found for n=', &
+         &          nnin,' l= ',ll,'WARNING scattering state with energy',ep, &
+         &          'WARNING will be used for the first projector'
+      end if
    end if
- end if
 
-!if specified ep is retained and is negative 
- if(ep<0.0d0) then
-   ep=0.25d0
-   write(6,'(/a,i2,a,i2/a,f12.8/a)') &
-&         'WARNING wellstate: negative energy specified for n=', &
-&         nnin,' l= ',ll, &
-&         'WARNING scattering state with energy',ep, &
-&         'WARNING will be used for the first projector'
- end if
+!if specified ep is retained and is negative
+   if(ep<0.0d0) then
+      ep=0.25d0
+      write(6,'(/a,i2,a,i2/a,f12.8/a)') &
+      &         'WARNING wellstate: negative energy specified for n=', &
+      &         nnin,' l= ',ll, &
+      &         'WARNING scattering state with energy',ep, &
+      &         'WARNING will be used for the first projector'
+   end if
 
 
 !scale factor to decrease well width until trial energy exceeds target
- rwscale=0.8d0
+   rwscale=0.8d0
 
 !asymptotic potential value to give target bound state a "binding" energy
 !of 0.5 Ha
- cwell=ep+0.5d0
+   cwell=ep+0.5d0
 
 !loop which will increment number of nodes before well wall gets too steep
- do nnloop=0,10
-   nn=nnin+nnloop
+   do nnloop=0,10
+      nn=nnin+nnloop
 
-   rwell=8.0d0*rr(irc)
-   rwmax=0.0d0
-   rwmin=0.0d0
+      rwell=8.0d0*rr(irc)
+      rwmax=0.0d0
+      rwmin=0.0d0
 
-   convg=.false.
+      convg=.false.
 
-   do itrwell=1,100
+      do itrwell=1,100
 
 
 !create well potential
-     do ii=1,mmax
-      vwell(ii)=vfull(ii)
-     end do
+         do ii=1,mmax
+            vwell(ii)=vfull(ii)
+         end do
 
 !   start outside rc to keep numerical derivatives at rc accurate
-     do ii=irc+6,mmax
-      xx=(rr(ii)-rr(irc+5))/rwell
-      vwell(ii)=vwell(ii)+cwell*xx**3/(1.0d0+xx**3)
-     end do
+         do ii=irc+6,mmax
+            xx=(rr(ii)-rr(irc+5))/rwell
+            vwell(ii)=vwell(ii)+cwell*xx**3/(1.0d0+xx**3)
+         end do
 
 !find bound state in well
-     et=ep
-     call ldiracfb(nn,ll,kap,ierr,et,rr,zz,vwell,uu,up,mmax,mch)
+         et=ep
+         call ldiracfb(nn,ll,kap,ierr,et,rr,zz,vwell,uu,up,mmax,mch)
 
 !     if(ierr < 0) then
 !       write(6,'(a,i3,a,i3,a,i3)') &
 !&            'wellstate_r: ERROR ldiracfb no classical turning point, &
-!&             n=',nn,' l=',ll,' kap=',kap 
+!&             n=',nn,' l=',ll,' kap=',kap
 !       stop
 !     end if
 
-     if(abs(et-ep)<eps) then
-      ep=et
-      convg=.true.
-      exit
-     end if
+         if(abs(et-ep)<eps) then
+            ep=et
+            convg=.true.
+            exit
+         end if
 
 !Interval-halving search after proper rwell has been bracketed
-     if(rwmin>0.0d0 .and. rwmax>0.0d0) then
-       if(et>ep) then
-         rwmin=rwell
-       else
-         rwmax=rwell
-      end if
-      rwell=0.5d0*(rwmax+rwmin) 
-      cycle
-     end if
+         if(rwmin>0.0d0 .and. rwmax>0.0d0) then
+            if(et>ep) then
+               rwmin=rwell
+            else
+               rwmax=rwell
+            end if
+            rwell=0.5d0*(rwmax+rwmin)
+            cycle
+         end if
 
-     if(et>ep) then
-       rwmin=rwell
-       if(rwmax>0.0d0) then
-         rwell=0.5d0*(rwmax+rwmin) 
-       else
-         rwell=rwell/rwscale
-       end if
-       cycle
-     end if
+         if(et>ep) then
+            rwmin=rwell
+            if(rwmax>0.0d0) then
+               rwell=0.5d0*(rwmax+rwmin)
+            else
+               rwell=rwell/rwscale
+            end if
+            cycle
+         end if
 
-     if(et<ep) then
-       rwmax=rwell
-       if(rwmin>0.0d0) then
-         rwell=0.5d0*(rwmax+rwmin) 
-       else
-         rwell=rwell*rwscale
-         if(rwell<dmax1(1.0d0,0.5d0*rr(irc))) exit
-       end if
-       cycle
-     end if
+         if(et<ep) then
+            rwmax=rwell
+            if(rwmin>0.0d0) then
+               rwell=0.5d0*(rwmax+rwmin)
+            else
+               rwell=rwell*rwscale
+               if(rwell<dmax1(1.0d0,0.5d0*rr(irc))) exit
+            end if
+            cycle
+         end if
 
-   end do !itrwell
+      end do  !itrwell
 
-   if(convg) exit
- end do !nnloop
+      if(convg) exit
+   end do  !nnloop
 
- if(.not. convg) then
-   write(6,'(a,a,i3,a,i3,a,i3a,f8.4)') &
-&   'ERROR wellstate_r: well potential iteration failed', &
-&   ' to converge, n=',nn,' l=',ll,' kap=', kap,' ep=',ep
-  stop
- end if
+   if(.not. convg) then
+      write(6,'(a,a,i3,a,i3,a,i3a,f8.4)') &
+      &   'ERROR wellstate_r: well potential iteration failed', &
+      &   ' to converge, n=',nn,' l=',ll,' kap=', kap,' ep=',ep
+      stop
+   end if
 
- if(cwell>0.0d0) then
-  write(6,'(/a,i3,a,i3,a,i3/a,f8.4,/a,f8.4/a,f8.4)') &
-&          '   Wellstate for l =',ll,'  n =',nn,' kap=',kap, &
-&          '     eigenvalue = ',et, &
-&          '     asymptotic potential = ',cwell, &
-&          '     half-point radius =',rr(irc)+rwell
- end if
+   if(cwell>0.0d0) then
+      write(6,'(/a,i3,a,i3,a,i3/a,f8.4,/a,f8.4/a,f8.4)') &
+      &          '   Wellstate for l =',ll,'  n =',nn,' kap=',kap, &
+      &          '     eigenvalue = ',et, &
+      &          '     asymptotic potential = ',cwell, &
+      &          '     half-point radius =',rr(irc)+rwell
+   end if
 
 !carry over node count
 
- nnin=nn
+   nnin=nn
 
- return
- end subroutine wellstate_r
+   return
+end subroutine wellstate_r

--- a/src/wf_rc_der.f90
+++ b/src/wf_rc_der.f90
@@ -2,21 +2,21 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
- subroutine wf_rc_der(rr,uu,al,rc,irc,mmax,uorder)
+subroutine wf_rc_der(rr,uu,al,rc,irc,mmax,uorder)
 
 !calculate derivatives of radial wave functin at core radius rc
 
@@ -25,7 +25,7 @@
 ! uu rr*radial wavefunction
 ! al  log of radial mesh factor
 ! mmax last point used on radial mesh
-! 
+!
 !IN/OUT
 ! irc  index of radial mesh point used as rc
 ! rc  input core radius.  If irc = 0 on input, irc is calculated and rc
@@ -34,38 +34,38 @@
 !OUTPUT
 ! uorder  value and four derivatives of uu/rr at final rc
 
- implicit none
- integer, parameter :: dp=kind(1.0d0)
+   implicit none
+   integer, parameter :: dp=kind(1.0d0)
 
 !subroutine arguments
- real(dp) :: rr(mmax),uu(mmax),uorder(5)
- real(dp) :: al,rc
- integer :: mmax,irc,nder
+   real(dp) :: rr(mmax),uu(mmax),uorder(5)
+   real(dp) :: al,rc
+   integer :: mmax,irc,nder
 
 !local variables
- integer :: ii,jj
- real(dp),allocatable :: work(:,:)
+   integer :: ii,jj
+   real(dp),allocatable :: work(:,:)
 
 !set rc to exact mesh value if not specified by irc
- if(irc .eq. 0) then
-  do ii=1,mmax
-   if(irc .eq. 0 .and. rr(ii)>=rc) then
-    irc=ii
-    rc=rr(ii)
-    exit
+   if(irc == 0) then
+      do ii=1,mmax
+         if(irc == 0 .and. rr(ii)>=rc) then
+            irc=ii
+            rc=rr(ii)
+            exit
+         end if
+      end do
+   else
+      rc=rr(irc)
    end if
-  end do
- else
-  rc=rr(irc)
- end if
 
- allocate(work(mmax,5))
+   allocate(work(mmax,5))
 
- do ii=1,mmax
-  work(ii,1)=uu(ii)/rr(ii)
- end do
+   do ii=1,mmax
+      work(ii,1)=uu(ii)/rr(ii)
+   end do
 
- do jj=2,5
+   do jj=2,5
 
 ! 5-point numerical first derivatives applied successively
 !  do ii=irc-18+2*jj,irc+18-2*jj
@@ -74,19 +74,19 @@
 !&     /(24.d0*al*rr(ii))
 
 ! 7-point numerical first derivatives applied successively
-  do ii=irc-25+3*jj,irc+25-3*jj
-     work(ii,jj)=(-work(ii-3,jj-1)+ 9.d0*work(ii-2,jj-1)&
-&     -45.d0*work(ii-1,jj-1)+45.d0*work(ii+1,jj-1)&
-&     -9.d0*work(ii+2,jj-1)+work(ii+3,jj-1))&
-&     /(60.d0*al*rr(ii))
-  end do
- end do
+      do ii=irc-25+3*jj,irc+25-3*jj
+         work(ii,jj)=(-work(ii-3,jj-1)+ 9.d0*work(ii-2,jj-1)&
+         &     -45.d0*work(ii-1,jj-1)+45.d0*work(ii+1,jj-1)&
+         &     -9.d0*work(ii+2,jj-1)+work(ii+3,jj-1))&
+         &     /(60.d0*al*rr(ii))
+      end do
+   end do
 
- do jj=1,5
-  uorder(jj)=work(irc,jj)
- end do
+   do jj=1,5
+      uorder(jj)=work(irc,jj)
+   end do
 
- deallocate(work)
+   deallocate(work)
 
- return
- end subroutine wf_rc_der
+   return
+end subroutine wf_rc_der

--- a/src/xmlf90-wxml/m_wxml_buffer.f90
+++ b/src/xmlf90-wxml/m_wxml_buffer.f90
@@ -1,7 +1,7 @@
 module m_wxml_buffer
 
 !
-! At this point we use a fixed-size buffer. 
+! At this point we use a fixed-size buffer.
 ! Note however that buffer overflows will only be
 ! triggered by overly long *unbroken* pcdata values, or
 ! by overly long attribute values. Hopefully
@@ -14,161 +14,161 @@ module m_wxml_buffer
 !
 ! In a forthcoming implementation it could be made dynamical...
 !
-integer, parameter, public   :: MAX_BUFF_SIZE  = 2000
-integer, parameter, private  :: BUFF_SIZE_WARNING  = 1750
+   integer, parameter, public   :: MAX_BUFF_SIZE  = 2000
+   integer, parameter, private  :: BUFF_SIZE_WARNING  = 1750
 !
-type, public  :: buffer_t
-private
+   type, public  :: buffer_t
+      private
       integer                       :: size
       character(len=MAX_BUFF_SIZE)  :: str
-end type buffer_t
+   end type buffer_t
 
-public :: add_to_buffer
-public :: print_buffer, str, char, len
-public :: operator (.equal.)
-public :: buffer_nearly_full, reset_buffer
+   public :: add_to_buffer
+   public :: print_buffer, str, char, len
+   public :: operator (.equal.)
+   public :: buffer_nearly_full, reset_buffer
 
 
 !----------------------------------------------------------------
-interface add_to_buffer
+   interface add_to_buffer
       module procedure add_str_to_buffer
-end interface
-private :: add_char_to_buffer, add_str_to_buffer
+   end interface add_to_buffer
+   private :: add_char_to_buffer, add_str_to_buffer
 
-interface operator (.equal.)
+   interface operator (.equal.)
       module procedure compare_buffers, compare_buffer_str, &
-             compare_str_buffer
-end interface
-private :: compare_buffers, compare_buffer_str, compare_str_buffer
+         compare_str_buffer
+   end interface operator (.equal.)
+   private :: compare_buffers, compare_buffer_str, compare_str_buffer
 
-interface str
+   interface str
       module procedure buffer_to_str
-end interface
-interface char                 ! Experimental
+   end interface str
+   interface char                 ! Experimental
       module procedure buffer_to_str
-end interface
-private :: buffer_to_str
+   end interface char
+   private :: buffer_to_str
 
-interface len
-   module procedure buffer_length
-end interface
-private :: buffer_length
+   interface len
+      module procedure buffer_length
+   end interface len
+   private :: buffer_length
 
 CONTAINS
 !==================================================================
 
 !----------------------------------------------------------------
 function compare_buffers(a,b) result(equal)     ! .equal. generic
-type(buffer_t), intent(in)  :: a
-type(buffer_t), intent(in)  :: b
-logical                     :: equal
+   type(buffer_t), intent(in)  :: a
+   type(buffer_t), intent(in)  :: b
+   logical                     :: equal
 
-equal = ((a%size == b%size) .and. (a%str(1:a%size) == b%str(1:b%size)))
+   equal = ((a%size == b%size) .and. (a%str(1:a%size) == b%str(1:b%size)))
 
 end function compare_buffers
 
 !----------------------------------------------------------------
-function compare_buffer_str(buffer,str) result(equal) ! .equal. generic
-type(buffer_t), intent(in)   :: buffer
-character(len=*), intent(in) :: str
-logical                      :: equal
+function compare_buffer_str(buffer,str) result(equal)  ! .equal. generic
+   type(buffer_t), intent(in)   :: buffer
+   character(len=*), intent(in) :: str
+   logical                      :: equal
 
-equal = (buffer%str(1:buffer%size) == trim(str))
+   equal = (buffer%str(1:buffer%size) == trim(str))
 
 end function compare_buffer_str
 
 !----------------------------------------------------------------
-function compare_str_buffer(str,buffer) result(equal) ! .equal. generic
-character(len=*), intent(in) :: str
-type(buffer_t), intent(in)   :: buffer
-logical                     :: equal
+function compare_str_buffer(str,buffer) result(equal)  ! .equal. generic
+   character(len=*), intent(in) :: str
+   type(buffer_t), intent(in)   :: buffer
+   logical                     :: equal
 
-equal = (buffer%str(1:buffer%size) == trim(str))
+   equal = (buffer%str(1:buffer%size) == trim(str))
 
 end function compare_str_buffer
 
 !----------------------------------------------------------------
 subroutine add_char_to_buffer(c,buffer)
-character(len=1), intent(in)   :: c
-type(buffer_t), intent(inout)  :: buffer
+   character(len=1), intent(in)   :: c
+   type(buffer_t), intent(inout)  :: buffer
 
-integer   :: n
-buffer%size = buffer%size + 1
-n = buffer%size
+   integer   :: n
+   buffer%size = buffer%size + 1
+   n = buffer%size
 
-if (n> MAX_BUFF_SIZE) then
-  stop "Buffer overflow: long unbroken string of pcdata or attribute value..."
+   if (n> MAX_BUFF_SIZE) then
+      stop "Buffer overflow: long unbroken string of pcdata or attribute value..."
 !  RETURN
 !
-endif
+   endif
 
-buffer%str(n:n) = c
+   buffer%str(n:n) = c
 end subroutine add_char_to_buffer
 
 !----------------------------------------------------------------
 subroutine add_str_to_buffer(s,buffer)
-character(len=*), intent(in)   :: s
-type(buffer_t), intent(inout)  :: buffer
+   character(len=*), intent(in)   :: s
+   type(buffer_t), intent(inout)  :: buffer
 
-integer   :: n, len_s, last_pos
+   integer   :: n, len_s, last_pos
 
-len_s = len(s)
-last_pos = buffer%size
-buffer%size = buffer%size + len_s
-n = buffer%size
+   len_s = len(s)
+   last_pos = buffer%size
+   buffer%size = buffer%size + len_s
+   n = buffer%size
 
-if (n> MAX_BUFF_SIZE) then
-  stop "Buffer overflow: long unbroken string of pcdata or attribute value..."
+   if (n> MAX_BUFF_SIZE) then
+      stop "Buffer overflow: long unbroken string of pcdata or attribute value..."
 !  RETURN
-endif
+   endif
 
-buffer%str(last_pos+1:n) = s
+   buffer%str(last_pos+1:n) = s
 end subroutine add_str_to_buffer
 
 !----------------------------------------------------------------
 subroutine reset_buffer(buffer)
-type(buffer_t), intent(inout)  :: buffer
+   type(buffer_t), intent(inout)  :: buffer
 
-buffer%size = 0
+   buffer%size = 0
 
 end subroutine reset_buffer
 
 !----------------------------------------------------------------
 subroutine print_buffer(buffer)
-type(buffer_t), intent(in)  :: buffer
+   type(buffer_t), intent(in)  :: buffer
 
-integer :: i
+   integer :: i
 
-do i = 1, buffer%size
+   do i = 1, buffer%size
       write(unit=6,fmt="(a1)",advance="no") buffer%str(i:i)
-enddo
+   enddo
 
 end subroutine print_buffer
 !----------------------------------------------------------------
 ! This is better... but could it lead to memory leaks?
 !
 function buffer_to_str(buffer) result(str)
-type(buffer_t), intent(in)          :: buffer
-character(len=buffer%size)          :: str
+   type(buffer_t), intent(in)          :: buffer
+   character(len=buffer%size)          :: str
 
-str = buffer%str(1:buffer%size)
+   str = buffer%str(1:buffer%size)
 end function buffer_to_str
 
 !----------------------------------------------------------------
 function buffer_nearly_full(buffer) result(warn)
-type(buffer_t), intent(in)          :: buffer
-logical                             :: warn
+   type(buffer_t), intent(in)          :: buffer
+   logical                             :: warn
 
-warn = buffer%size > BUFF_SIZE_WARNING
+   warn = buffer%size > BUFF_SIZE_WARNING
 
 end function buffer_nearly_full
 
 !----------------------------------------------------------------
 function buffer_length(buffer) result(length)
-type(buffer_t), intent(in)          :: buffer
-integer                             :: length
+   type(buffer_t), intent(in)          :: buffer
+   integer                             :: length
 
-length = buffer%size 
+   length = buffer%size
 
 end function buffer_length
 

--- a/src/xmlf90-wxml/m_wxml_core.f90
+++ b/src/xmlf90-wxml/m_wxml_core.f90
@@ -1,239 +1,239 @@
 module m_wxml_core
 
-use m_wxml_buffer
-use m_wxml_elstack
-use m_wxml_dictionary
+   use m_wxml_buffer
+   use m_wxml_elstack
+   use m_wxml_dictionary
 
-logical, private, save  :: pcdata_advance_line_default = .false.
-logical, private, save  :: pcdata_advance_space_default = .false.
+   logical, private, save  :: pcdata_advance_line_default = .false.
+   logical, private, save  :: pcdata_advance_space_default = .false.
 
-integer, private, parameter ::  sp = selected_real_kind(6,30)
-integer, private, parameter ::  dp = selected_real_kind(14,100)
+   integer, private, parameter ::  sp = selected_real_kind(6,30)
+   integer, private, parameter ::  dp = selected_real_kind(14,100)
 
-private
+   private
 
-type, public :: xmlf_t
-   integer            :: lun
-   type(buffer_t)     :: buffer
-   type(elstack_t)    :: stack
-   type(wxml_dictionary_t) :: dict
-   logical            :: start_tag_closed
-   logical            :: root_element_output
-   logical            :: indenting_requested
-end type xmlf_t
+   type, public :: xmlf_t
+      integer            :: lun
+      type(buffer_t)     :: buffer
+      type(elstack_t)    :: stack
+      type(wxml_dictionary_t) :: dict
+      logical            :: start_tag_closed
+      logical            :: root_element_output
+      logical            :: indenting_requested
+   end type xmlf_t
 
-public :: xml_OpenFile, xml_NewElement, xml_EndElement, xml_Close
-public :: xml_AddPcdata, xml_AddAttribute, xml_AddXMLDeclaration
-public :: xml_AddComment, xml_AddCdataSection
+   public :: xml_OpenFile, xml_NewElement, xml_EndElement, xml_Close
+   public :: xml_AddPcdata, xml_AddAttribute, xml_AddXMLDeclaration
+   public :: xml_AddComment, xml_AddCdataSection
 
-public :: xml_AddArray
-interface xml_AddArray
-   module procedure  xml_AddArray_integer,  &
-                xml_AddArray_real_dp, xml_AddArray_real_sp
-end interface
-private :: xml_AddArray_integer,  xml_AddArray_real_dp, xml_AddArray_real_sp
+   public :: xml_AddArray
+   interface xml_AddArray
+      module procedure  xml_AddArray_integer,  &
+         xml_AddArray_real_dp, xml_AddArray_real_sp
+   end interface xml_AddArray
+   private :: xml_AddArray_integer,  xml_AddArray_real_dp, xml_AddArray_real_sp
 
-private :: get_unit
-private :: add_eol
-private :: write_attributes
+   private :: get_unit
+   private :: add_eol
+   private :: write_attributes
 
 
-integer, private, parameter  :: COLUMNS = 80
+   integer, private, parameter  :: COLUMNS = 80
 
 CONTAINS
 
 !-------------------------------------------------------------------
 subroutine xml_OpenFile(filename, xf, indent)
-character(len=*), intent(in)  :: filename
-type(xmlf_t), intent(inout)   :: xf
-logical, intent(in), optional :: indent
+   character(len=*), intent(in)  :: filename
+   type(xmlf_t), intent(inout)   :: xf
+   logical, intent(in), optional :: indent
 
-integer :: iostat
+   integer :: iostat
 
-call get_unit(xf%lun,iostat)
-if (iostat /= 0) stop "cannot open file"
-open(unit=xf%lun, file=filename, form="formatted", status="replace", &
-     action="write", position="rewind") ! , recl=65536)
+   call get_unit(xf%lun,iostat)
+   if (iostat /= 0) stop "cannot open file"
+   open(unit=xf%lun, file=filename, form="formatted", status="replace", &
+        action="write", position="rewind")  ! , recl=65536)
 
-call reset_elstack(xf%stack)
-call reset_dict(xf%dict)
-call reset_buffer(xf%buffer)
+   call reset_elstack(xf%stack)
+   call reset_dict(xf%dict)
+   call reset_buffer(xf%buffer)
 
-xf%start_tag_closed = .true.
-xf%root_element_output = .false.
+   xf%start_tag_closed = .true.
+   xf%root_element_output = .false.
 
-xf%indenting_requested = .false.
-if (present(indent)) then
-   xf%indenting_requested = indent
-endif
+   xf%indenting_requested = .false.
+   if (present(indent)) then
+      xf%indenting_requested = indent
+   endif
 end subroutine xml_OpenFile
 
 !-------------------------------------------------------------------
 subroutine xml_AddXMLDeclaration(xf,encoding)
-type(xmlf_t), intent(inout)   :: xf
-character(len=*), intent(in), optional :: encoding
+   type(xmlf_t), intent(inout)   :: xf
+   character(len=*), intent(in), optional :: encoding
 
-if (present(encoding)) then
-   call add_to_buffer("<?xml version=""1.0"" encoding=""" &
-                     // trim(encoding) // """ ?>", xf%buffer)
-else
-   call add_to_buffer("<?xml version=""1.0"" ?>", xf%buffer)
-endif
+   if (present(encoding)) then
+      call add_to_buffer("<?xml version=""1.0"" encoding=""" &
+                         // trim(encoding) // """ ?>", xf%buffer)
+   else
+      call add_to_buffer("<?xml version=""1.0"" ?>", xf%buffer)
+   endif
 end subroutine xml_AddXMLDeclaration
 
 !-------------------------------------------------------------------
 subroutine xml_AddComment(xf,comment)
-type(xmlf_t), intent(inout)   :: xf
-character(len=*), intent(in)  :: comment
+   type(xmlf_t), intent(inout)   :: xf
+   character(len=*), intent(in)  :: comment
 
-call close_start_tag(xf,">")
-call add_eol(xf)
-call add_to_buffer("<!--", xf%buffer)
-call add_to_buffer(comment, xf%buffer)
-call add_to_buffer("-->", xf%buffer)
+   call close_start_tag(xf,">")
+   call add_eol(xf)
+   call add_to_buffer("<!--", xf%buffer)
+   call add_to_buffer(comment, xf%buffer)
+   call add_to_buffer("-->", xf%buffer)
 end subroutine xml_AddComment
 
 !-------------------------------------------------------------------
 subroutine xml_AddCdataSection(xf,cdata)
-type(xmlf_t), intent(inout)   :: xf
-character(len=*), intent(in)  :: cdata
+   type(xmlf_t), intent(inout)   :: xf
+   character(len=*), intent(in)  :: cdata
 
-call close_start_tag(xf,">")
-call add_to_buffer("<![CDATA[", xf%buffer)
-call add_to_buffer(cdata, xf%buffer)
-call add_to_buffer("]]>", xf%buffer)
+   call close_start_tag(xf,">")
+   call add_to_buffer("<![CDATA[", xf%buffer)
+   call add_to_buffer(cdata, xf%buffer)
+   call add_to_buffer("]]>", xf%buffer)
 end subroutine xml_AddCdataSection
 
 !-------------------------------------------------------------------
 subroutine xml_NewElement(xf,name)
-type(xmlf_t), intent(inout)   :: xf
-character(len=*), intent(in)  :: name
+   type(xmlf_t), intent(inout)   :: xf
+   character(len=*), intent(in)  :: name
 
-if (is_empty(xf%stack)) then
-   if (xf%root_element_output) stop "two root elements"
-   xf%root_element_output = .true.
-endif
+   if (is_empty(xf%stack)) then
+      if (xf%root_element_output) stop "two root elements"
+      xf%root_element_output = .true.
+   endif
 
-call close_start_tag(xf,">")
-call push_elstack(name,xf%stack)
-call add_eol(xf)
-call add_to_buffer("<" // trim(name),xf%buffer)
-xf%start_tag_closed = .false.
-call reset_dict(xf%dict)
+   call close_start_tag(xf,">")
+   call push_elstack(name,xf%stack)
+   call add_eol(xf)
+   call add_to_buffer("<" // trim(name),xf%buffer)
+   xf%start_tag_closed = .false.
+   call reset_dict(xf%dict)
 
 end subroutine xml_NewElement
 !-------------------------------------------------------------------
 subroutine xml_AddPcdata(xf,pcdata,space,line_feed)
-type(xmlf_t), intent(inout)   :: xf
-character(len=*), intent(in)  :: pcdata
-logical, intent(in), optional  :: space
-logical, intent(in), optional  :: line_feed
+   type(xmlf_t), intent(inout)   :: xf
+   character(len=*), intent(in)  :: pcdata
+   logical, intent(in), optional  :: space
+   logical, intent(in), optional  :: line_feed
 
-logical :: advance_line , advance_space
-integer :: n, i, jmax
-integer, parameter   :: chunk_size = 128
+   logical :: advance_line , advance_space
+   integer :: n, i, jmax
+   integer, parameter   :: chunk_size = 128
 
-advance_line = pcdata_advance_line_default 
-if (present(line_feed)) then
-   advance_line = line_feed
-endif
+   advance_line = pcdata_advance_line_default
+   if (present(line_feed)) then
+      advance_line = line_feed
+   endif
 
-advance_space = pcdata_advance_space_default 
-if (present(space)) then
-   advance_space = space
-endif
+   advance_space = pcdata_advance_space_default
+   if (present(space)) then
+      advance_space = space
+   endif
 
-if (is_empty(xf%stack)) then
-   stop "pcdata outside element content"
-endif
+   if (is_empty(xf%stack)) then
+      stop "pcdata outside element content"
+   endif
 
-call close_start_tag(xf,">")
+   call close_start_tag(xf,">")
 
-if (advance_line) then
-   call add_eol(xf)
-   advance_space = .false.
-else
-   if (xf%indenting_requested) then
-      if ((len(xf%buffer) + len_trim(pcdata) + 1) > COLUMNS ) then
-         call add_eol(xf)
-         advance_space = .false.
+   if (advance_line) then
+      call add_eol(xf)
+      advance_space = .false.
+   else
+      if (xf%indenting_requested) then
+         if ((len(xf%buffer) + len_trim(pcdata) + 1) > COLUMNS ) then
+            call add_eol(xf)
+            advance_space = .false.
+         endif
       endif
    endif
-endif
-if (advance_space) call add_to_buffer(" ",xf%buffer)
-if (len(xf%buffer) > 0) call dump_buffer(xf,lf=.false.)
+   if (advance_space) call add_to_buffer(" ",xf%buffer)
+   if (len(xf%buffer) > 0) call dump_buffer(xf,lf=.false.)
 !
 ! We bypass the buffer for the bulk of the dump
 !
-n = len(pcdata)
+   n = len(pcdata)
 !print *, "writing pcdata of length: ", n
-i = 1
-do
-   jmax = min(i+chunk_size-1,n)
+   i = 1
+   do
+      jmax = min(i+chunk_size-1,n)
 !   print *, "writing chunk: ", i, jmax
-   write(unit=xf%lun,fmt="(a)",advance="no") pcdata(i:jmax)
-   if (jmax == n) exit
-   i = jmax + 1
-enddo
+      write(unit=xf%lun,fmt="(a)",advance="no") pcdata(i:jmax)
+      if (jmax == n) exit
+      i = jmax + 1
+   enddo
 end subroutine xml_AddPcdata
 
 !-------------------------------------------------------------------
 subroutine xml_AddAttribute(xf,name,value)
-type(xmlf_t), intent(inout)   :: xf
-character(len=*), intent(in)  :: name
-character(len=*), intent(in)  :: value
+   type(xmlf_t), intent(inout)   :: xf
+   character(len=*), intent(in)  :: name
+   character(len=*), intent(in)  :: value
 
-if (is_empty(xf%stack)) then
-   stop "attributes outside element content"
-endif
+   if (is_empty(xf%stack)) then
+      stop "attributes outside element content"
+   endif
 
-if (xf%start_tag_closed)  then
-   stop "attributes outside start tag"
-endif
-if (has_key(xf%dict,name)) then
-   stop "duplicate att name"
-endif
+   if (xf%start_tag_closed)  then
+      stop "attributes outside start tag"
+   endif
+   if (has_key(xf%dict,name)) then
+      stop "duplicate att name"
+   endif
 
-call add_key_to_dict(trim(name),xf%dict)
-call add_value_to_dict(trim(value),xf%dict)
+   call add_key_to_dict(trim(name),xf%dict)
+   call add_value_to_dict(trim(value),xf%dict)
 
 end subroutine xml_AddAttribute
 
 !-----------------------------------------------------------
 subroutine xml_EndElement(xf,name)
-type(xmlf_t), intent(inout)   :: xf
-character(len=*), intent(in)  :: name
+   type(xmlf_t), intent(inout)   :: xf
+   character(len=*), intent(in)  :: name
 
-character(len=100)  :: current
+   character(len=100)  :: current
 
-if (is_empty(xf%stack)) then
-   stop "Out of elements to close"
-endif
+   if (is_empty(xf%stack)) then
+      stop "Out of elements to close"
+   endif
 
-call get_top_elstack(xf%stack,current)
-if (current /= name) then
-   print *, "current, name: ", trim(current), " ", trim(name)
-   stop
-endif
-if (.not. xf%start_tag_closed)  then                ! Empty element
-   if (len(xf%dict) > 0) call write_attributes(xf)
-   call add_to_buffer(" />",xf%buffer)
-   xf%start_tag_closed = .true.
-else
-   call add_eol(xf)
-   call add_to_buffer("</" // trim(name) // ">", xf%buffer)
-endif
-call pop_elstack(xf%stack,current)
+   call get_top_elstack(xf%stack,current)
+   if (current /= name) then
+      print *, "current, name: ", trim(current), " ", trim(name)
+      stop
+   endif
+   if (.not. xf%start_tag_closed)  then                ! Empty element
+      if (len(xf%dict) > 0) call write_attributes(xf)
+      call add_to_buffer(" />",xf%buffer)
+      xf%start_tag_closed = .true.
+   else
+      call add_eol(xf)
+      call add_to_buffer("</" // trim(name) // ">", xf%buffer)
+   endif
+   call pop_elstack(xf%stack,current)
 
 end subroutine xml_EndElement
 
 !----------------------------------------------------------------
 
 subroutine xml_Close(xf)
-type(xmlf_t), intent(in)   :: xf
+   type(xmlf_t), intent(in)   :: xf
 
-write(unit=xf%lun,fmt="(a)") char(xf%buffer)
-close(unit=xf%lun)
+   write(unit=xf%lun,fmt="(a)") char(xf%buffer)
+   close(unit=xf%lun)
 
 end subroutine xml_Close
 
@@ -243,138 +243,137 @@ subroutine get_unit(lun,iostat)
 
 ! Get an available Fortran unit number
 
-integer, intent(out)  :: lun
-integer, intent(out)  :: iostat
+   integer, intent(out)  :: lun
+   integer, intent(out)  :: iostat
 
-integer :: i
-logical :: unit_used
+   integer :: i
+   logical :: unit_used
 
-do i = 10, 99
-   lun = i
-   inquire(unit=lun,opened=unit_used)
-   if (.not. unit_used) then
-      iostat = 0
-      return
-   endif
-enddo
-iostat = -1
-lun = -1
+   do i = 10, 99
+      lun = i
+      inquire(unit=lun,opened=unit_used)
+      if (.not. unit_used) then
+         iostat = 0
+         return
+      endif
+   enddo
+   iostat = -1
+   lun = -1
 end subroutine get_unit
 
 !----------------------------------------------------------
 subroutine add_eol(xf)
-type(xmlf_t), intent(inout)   :: xf
+   type(xmlf_t), intent(inout)   :: xf
 
-integer :: indent_level
-character(len=100), parameter  ::  blanks =  ""
+   integer :: indent_level
+   character(len=100), parameter  ::  blanks =  ""
 
-indent_level = len(xf%stack) - 1
-write(unit=xf%lun,fmt="(a)") char(xf%buffer)
-call reset_buffer(xf%buffer)
+   indent_level = len(xf%stack) - 1
+   write(unit=xf%lun,fmt="(a)") char(xf%buffer)
+   call reset_buffer(xf%buffer)
 
-if (xf%indenting_requested) &
-   call add_to_buffer(blanks(1:indent_level),xf%buffer)
+   if (xf%indenting_requested) &
+      call add_to_buffer(blanks(1:indent_level),xf%buffer)
 
 end subroutine add_eol
 !------------------------------------------------------------
 subroutine dump_buffer(xf,lf)
-type(xmlf_t), intent(inout)   :: xf
-logical, intent(in), optional :: lf
+   type(xmlf_t), intent(inout)   :: xf
+   logical, intent(in), optional :: lf
 
-if (present(lf)) then
-   if (lf) then
-      write(unit=xf%lun,fmt="(a)",advance="yes") char(xf%buffer)
+   if (present(lf)) then
+      if (lf) then
+         write(unit=xf%lun,fmt="(a)",advance="yes") char(xf%buffer)
+      else
+         write(unit=xf%lun,fmt="(a)",advance="no") char(xf%buffer)
+      endif
    else
       write(unit=xf%lun,fmt="(a)",advance="no") char(xf%buffer)
    endif
-else
-   write(unit=xf%lun,fmt="(a)",advance="no") char(xf%buffer)
-endif
-call reset_buffer(xf%buffer)
+   call reset_buffer(xf%buffer)
 
 end subroutine dump_buffer
 
 !------------------------------------------------------------
 subroutine close_start_tag(xf,s)
-type(xmlf_t), intent(inout)   :: xf
-character(len=*), intent(in)  :: s
+   type(xmlf_t), intent(inout)   :: xf
+   character(len=*), intent(in)  :: s
 
-if (.not. xf%start_tag_closed)  then
-   if (len(xf%dict) > 0)  call write_attributes(xf)
-   call add_to_buffer(s, xf%buffer)
-   xf%start_tag_closed = .true.
-endif
+   if (.not. xf%start_tag_closed)  then
+      if (len(xf%dict) > 0)  call write_attributes(xf)
+      call add_to_buffer(s, xf%buffer)
+      xf%start_tag_closed = .true.
+   endif
 
 end subroutine close_start_tag
 
 !-------------------------------------------------------------
 subroutine write_attributes(xf)
-type(xmlf_t), intent(inout)   :: xf
+   type(xmlf_t), intent(inout)   :: xf
 
-integer  :: i, status, size
-character(len=100)  :: key, value
+   integer  :: i, status, size
+   character(len=100)  :: key, value
 
-do i = 1, len(xf%dict)
-   call get_key(xf%dict,i,key,status)
-   call get_value(xf%dict,key,value,status)
-   key = adjustl(key)
-   value = adjustl(value)
-   size = len_trim(key) + len_trim(value) + 4
-   if ((len(xf%buffer) + size) > COLUMNS) call add_eol(xf)
-   call add_to_buffer(" ", xf%buffer)
-   call add_to_buffer(trim(key), xf%buffer)
-   call add_to_buffer("=", xf%buffer)
-   call add_to_buffer("""",xf%buffer)
-   call add_to_buffer(trim(value), xf%buffer)
-   call add_to_buffer("""", xf%buffer)
-enddo
+   do i = 1, len(xf%dict)
+      call get_key(xf%dict,i,key,status)
+      call get_value(xf%dict,key,value,status)
+      key = adjustl(key)
+      value = adjustl(value)
+      size = len_trim(key) + len_trim(value) + 4
+      if ((len(xf%buffer) + size) > COLUMNS) call add_eol(xf)
+      call add_to_buffer(" ", xf%buffer)
+      call add_to_buffer(trim(key), xf%buffer)
+      call add_to_buffer("=", xf%buffer)
+      call add_to_buffer("""",xf%buffer)
+      call add_to_buffer(trim(value), xf%buffer)
+      call add_to_buffer("""", xf%buffer)
+   enddo
 
 end subroutine write_attributes
 
 !---------------------------------------------------------------
-    subroutine xml_AddArray_integer(xf,a,format)
-      type(xmlf_t), intent(inout)         :: xf
-      integer, intent(in), dimension(:)   :: a
-      character(len=*), intent(in), optional  :: format
+subroutine xml_AddArray_integer(xf,a,format)
+   type(xmlf_t), intent(inout)         :: xf
+   integer, intent(in), dimension(:)   :: a
+   character(len=*), intent(in), optional  :: format
 
-      call close_start_tag(xf,">")
-      if (len(xf%buffer) > 0) call dump_buffer(xf,lf=.true.)
-      if (present(format)) then
-         write(xf%lun,format) a
-      else
-         write(xf%lun,"(6(i12))") a
-      endif
-    end subroutine xml_AddArray_integer
+   call close_start_tag(xf,">")
+   if (len(xf%buffer) > 0) call dump_buffer(xf,lf=.true.)
+   if (present(format)) then
+      write(xf%lun,format) a
+   else
+      write(xf%lun,"(6(i12))") a
+   endif
+end subroutine xml_AddArray_integer
 
 !-------------------------------------------------------------------
-    subroutine xml_AddArray_real_dp(xf,a,format)
-      type(xmlf_t), intent(inout)         :: xf
-      real(kind=dp), intent(in), dimension(:)   :: a
-      character(len=*), intent(in), optional  :: format
+subroutine xml_AddArray_real_dp(xf,a,format)
+   type(xmlf_t), intent(inout)         :: xf
+   real(kind=dp), intent(in), dimension(:)   :: a
+   character(len=*), intent(in), optional  :: format
 
-      call close_start_tag(xf,">")
-      if (len(xf%buffer) > 0) call dump_buffer(xf,lf=.true.)
-      if (present(format)) then
-         write(xf%lun,format) a
-      else
-         write(xf%lun,"(4(es20.12))") a
-      endif
-    end subroutine xml_AddArray_real_dp
+   call close_start_tag(xf,">")
+   if (len(xf%buffer) > 0) call dump_buffer(xf,lf=.true.)
+   if (present(format)) then
+      write(xf%lun,format) a
+   else
+      write(xf%lun,"(4(es20.12))") a
+   endif
+end subroutine xml_AddArray_real_dp
 
 !------------------------------------------------------------------
-    subroutine xml_AddArray_real_sp(xf,a,format)
-      type(xmlf_t), intent(inout)         :: xf
-      real(kind=sp), intent(in), dimension(:)   :: a
-      character(len=*), intent(in), optional  :: format
+subroutine xml_AddArray_real_sp(xf,a,format)
+   type(xmlf_t), intent(inout)         :: xf
+   real(kind=sp), intent(in), dimension(:)   :: a
+   character(len=*), intent(in), optional  :: format
 
-      call close_start_tag(xf,">")
-      if (len(xf%buffer) > 0) call dump_buffer(xf,lf=.true.)
-      if (present(format)) then
-         write(xf%lun,format) a
-      else
-         write(xf%lun,"(4(es20.12))") a
-      endif
-    end subroutine xml_AddArray_real_sp
+   call close_start_tag(xf,">")
+   if (len(xf%buffer) > 0) call dump_buffer(xf,lf=.true.)
+   if (present(format)) then
+      write(xf%lun,format) a
+   else
+      write(xf%lun,"(4(es20.12))") a
+   endif
+end subroutine xml_AddArray_real_sp
 
 end module m_wxml_core
-

--- a/src/xmlf90-wxml/m_wxml_dictionary.f90
+++ b/src/xmlf90-wxml/m_wxml_dictionary.f90
@@ -1,87 +1,87 @@
 module m_wxml_dictionary
 
-private
+   private
 !
 ! A very rough implementation for now
 ! It uses fixed-length buffers for key/value pairs,
 ! and the maximum number of dictionary items is hardwired.
 
-integer, parameter, private    :: MAX_ITEMS = 30
-type, public :: wxml_dictionary_t
-private
-      integer                               :: number_of_items ! = 0
+   integer, parameter, private    :: MAX_ITEMS = 30
+   type, public :: wxml_dictionary_t
+      private
+      integer                               :: number_of_items  ! = 0
       character(len=100), dimension(MAX_ITEMS)  :: key
       character(len=100), dimension(MAX_ITEMS)  :: value
-end type wxml_dictionary_t
+   end type wxml_dictionary_t
 
 !
 ! Building procedures
 !
-public  :: add_key_to_dict, add_value_to_dict, reset_dict
+   public  :: add_key_to_dict, add_value_to_dict, reset_dict
 
 !
 ! Query and extraction procedures
 !
-public  :: len
-interface len
-   module procedure number_of_entries
-end interface
-public  :: number_of_entries
-public  :: get_key
-public  :: get_value
-public  :: has_key
-public  :: print_dict
+   public  :: len
+   interface len
+      module procedure number_of_entries
+   end interface len
+   public  :: number_of_entries
+   public  :: get_key
+   public  :: get_value
+   public  :: has_key
+   public  :: print_dict
 !
-interface get_value
-   module procedure wxml_get_value
-end interface
+   interface get_value
+      module procedure wxml_get_value
+   end interface get_value
 
 CONTAINS
 
 !------------------------------------------------------
 function number_of_entries(dict) result(n)
-type(wxml_dictionary_t), intent(in)   :: dict
-integer                          :: n
+   type(wxml_dictionary_t), intent(in)   :: dict
+   integer                          :: n
 
-n = dict%number_of_items
+   n = dict%number_of_items
 
 end function number_of_entries
 
 !------------------------------------------------------
 function has_key(dict,key) result(found)
-type(wxml_dictionary_t), intent(in)   :: dict
-character(len=*), intent(in)     :: key
-logical                          :: found
+   type(wxml_dictionary_t), intent(in)   :: dict
+   character(len=*), intent(in)     :: key
+   logical                          :: found
 
-integer  :: n, i
-found = .false.
-n = dict%number_of_items
-do  i = 1, n
+   integer  :: n, i
+   found = .false.
+   n = dict%number_of_items
+   do  i = 1, n
       if (dict%key(i) == key) then
          found = .true.
          exit
       endif
-enddo
+   enddo
 end function has_key
 
 !------------------------------------------------------
 subroutine wxml_get_value(dict,key,value,status)
-type(wxml_dictionary_t), intent(in)            :: dict
-character(len=*), intent(in)              :: key
-character(len=*), intent(out)             :: value
-integer, intent(out)                      :: status
+   type(wxml_dictionary_t), intent(in)            :: dict
+   character(len=*), intent(in)              :: key
+   character(len=*), intent(out)             :: value
+   integer, intent(out)                      :: status
 !
-integer  :: n, i
+   integer  :: n, i
 
-status = -1
-n = dict%number_of_items
-do  i = 1, n
+   status = -1
+   n = dict%number_of_items
+   do  i = 1, n
       if (dict%key(i) == key) then
          value = dict%value(i)
          status = 0
          RETURN
       endif
-enddo
+   enddo
 
 end subroutine wxml_get_value
 
@@ -90,37 +90,37 @@ subroutine get_key(dict,i,key,status)
 !
 ! Get the i'th key
 !
-type(wxml_dictionary_t), intent(in)            :: dict
-integer, intent(in)                       :: i
-character(len=*), intent(out)             :: key
-integer, intent(out)                      :: status
+   type(wxml_dictionary_t), intent(in)            :: dict
+   integer, intent(in)                       :: i
+   character(len=*), intent(out)             :: key
+   integer, intent(out)                      :: status
 
-if (i <= dict%number_of_items) then
+   if (i <= dict%number_of_items) then
       key = dict%key(i)
       status = 0
-else
+   else
       key = ""
       status = -1
-endif
+   endif
 
 end subroutine get_key
 
 !------------------------------------------------------
 subroutine add_key_to_dict(key,dict)
-character(len=*), intent(in)          :: key
-type(wxml_dictionary_t), intent(inout)   :: dict
+   character(len=*), intent(in)          :: key
+   type(wxml_dictionary_t), intent(inout)   :: dict
 
-integer  :: n
+   integer  :: n
 
-n = dict%number_of_items
-if (n == MAX_ITEMS) then
+   n = dict%number_of_items
+   if (n == MAX_ITEMS) then
       write(unit=0,fmt=*) "Dictionary capacity exceeded !"
       RETURN
-endif
+   endif
 
-n = n + 1
-dict%key(n) = key
-dict%number_of_items = n
+   n = n + 1
+   dict%key(n) = key
+   dict%number_of_items = n
 
 end subroutine add_key_to_dict
 
@@ -129,33 +129,33 @@ end subroutine add_key_to_dict
 ! so one adds first the key and then immediately afterwards the value.
 !
 subroutine add_value_to_dict(value,dict)
-character(len=*), intent(in)          :: value
-type(wxml_dictionary_t), intent(inout)   :: dict
+   character(len=*), intent(in)          :: value
+   type(wxml_dictionary_t), intent(inout)   :: dict
 
-integer  :: n
+   integer  :: n
 
-n = dict%number_of_items
-dict%value(n) = value
+   n = dict%number_of_items
+   dict%value(n) = value
 
 end subroutine add_value_to_dict
 
 !------------------------------------------------------
 subroutine reset_dict(dict)
-type(wxml_dictionary_t), intent(inout)   :: dict
+   type(wxml_dictionary_t), intent(inout)   :: dict
 
-dict%number_of_items = 0
+   dict%number_of_items = 0
 
 end subroutine reset_dict
 
 !------------------------------------------------------
 subroutine print_dict(dict)
-type(wxml_dictionary_t), intent(in)   :: dict
+   type(wxml_dictionary_t), intent(in)   :: dict
 
-integer  :: i
+   integer  :: i
 
-do i = 1, dict%number_of_items
+   do i = 1, dict%number_of_items
       print *, trim(dict%key(i)), " = ", trim(dict%value(i))
-enddo
+   enddo
 
 end subroutine print_dict
 

--- a/src/xmlf90-wxml/m_wxml_elstack.f90
+++ b/src/xmlf90-wxml/m_wxml_elstack.f90
@@ -1,91 +1,91 @@
 module m_wxml_elstack
 
-private
+   private
 
 !
 ! Simple stack to keep track of which elements have appeared so far
 !
-integer, parameter, private            :: STACK_SIZE = 20
+   integer, parameter, private            :: STACK_SIZE = 20
 
-type, public :: elstack_t
-private
+   type, public :: elstack_t
+      private
       integer                                    :: n_items
       character(len=100), dimension(STACK_SIZE)  :: data
-end type elstack_t
+   end type elstack_t
 
-public  :: push_elstack, pop_elstack, reset_elstack, print_elstack
-public  :: get_top_elstack, is_empty, get_elstack_signature
-public  :: len
+   public  :: push_elstack, pop_elstack, reset_elstack, print_elstack
+   public  :: get_top_elstack, is_empty, get_elstack_signature
+   public  :: len
 
-interface len
-   module procedure number_of_items
-end interface
-private :: number_of_items
+   interface len
+      module procedure number_of_items
+   end interface len
+   private :: number_of_items
 
-interface is_empty
+   interface is_empty
       module procedure is_empty_elstack
-end interface
-private :: is_empty_elstack
+   end interface is_empty
+   private :: is_empty_elstack
 
 CONTAINS
 
 !-----------------------------------------------------------------
 subroutine reset_elstack(elstack)
-type(elstack_t), intent(inout)  :: elstack
+   type(elstack_t), intent(inout)  :: elstack
 
-elstack%n_items = 0
+   elstack%n_items = 0
 
 end subroutine reset_elstack
 
 !-----------------------------------------------------------------
 function is_empty_elstack(elstack) result(answer)
-type(elstack_t), intent(in)  :: elstack
-logical                    :: answer
+   type(elstack_t), intent(in)  :: elstack
+   logical                    :: answer
 
-answer = (elstack%n_items == 0)
+   answer = (elstack%n_items == 0)
 end function is_empty_elstack
 
 !-----------------------------------------------------------------
 function number_of_items(elstack) result(n)
-type(elstack_t), intent(in)  :: elstack
-integer                      :: n
+   type(elstack_t), intent(in)  :: elstack
+   integer                      :: n
 
-n = elstack%n_items
+   n = elstack%n_items
 end function number_of_items
 
 !-----------------------------------------------------------------
 subroutine push_elstack(item,elstack)
-character(len=*), intent(in)      :: item
-type(elstack_t), intent(inout)  :: elstack
+   character(len=*), intent(in)      :: item
+   type(elstack_t), intent(inout)  :: elstack
 
-integer   :: n
+   integer   :: n
 
-n = elstack%n_items
-if (n == STACK_SIZE) then
+   n = elstack%n_items
+   if (n == STACK_SIZE) then
       stop "*Element stack full"
-endif
-n = n + 1
-elstack%data(n) = item
-elstack%n_items = n
+   endif
+   n = n + 1
+   elstack%data(n) = item
+   elstack%n_items = n
 
 end subroutine push_elstack
 
 !-----------------------------------------------------------------
 subroutine pop_elstack(elstack,item)
-type(elstack_t), intent(inout)     :: elstack
-character(len=*), intent(out)        :: item
+   type(elstack_t), intent(inout)     :: elstack
+   character(len=*), intent(out)        :: item
 
 !
 ! We assume the elstack is not empty... (the user has called is_empty first)
 !
-integer   :: n
+   integer   :: n
 
-n = elstack%n_items
-if (n == 0) then
+   n = elstack%n_items
+   if (n == 0) then
       stop "*********Element stack empty"
-endif
-item = elstack%data(n)
-elstack%n_items = n - 1
+   endif
+   item = elstack%data(n)
+   elstack%n_items = n - 1
 
 end subroutine pop_elstack
 
@@ -94,49 +94,49 @@ subroutine get_top_elstack(elstack,item)
 !
 ! Get the top element of the stack, *without popping it*.
 !
-type(elstack_t), intent(in)        :: elstack
-character(len=*), intent(out)        :: item
+   type(elstack_t), intent(in)        :: elstack
+   character(len=*), intent(out)        :: item
 
 !
 ! We assume the elstack is not empty... (the user has called is_empty first)
 !
-integer   :: n
+   integer   :: n
 
-n = elstack%n_items
-if (n == 0) then
+   n = elstack%n_items
+   if (n == 0) then
       stop "*********Element stack empty"
-endif
-item = elstack%data(n)
+   endif
+   item = elstack%data(n)
 
 end subroutine get_top_elstack
 
 !-----------------------------------------------------------------
 subroutine print_elstack(elstack,unit)
-type(elstack_t), intent(in)   :: elstack
-integer, intent(in)           :: unit
-integer   :: i
+   type(elstack_t), intent(in)   :: elstack
+   integer, intent(in)           :: unit
+   integer   :: i
 
-do i = elstack%n_items, 1, -1
+   do i = elstack%n_items, 1, -1
       write(unit=unit,fmt=*) trim(elstack%data(i))
-enddo
+   enddo
 
 end subroutine print_elstack
 
 !-------------------------------------------------------------
 subroutine get_elstack_signature(elstack,string)
-type(elstack_t), intent(in)   :: elstack
-character(len=*), intent(out) :: string
-integer   :: i, length, j
+   type(elstack_t), intent(in)   :: elstack
+   character(len=*), intent(out) :: string
+   integer   :: i, length, j
 
-string = ""
-j = 0
-do i = 1, elstack%n_items
-   length = len_trim(elstack%data(i))
-   string(j+1:j+1) = "/"
-   j = j+1
-   string(j+1:j+length) = trim(elstack%data(i))
-   j = j + length
-enddo
+   string = ""
+   j = 0
+   do i = 1, elstack%n_items
+      length = len_trim(elstack%data(i))
+      string(j+1:j+1) = "/"
+      j = j+1
+      string(j+1:j+length) = trim(elstack%data(i))
+      j = j + length
+   enddo
 
 end subroutine get_elstack_signature
 

--- a/src/xmlf90-wxml/m_wxml_text.f90
+++ b/src/xmlf90-wxml/m_wxml_text.f90
@@ -1,79 +1,79 @@
 module m_wxml_text
 !
-integer, private, parameter ::  sp = selected_real_kind(6,30)
-integer, private, parameter ::  dp = selected_real_kind(14,100)
+   integer, private, parameter ::  sp = selected_real_kind(6,30)
+   integer, private, parameter ::  dp = selected_real_kind(14,100)
 !
-private
+   private
 
-public :: str
+   public :: str
 
-interface str
-   module procedure  str_integer,  str_real_dp, str_real_sp, &
-                     str_logical
-end interface
-private :: str_integer,  str_real_dp, str_real_sp, str_logical
+   interface str
+      module procedure  str_integer,  str_real_dp, str_real_sp, &
+         str_logical
+   end interface str
+   private :: str_integer,  str_real_dp, str_real_sp, str_logical
 
 CONTAINS
 
-      function str_integer(int,format) result(s)
-      integer, intent(in)   :: int
-      character(len=*), intent(in), optional  :: format
-      character(len=100)    :: s
+function str_integer(int,format) result(s)
+   integer, intent(in)   :: int
+   character(len=*), intent(in), optional  :: format
+   character(len=100)    :: s
 
-      if (present(format)) then
-         write(s,format) int
+   if (present(format)) then
+      write(s,format) int
+   else
+      write(s,"(i25)") int
+   endif
+   s = adjustl(s)
+end function str_integer
+
+function str_logical(log,format) result(s)
+   logical, intent(in)   :: log
+   character(len=*), intent(in), optional  :: format
+   character(len=100)    :: s
+
+   if (present(format)) then
+      write(s,format) log
+   else
+      write(s,"(l1)") log
+   endif
+   s = adjustl(s)
+end function str_logical
+
+function str_real_dp(x,format) result(s)
+   real(kind=dp), intent(in)   :: x
+   character(len=*), intent(in), optional  :: format
+   character(len=100)    :: s
+
+   if (present(format)) then
+      write(s,format) x
+   else
+      if (abs(nint(x)-x) < epsilon(x)) then
+         write(s,"(f20.0)") x
       else
-         write(s,"(i25)") int
+         write(s,"(g22.12)") x
       endif
-      s = adjustl(s)
-      end function str_integer
+   endif
+   s = adjustl(s)
+end function str_real_dp
 
-      function str_logical(log,format) result(s)
-      logical, intent(in)   :: log
-      character(len=*), intent(in), optional  :: format
-      character(len=100)    :: s
+function str_real_sp(x,format) result(s)
+   real(kind=sp), intent(in)   :: x
+   character(len=*), intent(in), optional  :: format
+   character(len=100)    :: s
 
-      if (present(format)) then
-         write(s,format) log
+   if (present(format)) then
+      write(s,format) x
+   else
+      if (abs(nint(x)-x) < epsilon(x)) then
+         write(s,"(f20.0)") x
       else
-         write(s,"(l1)") log
+         write(s,"(g22.12)") x
       endif
-      s = adjustl(s)
-      end function str_logical
-
-      function str_real_dp(x,format) result(s)
-      real(kind=dp), intent(in)   :: x
-      character(len=*), intent(in), optional  :: format
-      character(len=100)    :: s
-
-      if (present(format)) then
-            write(s,format) x
-      else
-         if (abs(nint(x)-x) .lt. epsilon(x)) then
-            write(s,"(f20.0)") x
-         else
-            write(s,"(g22.12)") x
-         endif
-      endif
-      s = adjustl(s)
-      end function str_real_dp
-
-      function str_real_sp(x,format) result(s)
-      real(kind=sp), intent(in)   :: x
-      character(len=*), intent(in), optional  :: format
-      character(len=100)    :: s
-
-      if (present(format)) then
-         write(s,format) x
-      else
-         if (abs(nint(x)-x) .lt. epsilon(x)) then
-            write(s,"(f20.0)") x
-         else
-            write(s,"(g22.12)") x
-         endif
-      endif
-      s = adjustl(s)
-      end function str_real_sp
+   endif
+   s = adjustl(s)
+end function str_real_sp
 
 
 end module m_wxml_text

--- a/src/xmlf90-wxml/makefile
+++ b/src/xmlf90-wxml/makefile
@@ -1,4 +1,4 @@
-.SUFFIXES: 
+.SUFFIXES:
 .SUFFIXES: .f .F .o .a  .f90 .F90
 #
 include ../../make.inc
@@ -30,5 +30,3 @@ m_wxml_core.o: m_wxml_buffer.o m_wxml_dictionary.o m_wxml_elstack.o
 	$(F90) $(FFLAGS) $(INC) -c $*.f
 .F.o:
 	$(F90) $(FFLAGS) $(DEFS) $(INC) -c $*.F
-
-

--- a/src/xmlf90-wxml/xmlf90_wxml.f90
+++ b/src/xmlf90-wxml/xmlf90_wxml.f90
@@ -3,9 +3,9 @@ module xmlf90_wxml
 !use m_wxml_buffer
 !use m_wxml_dictionary
 !use m_wxml_elstack
-use m_wxml_text
-use m_wxml_core
+   use m_wxml_text
+   use m_wxml_core
 
-public
+   public
 
 end module xmlf90_wxml


### PR DESCRIPTION
Currently, modifying the code of oncvpsp often involves unintended changes due to editor settings which trim trailing whitespace, fix inconsistent indentation, etc.

This makes reviewing PRs a pain and muddies the commit history with whitespace diffs.

Here, I add pre-commit hooks which should run before every commit to enforce style consistency up to a point (via the formatter `findent`), and to check for code style (via the linter `fortitude`).

The readme explains how to set up `pre-commit`.

`findent` is configured in `.pre-commit-config.yaml`, and `fortitude` is configured in `fortitude.toml`.

I ran pre-commit on all the files in the repository (with some exceptions defined in `.pre-commit-config.yaml`).
Notably, _many_ of the `fortitude` code quality checks do _not_ pass, including missing `implicit none`.
I've ignored all of the currently present errors for the moment; this can be fixed in future PRs.