### PR TITLE
TOML input

### DIFF
--- a/.github/workflows/cmake-multi-platform.yaml
+++ b/.github/workflows/cmake-multi-platform.yaml
@@ -21,7 +21,7 @@ jobs:
         os: [ubuntu-latest]
         build_type: [Release, Debug]
         c_compiler: [gcc]
-        libxc_version: [5.2.3] # [4.3.4, 5.2.3, 6.2.2, 7.0.0]
+        libxc_version: [5.2.3]
         include:
           - os: ubuntu-latest
             c_compiler: gcc
@@ -46,8 +46,6 @@ jobs:
         sudo apt install -y build-essential gfortran
         # 2 # LAPACK and BLAS
         sudo apt install -y liblapack-dev libblas-dev
-        # # 3 # Libxc
-        # sudo apt install -y libxc-dev
 
     - name: Cache Libxc
       id: cache-libxc
@@ -64,7 +62,7 @@ jobs:
         cd libxc-${{ matrix.libxc_version }}
         mkdir build
         cd build
-        cmake .. -DCMAKE_ENABLE_FORTRAN=ON -DCMAKE_C_COMPILER=${{ matrix.c_compiler }} -DCMAKE_Fortran_COMPILER=${{ matrix.fortran_compiler }} -DCMAKE_INSTALL_PREFIX=$HOME/local/libxc-${{ matrix.libxc_version }}
+        cmake .. -DENABLE_FORTRAN=ON -DCMAKE_C_COMPILER=${{ matrix.c_compiler }} -DCMAKE_Fortran_COMPILER=${{ matrix.fortran_compiler }} -DCMAKE_INSTALL_PREFIX=$HOME/local/libxc-${{ matrix.libxc_version }}
         make -j4
         make install
 

--- a/.github/workflows/cmake-multi-platform.yaml
+++ b/.github/workflows/cmake-multi-platform.yaml
@@ -56,8 +56,8 @@ jobs:
         -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
         -DCMAKE_Fortran_COMPILER=${{ matrix.fortran_compiler }}
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
-        -DLAPACK_ROOT=/usr/lib/x86_64-linux-gnu
-        -DBLAS_ROOT=/usr/lib/x86_64-linux-gnu
+        -DLAPACK_ROOT=/usr/lib/x86_64-linux-gnu/lapack
+        -DBLAS_ROOT=/usr/lib/x86_64-linux-gnu/blas
         -S ${{ github.workspace }}
 
     - name: Build

--- a/.github/workflows/cmake-multi-platform.yaml
+++ b/.github/workflows/cmake-multi-platform.yaml
@@ -18,14 +18,11 @@ jobs:
 
       # Set up a matrix
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
         build_type: [Release, Debug]
         c_compiler: [gcc]
         include:
           - os: ubuntu-latest
-            c_compiler: gcc
-            fortran_compiler: gfortran
-          - os: macos-latest
             c_compiler: gcc
             fortran_compiler: gfortran
 
@@ -59,6 +56,8 @@ jobs:
         -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
         -DCMAKE_Fortran_COMPILER=${{ matrix.fortran_compiler }}
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        -DLAPACK_ROOT=/usr/lib/x86_64-linux-gnu
+        -DBLAS_ROOT=/usr/lib/x86_64-linux-gnu
         -S ${{ github.workspace }}
 
     - name: Build

--- a/.github/workflows/cmake-multi-platform.yaml
+++ b/.github/workflows/cmake-multi-platform.yaml
@@ -51,18 +51,24 @@ jobs:
       id: cache-libxc
       uses: actions/cache@v4
       with:
-        path: $HOME/local/libxc-${{ matrix.libxc_version }}
+        path: |
+          $HOME/dependencies/libxc-${{ matrix.libxc_version }}
         key: ${{ runner.os }}-${{ matrix.c_compiler }}-libxc-${{ matrix.libxc_version }}
 
     - name: Compile Libxc
       if: steps.cache-libxc.outputs.cache-hit != 'true'
       run: |
+        cd $HOME
         wget https://gitlab.com/libxc/libxc/-/archive/${{ matrix.libxc_version }}/libxc-${{ matrix.libxc_version }}.tar.bz2
         tar -xf libxc-${{ matrix.libxc_version }}.tar.bz2
         cd libxc-${{ matrix.libxc_version }}
         mkdir build
         cd build
-        cmake .. -DENABLE_FORTRAN=ON -DCMAKE_C_COMPILER=${{ matrix.c_compiler }} -DCMAKE_Fortran_COMPILER=${{ matrix.fortran_compiler }} -DCMAKE_INSTALL_PREFIX=$HOME/local/libxc-${{ matrix.libxc_version }}
+        cmake .. \
+          -DENABLE_FORTRAN=ON \
+          -DCMAKE_C_COMPILER=${{ matrix.c_compiler }} \
+          -DCMAKE_Fortran_COMPILER=${{ matrix.fortran_compiler }} \
+          -DCMAKE_INSTALL_PREFIX=$HOME/dependencies/libxc-${{ matrix.libxc_version }}
         make -j4
         make install
 
@@ -74,12 +80,14 @@ jobs:
         -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
         -DCMAKE_Fortran_COMPILER=${{ matrix.fortran_compiler }}
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
-        -DLibxc_ROOT=$HOME/local/libxc-${{ matrix.libxc_version }}
+        -DLibxc_ROOT=$HOME/dependencies/libxc-${{ matrix.libxc_version }}
         -S ${{ github.workspace }}
 
     - name: Build
       # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
-      run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}
+      run: >
+        cmake --build ${{ steps.strings.outputs.build-output-dir }}
+        --config ${{ matrix.build_type }}
 
     - name: Test
       run: |

--- a/.github/workflows/cmake-multi-platform.yaml
+++ b/.github/workflows/cmake-multi-platform.yaml
@@ -4,7 +4,7 @@ name: CMake on multiple platforms
 
 on:
   push:
-    branches: [ "master", "dev", "ci-build-test" ]
+    branches: [ "master", "dev", "ci-build-test", "libxc-support" ]
   pull_request:
     branches: [ "master" ]
 

--- a/.github/workflows/cmake-multi-platform.yaml
+++ b/.github/workflows/cmake-multi-platform.yaml
@@ -59,9 +59,9 @@ jobs:
     - name: Compile Libxc
       if: steps.cache-libxc.outputs.cache-hit != 'true'
       run: |
-        wget https://gitlab.com/libxc/libxc/-/archive/${{ libxc_version }}/libxc-${{ libxc_version }}.tar.bz2
-        tar -xf libxc-${{ libxc_version }}.tar.bz2
-        cd libxc-${{ libxc_version }}
+        wget https://gitlab.com/libxc/libxc/-/archive/${{ matrix.libxc_version }}/libxc-${{ matrix.libxc_version }}.tar.bz2
+        tar -xf libxc-${{ matrix.libxc_version }}.tar.bz2
+        cd libxc-${{ matrix.libxc_version }}
         mkdir build
         cd build
         cmake .. -DCMAKE_ENABLE_FORTRAN=ON -DCMAKE_C_COMPILER=${{ matrix.c_compiler }} -DCMAKE_Fortran_COMPILER=${{ matrix.fortran_compiler }} -DCMAKE_INSTALL_PREFIX=$HOME/local/libxc-${{ libxc_version }}

--- a/.github/workflows/cmake-multi-platform.yaml
+++ b/.github/workflows/cmake-multi-platform.yaml
@@ -71,5 +71,5 @@ jobs:
     - name: Upload TEST.report
       uses: actions/upload-artifact@v4
       with:
-        name: TEST.report
+        name: ${{ matrix.os }}-${{ matrix.fortran_compiler }}-${{ matrix.build_type }}-TEST.report
         path: tests/data/TEST.report

--- a/.github/workflows/cmake-multi-platform.yaml
+++ b/.github/workflows/cmake-multi-platform.yaml
@@ -56,8 +56,6 @@ jobs:
         -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
         -DCMAKE_Fortran_COMPILER=${{ matrix.fortran_compiler }}
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
-        -DLAPACK_ROOT=/usr/lib/x86_64-linux-gnu/lapack
-        -DBLAS_ROOT=/usr/lib/x86_64-linux-gnu/blas
         -S ${{ github.workspace }}
 
     - name: Build

--- a/.github/workflows/cmake-multi-platform.yaml
+++ b/.github/workflows/cmake-multi-platform.yaml
@@ -72,7 +72,7 @@ jobs:
         ./TEST.sh
 
     - name: Upload TEST.report
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: TEST.report
         path: tests/data/TEST.report

--- a/.github/workflows/cmake-multi-platform.yaml
+++ b/.github/workflows/cmake-multi-platform.yaml
@@ -64,7 +64,7 @@ jobs:
         cd libxc-${{ matrix.libxc_version }}
         mkdir build
         cd build
-        cmake .. -DCMAKE_ENABLE_FORTRAN=ON -DCMAKE_C_COMPILER=${{ matrix.c_compiler }} -DCMAKE_Fortran_COMPILER=${{ matrix.fortran_compiler }} -DCMAKE_INSTALL_PREFIX=$HOME/local/libxc-${{ libxc_version }}
+        cmake .. -DCMAKE_ENABLE_FORTRAN=ON -DCMAKE_C_COMPILER=${{ matrix.c_compiler }} -DCMAKE_Fortran_COMPILER=${{ matrix.fortran_compiler }} -DCMAKE_INSTALL_PREFIX=$HOME/local/libxc-${{ matrix.libxc_version }}
         make -j4
         make install
 

--- a/.github/workflows/cmake-multi-platform.yaml
+++ b/.github/workflows/cmake-multi-platform.yaml
@@ -21,6 +21,7 @@ jobs:
         os: [ubuntu-latest]
         build_type: [Release, Debug]
         c_compiler: [gcc]
+        libxc_version: [5.2.3] # [4.3.4, 5.2.3, 6.2.2, 7.0.0]
         include:
           - os: ubuntu-latest
             c_compiler: gcc
@@ -37,7 +38,7 @@ jobs:
       run: |
         echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
 
-    - name: Install dependencies
+    - name: Install packaged dependencies
       run: |
         sudo apt update
         sudo apt install -y cmake
@@ -45,8 +46,27 @@ jobs:
         sudo apt install -y build-essential gfortran
         # 2 # LAPACK and BLAS
         sudo apt install -y liblapack-dev libblas-dev
-        # 3 # Libxc
-        sudo apt install -y libxc-dev
+        # # 3 # Libxc
+        # sudo apt install -y libxc-dev
+
+    - name: Cache Libxc
+      id: cache-libxc
+      uses: actions/cache@v4
+      with:
+        path: $HOME/local/libxc-${{ matrix.libxc_version }}
+        key: ${{ runner.os }}-${{ matrix.c_compiler }}-libxc-${{ matrix.libxc_version }}
+
+    - name: Compile Libxc
+      if: steps.cache-libxc.outputs.cache-hit != 'true'
+      run: |
+        wget https://gitlab.com/libxc/libxc/-/archive/${{ libxc_version }}/libxc-${{ libxc_version }}.tar.bz2
+        tar -xf libxc-${{ libxc_version }}.tar.bz2
+        cd libxc-${{ libxc_version }}
+        mkdir build
+        cd build
+        cmake .. -DCMAKE_ENABLE_FORTRAN=ON -DCMAKE_C_COMPILER=${{ matrix.c_compiler }} -DCMAKE_Fortran_COMPILER=${{ matrix.fortran_compiler }} -DCMAKE_INSTALL_PREFIX=$HOME/local/libxc-${{ libxc_version }}
+        make -j4
+        make install
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
@@ -56,6 +76,7 @@ jobs:
         -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
         -DCMAKE_Fortran_COMPILER=${{ matrix.fortran_compiler }}
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        -DLibxc_ROOT=$HOME/local/libxc-${{ matrix.libxc_version }}
         -S ${{ github.workspace }}
 
     - name: Build

--- a/.github/workflows/cmake-multi-platform.yaml
+++ b/.github/workflows/cmake-multi-platform.yaml
@@ -4,7 +4,7 @@ name: CMake on multiple platforms
 
 on:
   push:
-    branches: [ "master", "dev", "CI" ]
+    branches: [ "master", "dev", "ci-build-test" ]
   pull_request:
     branches: [ "master" ]
 

--- a/.github/workflows/cmake-multi-platform.yaml
+++ b/.github/workflows/cmake-multi-platform.yaml
@@ -1,0 +1,78 @@
+# This starter workflow is for a CMake project running on multiple platforms. There is a different starter workflow if you just want a single platform.
+# See: https://github.com/actions/starter-workflows/blob/main/ci/cmake-single-platform.yml
+name: CMake on multiple platforms
+
+on:
+  push:
+    branches: [ "master", "dev", "CI" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      # Set fail-fast to false to ensure that feedback is delivered for all matrix combinations. Consider changing this to true when your workflow is stable.
+      fail-fast: false
+
+      # Set up a matrix
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        build_type: [Release, Debug]
+        c_compiler: [gcc]
+        include:
+          - os: ubuntu-latest
+            c_compiler: gcc
+            fortran_compiler: gfortran
+          - os: macos-latest
+            c_compiler: gcc
+            fortran_compiler: gfortran
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set reusable strings
+      # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.
+      id: strings
+      shell: bash
+      run: |
+        echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
+
+    - name: Install dependencies
+      run: |
+        sudo apt update
+        sudo apt install -y cmake
+        # 1 # compiler
+        sudo apt install -y build-essential gfortran
+        # 2 # LAPACK and BLAS
+        sudo apt install -y liblapack-dev libblas-dev
+        # 3 # Libxc
+        sudo apt install -y libxc-dev
+
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: >
+        cmake -B ${{ steps.strings.outputs.build-output-dir }}
+        -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
+        -DCMAKE_Fortran_COMPILER=${{ matrix.fortran_compiler }}
+        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        -S ${{ github.workspace }}
+
+    - name: Build
+      # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
+      run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}
+
+    - name: Test
+      run: |
+        ./set_path
+        cd tests/data
+        ./TEST.sh
+
+    - name: Upload TEST.report
+      uses: actions/upload-artifact@v3
+      with:
+        name: TEST.report
+        path: tests/data/TEST.report

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,11 @@ project(oncvpsp
     DESCRIPTION "Optimized norm-conserving Vanderbilt pseudopotentials"
     LANGUAGES Fortran C)
 
+##########################################################
+# Options
+##########################################################
+option(WITH_TOML "Enable TOML input support" ON)
+
 ###########################################################
 # Include CMake modules
 ###########################################################
@@ -170,11 +175,13 @@ endif()
 ###########################################################
 # TOML-F (via CPM)
 ###########################################################
-CPMAddPackage(
-    URI "gh:toml-f/toml-f@0.4.2"
-    OPTIONS "BUILD_TESTING=OFF"
-)
-list(APPEND COMMON_LIBRARIES toml-f-lib)
+if (WITH_TOML)
+    CPMAddPackage(
+        URI "gh:toml-f/toml-f@0.4.2"
+        OPTIONS "BUILD_TESTING=OFF"
+    )
+    list(APPEND COMMON_LIBRARIES toml-f-lib)
+endif()
 
 ###########################################################
 # CMake Configuration

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,54 +68,98 @@ find_package(PkgConfig)
 ###########################################################
 # LAPACK
 ###########################################################
-find_package(LAPACK)
-if (NOT LAPACK_FOUND)
-    message(STATUS "LAPACK not found. Trying with hints.")
+if (DEFINED LAPACK_ROOT)
     find_package(LAPACK REQUIRED HINTS ${LAPACK_ROOT})
+else()
+    find_package(LAPACK REQUIRED)
 endif()
+message(STATUS "Found LAPACK version ${LAPACK_VERSION}")
+message(STATUS "  LAPACK libraries: ${LAPACK_LIBRARIES}")
 list(APPEND COMMON_LIBRARIES ${LAPACK_LIBRARIES})
 
 ###########################################################
 # LIBXC
-# Prefer using pkg-config
-# Otherwise, try using CMake's FindLibxc module
+# Prefer using pkg-config; otherwise, try using CMake's FindLibxc module
+# N.B. Libxc v5.0.0 had a breaking change to the Fortran interface where
+# the f03 module was renamed (and overwrote an existing) f90 module, so
+# it needs to be special-cased.
 ###########################################################
-include(CMakePrintHelpers)
+
+# Try to find Libxc via pkg-config
+set(Libxc_FOUND FALSE)
 if ((PkgConfig_FOUND) AND (NOT DEFINED Libxc_ROOT))
-    pkg_check_modules(ONCVPSP_LIBXCF90 QUIET IMPORTED_TARGET libxcf90)
-    pkg_check_modules(ONCVPSP_LIBXCF03 QUIET IMPORTED_TARGET libxcf03)
-    if (ONCVPSP_LIBXCF03_FOUND AND ONCVPSP_LIBXCF90_FOUND)
+    message(STATUS "Looking for Libxc via pkg-config")
+    # C library
+    pkg_check_modules(ONCVPSP_LIBXC QUIET IMPORTED_TARGET libxc)
+    if (ONCVPSP_LIBXC_FOUND)
+        message(STATUS "Found Libxc version ${ONCVPSP_LIBXC_VERSION} via pkg-config")
+    endif()
+    # Fortran interface
+    pkg_check_modules(ONCVPSP_LIBXCF QUIET IMPORTED_TARGET libxcf03)
+    if (ONCVPSP_LIBXCF_FOUND)
+        message(STATUS "Found Libxc Fortran version ${ONCVPSP_LIBXCF_VERSION} via pkg-config")
+    endif()
+    # Version check
+    if (ONCVPSP_LIBXC_VERSION VERSION_LESS 3)
+        message(STATUS "Libxc version ${ONCVPSP_LIBXC_VERSION} found via pkg-config is too old (<3.0.0). Setting Libxc_FOUND to FALSE.")
+        set(Libxc_FOUND FALSE)
+    elseif (ONCVPSP_LIBXC_VERSION VERSION_EQUAL 5.0.0)
+        message(STATUS "Libxc version 5.0.0 found via pkg-config is affected by serious bugs. Setting Libxc_FOUND to FALSE.")
+        set(Libxc_FOUND FALSE)
+    endif()
+    # Success check
+    if (ONCVPSP_LIBXC_FOUND AND ONCVPSP_LIBXCF_FOUND)
         message(STATUS "Found Libxc via pkg-config")
         set(Libxc_FOUND TRUE)
-        set(Libxc_VERSION ${ONCVPSP_LIBXCF03_VERSION})
-        set(LIBXC_LIBRARIES PkgConfig::ONCVPSP_LIBXCF90 PkgConfig::ONCVPSP_LIBXCF03)
-        set(LIBXC_INCLUDE_DIRS ${ONCVPSP_LIBXCF03_INCLUDE_DIRS})
+        set(Libxc_VERSION ${ONCVPSP_LIBXCF_VERSION})
+        set(LIBXC_LIBRARIES PkgConfig::ONCVPSP_LIBXC PkgConfig::ONCVPSP_LIBXCF)
+        set(LIBXC_INCLUDE_DIRS ${ONCVPSP_LIBXCF_INCLUDE_DIRS})
     else()
         message(STATUS "Libxc not found via pkg-config")
-        set(Libxc_FOUND FALSE)
     endif()
 endif()
 
+# If not found via pkg-config, try CMake's FindLibxc module
 if (NOT Libxc_FOUND)
-    find_package(Libxc COMPONENTS Fortran)
-    message(STATUS "Found Libxc via CMake's find_package")
+    message(STATUS "Looking for Libxc via CMake's find_package")
+    find_package(Libxc)
     if (Libxc_FOUND)
-        set(LIBXC_LIBRARIES Libxc::xcf90 Libxc::xcf03)
+        message(STATUS "Found Libxc version ${Libxc_VERSION} via CMake's find_package")
+        # Version check
+        if (Libxc_VERSION VERSION_LESS 3)
+            message(STATUS "Libxc version ${Libxc_VERSION} found via CMake is too old. Setting Libxc_FOUND to FALSE.")
+            set(Libxc_FOUND FALSE)
+        elseif (Libxc_VERSION VERSION_EQUAL 5.0.0)
+            message(STATUS "Libxc version 5.0.0 found via pkg-config is affected by serious bugs. Setting Libxc_FOUND to FALSE.")
+            set(Libxc_FOUND FALSE)
+        endif()
+        # Fortran interface check
+        if (NOT TARGET Libxc::xcf03)
+            message(STATUS "Libxc version ${Libxc_VERSION} found via CMake lacks Fortran03 interface. Setting Libxc_FOUND to FALSE.")
+            set(Libxc_FOUND FALSE)
+        elseif (Libxc_VERSION VERSION_LESS 7)
+            if (NOT TARGET Libxc::xcf90)
+                message(STATUS "Libxc version ${Libxc_VERSION} found via CMake lacks Fortran90 interface. Setting Libxc_FOUND to FALSE.")
+                set(Libxc_FOUND FALSE)
+            endif()
+        endif()
+    endif()
+    if (Libxc_FOUND)
+        if (Libxc_VERSION VERSION_GREATER_EQUAL 7)
+            set(LIBXC_LIBRARIES Libxc::xcf03 Libxc::xc)
+        else()
+            set(LIBXC_LIBRARIES Libxc::xcf03 Libxc::xcf90 Libxc::xc)
+        endif()
         set(LIBXC_INCLUDE_DIRS ${Libxc_INCLUDE_DIRS})
     endif()
 endif()
 
 if (Libxc_FOUND)
     message(STATUS "Libxc version ${Libxc_VERSION}:")
-    if (${Libxc_VERSION} VERSION_GREATER_EQUAL 5 AND ${Libxc_VERSION} VERSION_LESS 7)
-        list(APPEND COMMON_LIBRARIES ${LIBXC_LIBRARIES})
-        message(STATUS "  Libxc libraries: ${LIBXC_LIBRARIES}")
-        list(APPEND COMMON_INCLUDE_DIRECTORIES ${LIBXC_INCLUDE_DIRS})
-        message(STATUS "  Libxc include directories: ${LIBXC_INCLUDE_DIRS}")
-    else()
-        message(STATUS "Only Libxc major versions 5 and 6 are supported. Setting Libxc_FOUND to FALSE.")
-        set(Libxc_FOUND FALSE)
-    endif()
+    list(APPEND COMMON_LIBRARIES ${LIBXC_LIBRARIES})
+    message(STATUS "  Libxc libraries: ${LIBXC_LIBRARIES}")
+    list(APPEND COMMON_INCLUDE_DIRECTORIES ${LIBXC_INCLUDE_DIRS})
+    message(STATUS "  Libxc include directories: ${LIBXC_INCLUDE_DIRS}")
 endif()
 
 ###########################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,11 @@ project(oncvpsp
     DESCRIPTION "Optimized norm-conserving Vanderbilt pseudopotentials"
     LANGUAGES Fortran C)
 
+###########################################################
+# Include CMake modules
+###########################################################
+include(cmake/CPM.cmake)
+
 ##########################################################
 # Build types
 ##########################################################
@@ -161,6 +166,15 @@ if (Libxc_FOUND)
     list(APPEND COMMON_INCLUDE_DIRECTORIES ${LIBXC_INCLUDE_DIRS})
     message(STATUS "  Libxc include directories: ${LIBXC_INCLUDE_DIRS}")
 endif()
+
+###########################################################
+# TOML-F (via CPM)
+###########################################################
+CPMAddPackage(
+    URI "gh:toml-f/toml-f@0.4.2"
+    OPTIONS "BUILD_TESTING=OFF"
+)
+list(APPEND COMMON_LIBRARIES toml-f-lib)
 
 ###########################################################
 # CMake Configuration

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,11 @@ set(COMMON_LIBRARIES "")
 set(COMMON_INCLUDE_DIRECTORIES "")
 
 ###########################################################
+# PkgConfig (used preferentially for Libxc)
+###########################################################
+find_package(PkgConfig)
+
+###########################################################
 # LAPACK
 ###########################################################
 find_package(LAPACK)
@@ -72,14 +77,41 @@ list(APPEND COMMON_LIBRARIES ${LAPACK_LIBRARIES})
 
 ###########################################################
 # LIBXC
+# Prefer using pkg-config
+# Otherwise, try using CMake's FindLibxc module
 ###########################################################
-find_package(Libxc COMPONENTS Fortran)
+include(CMakePrintHelpers)
+if ((PkgConfig_FOUND) AND (NOT DEFINED Libxc_ROOT))
+    pkg_check_modules(ONCVPSP_LIBXCF90 QUIET IMPORTED_TARGET libxcf90)
+    pkg_check_modules(ONCVPSP_LIBXCF03 QUIET IMPORTED_TARGET libxcf03)
+    if (ONCVPSP_LIBXCF03_FOUND AND ONCVPSP_LIBXCF90_FOUND)
+        message(STATUS "Found Libxc via pkg-config")
+        set(Libxc_FOUND TRUE)
+        set(Libxc_VERSION ${ONCVPSP_LIBXCF03_VERSION})
+        set(LIBXC_LIBRARIES PkgConfig::ONCVPSP_LIBXCF90 PkgConfig::ONCVPSP_LIBXCF03)
+        set(LIBXC_INCLUDE_DIRS ${ONCVPSP_LIBXCF03_INCLUDE_DIRS})
+    else()
+        message(STATUS "Libxc not found via pkg-config")
+        set(Libxc_FOUND FALSE)
+    endif()
+endif()
+
+if (NOT Libxc_FOUND)
+    find_package(Libxc COMPONENTS Fortran)
+    message(STATUS "Found Libxc via CMake's find_package")
+    if (Libxc_FOUND)
+        set(LIBXC_LIBRARIES Libxc::xcf90 Libxc::xcf03)
+        set(LIBXC_INCLUDE_DIRS ${Libxc_INCLUDE_DIRS})
+    endif()
+endif()
+
 if (Libxc_FOUND)
-    message(STATUS "Libxc version ${Libxc_VERSION} found.")
+    message(STATUS "Libxc version ${Libxc_VERSION}:")
     if (${Libxc_VERSION} VERSION_GREATER_EQUAL 5 AND ${Libxc_VERSION} VERSION_LESS 7)
-        set(LIBXC_LIBRARIES Libxc::xcf03)
         list(APPEND COMMON_LIBRARIES ${LIBXC_LIBRARIES})
         message(STATUS "  Libxc libraries: ${LIBXC_LIBRARIES}")
+        list(APPEND COMMON_INCLUDE_DIRECTORIES ${LIBXC_INCLUDE_DIRS})
+        message(STATUS "  Libxc include directories: ${LIBXC_INCLUDE_DIRS}")
     else()
         message(STATUS "Only Libxc major versions 5 and 6 are supported. Setting Libxc_FOUND to FALSE.")
         set(Libxc_FOUND FALSE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,13 +63,10 @@ set(COMMON_INCLUDE_DIRECTORIES "")
 ###########################################################
 # LAPACK
 ###########################################################
-find_package(LAPACK REQUIRED HINTS ${LAPACK_ROOT} ${BLAS_ROOT})
-if (LAPACK_FOUND)
-    message(STATUS "LAPACK found.")
-    message(STATUS "  LAPACK libraries: ${LAPACK_LIBRARIES}")
-    message(STATUS "  LAPACK linker flags: ${LAPACK_LINKER_FLAGS}")
-else ()
-    message(FATAL ERROR "Failed to find LAPACK.")
+find_package(LAPACK)
+if (NOT LAPACK_FOUND)
+    message(STATUS "LAPACK not found. Trying with hints.")
+    find_package(LAPACK REQUIRED HINTS ${LAPACK_ROOT})
 endif()
 list(APPEND COMMON_LIBRARIES ${LAPACK_LIBRARIES})
 

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: MIT
+#
+# SPDX-FileCopyrightText: Copyright (c) 2019-2023 Lars Melchior and contributors
+
+set(CPM_DOWNLOAD_VERSION 0.42.0)
+set(CPM_HASH_SUM "2020b4fc42dba44817983e06342e682ecfc3d2f484a581f11cc5731fbe4dce8a")
+
+if(CPM_SOURCE_CACHE)
+  set(CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+elseif(DEFINED ENV{CPM_SOURCE_CACHE})
+  set(CPM_DOWNLOAD_LOCATION "$ENV{CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+else()
+  set(CPM_DOWNLOAD_LOCATION "${CMAKE_BINARY_DIR}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+endif()
+
+# Expand relative path. This is important if the provided path contains a tilde (~)
+get_filename_component(CPM_DOWNLOAD_LOCATION ${CPM_DOWNLOAD_LOCATION} ABSOLUTE)
+
+file(DOWNLOAD
+     https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
+     ${CPM_DOWNLOAD_LOCATION} EXPECTED_HASH SHA256=${CPM_HASH_SUM}
+)
+
+include(${CPM_DOWNLOAD_LOCATION})

--- a/scripts/input_text_to_toml.py
+++ b/scripts/input_text_to_toml.py
@@ -1,0 +1,1017 @@
+#!/usr/bin/env python3
+# %%
+import argparse
+import logging
+import pathlib as pl
+import sys
+import typing as ty
+from dataclasses import dataclass
+
+import toml
+
+logging.basicConfig(level=logging.ERROR)
+
+ATOL: float = 1e-12
+
+
+def fort_float(s: str) -> float:
+    """Convert a Fortran-style float string to a Python float.
+
+    Args:
+        s: String to convert.
+
+    Returns:
+        Converted float.
+    """
+    return float(s.lower().replace("d", "e"))
+
+
+@dataclass
+class StateConfiguration:
+    """Configuration of an atomic state."""
+
+    "Principal quantum number"
+    n: int
+    "Angular quantum number"
+    l: int
+    "Occupation number"
+    f: float
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, StateConfiguration):
+            raise NotImplementedError(
+                f"Cannot compare StateConfiguration with {type(other)}"
+            )
+        if self.n != other.n:
+            logging.debug("n differs: %d != %d", self.n, other.n)
+            return False
+        if self.l != other.l:
+            logging.debug("l differs: %d != %d", self.l, other.l)
+            return False
+        if abs(self.f - other.f) >= ATOL:
+            logging.debug("f differs: %f != %f", self.f, other.f)
+            return False
+        return True
+
+    @classmethod
+    def from_str(cls, s: str) -> "StateConfiguration":
+        """Create a StateConfiguration from a string.
+
+        Args:
+            s: String in the format "n l f".
+
+        Returns:
+            StateConfiguration instance.
+        """
+        parts = s.split()
+        if len(parts) < 3:
+            raise ValueError(f"Invalid state configuration: {s}")
+        if len(parts) > 3:
+            logging.warning("Ignoring extra parts in state configuration: %s", s)
+        n, l, f = int(parts[0]), int(parts[1]), fort_float(parts[2])
+        return cls(n=n, l=l, f=f)
+
+    @classmethod
+    def to_str(cls, state: "StateConfiguration", with_comment: bool = False) -> str:
+        """Convert a StateConfiguration to a string.
+
+        Args:
+            state: StateConfiguration instance.
+
+        Returns:
+            String in the format "n l f".
+        """
+        s = f"{state.n:2d} {state.l:2d} {state.f:10.5f}"
+        if with_comment:
+            s = f"# {'n':>2} {'l':>2} {'f':>10}\n" + s
+        return s
+
+    def to_dict(self) -> dict[str, ty.Any]:
+        """Convert a StateConfiguration to a dictionary.
+
+        Returns:
+            Dictionary with keys "n", "l", and "f".
+        """
+        return {"n": self.n, "l": self.l, "f": self.f}
+
+
+@dataclass
+class PseudopotentialConfiguration:
+    """Configuration of a pseudopotential."""
+
+    "Angular momentum"
+    l: int
+    "Core radii"
+    rc: float
+    "Energy"
+    ep: float
+    "Number of matching constraints"
+    ncon: int
+    "Number of basis functions"
+    nbas: int
+    "Cutoff wavevectors"
+    qcut: float
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, PseudopotentialConfiguration):
+            raise NotImplementedError(
+                f"Cannot compare PseudopotentialConfiguration with {type(other)}"
+            )
+        if self.l != other.l:
+            logging.debug("l differs: %d != %d", self.l, other.l)
+            return False
+        if abs(self.rc - other.rc) >= ATOL:
+            logging.debug("rc differs: %f != %f", self.rc, other.rc)
+            return False
+        if abs(self.ep - other.ep) >= ATOL:
+            logging.debug("ep differs: %f != %f", self.ep, other.ep)
+            return False
+        if self.ncon != other.ncon:
+            logging.debug("ncon differs: %d != %d", self.ncon, other.ncon)
+            return False
+        if self.nbas != other.nbas:
+            logging.debug("nbas differs: %d != %d", self.nbas, other.nbas)
+            return False
+        if abs(self.qcut - other.qcut) >= ATOL:
+            logging.debug("qcut differs: %f != %f", self.qcut, other.qcut)
+            return False
+        return True
+
+    @classmethod
+    def from_str(cls, s: str) -> "PseudopotentialConfiguration":
+        """Create a PseudopotentialConfiguration from a string.
+
+        Args:
+            s: String in the format "l rc ep ncon nbas qcut"
+
+        Returns:
+            PseudopotentialConfiguration instance.
+        """
+        parts = s.split()
+        if len(parts) != 6:
+            raise ValueError(f"Invalid pseudopotential configuration: {s}")
+        l, rc, ep, ncon, nbas, qcut = (
+            int(parts[0]),
+            fort_float(parts[1]),
+            fort_float(parts[2]),
+            int(parts[3]),
+            int(parts[4]),
+            fort_float(parts[5]),
+        )
+        return cls(l=l, rc=rc, ep=ep, ncon=ncon, nbas=nbas, qcut=qcut)
+
+    @classmethod
+    def to_str(
+        cls, pp: "PseudopotentialConfiguration", with_comment: bool = False
+    ) -> str:
+        """Convert a PseudopotentialConfiguration to a string.
+
+        Args:
+            pp: PseudopotentialConfiguration instance.
+
+        Returns:
+            String in the format "l rc ep ncon nbas qcut".
+        """
+        s = f"{pp.l:2d} {pp.rc:10.5f} {pp.ep:10.5f} {pp.ncon:2d} {pp.nbas:2d} {pp.qcut:10.5f}"
+        if with_comment:
+            s = (
+                f"# {'l':>2} {'rc':>10} {'ep':>10} {'ncon':>2} {'nbas':>2} {'qcut':>10}\n"
+                + s
+            )
+        return s
+
+    def to_dict(self) -> dict[str, ty.Any]:
+        """Convert a PseudopotentialConfiguration to a dictionary.
+
+        Returns:
+            Dictionary with keys "l", "rc", "ep", "ncon", "nbas", and "qcut".
+        """
+        return {
+            "l": self.l,
+            "rc": self.rc,
+            "ep": self.ep,
+            "ncon": self.ncon,
+            "nbas": self.nbas,
+            "qcut": self.qcut,
+        }
+
+
+@dataclass
+class LocalPotentialConfiguration:
+    """Configuration of the local potential."""
+
+    "Local potential angular momentum"
+    lloc: int
+    "Local potential optimization level"
+    lpopt: int
+    "Local potential cutoff radius"
+    rcloc: float
+    "Local potential delta value"
+    dvloc0: float
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, LocalPotentialConfiguration):
+            raise NotImplementedError(
+                f"Cannot compare LocalPotentialConfiguration with {type(other)}"
+            )
+        if self.lloc != other.lloc:
+            logging.debug("lloc differs: %d != %d", self.lloc, other.lloc)
+            return False
+        if self.lpopt != other.lpopt:
+            logging.debug("lpopt differs: %d != %d", self.lpopt, other.lpopt)
+            return False
+        if abs(self.rcloc - other.rcloc) >= ATOL:
+            logging.debug("rcloc differs: %f != %f", self.rcloc, other.rcloc)
+            return False
+        if abs(self.dvloc0 - other.dvloc0) >= ATOL:
+            logging.debug("dvloc0 differs: %f != %f", self.dvloc0, other.dvloc0)
+            return False
+        return True
+
+    @classmethod
+    def from_str(cls, s: str) -> "LocalPotentialConfiguration":
+        """Create a LocalPotentialConfiguration from a string.
+
+        Args:
+            s: String in the format "lloc lpopt rcloc dvloc0"
+
+        Returns:
+            LocalPotentialConfiguration instance.
+        """
+        parts = s.split()
+        if len(parts) != 4:
+            raise ValueError(f"Invalid local potential configuration: {s}")
+        lloc, lpopt, rcloc, dvloc0 = (
+            int(parts[0]),
+            int(parts[1]),
+            fort_float(parts[2]),
+            fort_float(parts[3]),
+        )
+        return cls(lloc=lloc, lpopt=lpopt, rcloc=rcloc, dvloc0=dvloc0)
+
+
+@dataclass
+class KBProjectorConfiguration:
+    """Configuration of the Kleinman-Bylander projectors."""
+
+    "Angular momentum"
+    l: int
+    "Number of projectors"
+    nproj: int
+    "Energy shift for unbound states"
+    debl: float
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, KBProjectorConfiguration):
+            raise NotImplementedError(
+                f"Cannot compare KBProjectorConfiguration with {type(other)}"
+            )
+        if self.l != other.l:
+            logging.debug("l differs: %d != %d", self.l, other.l)
+            return False
+        if self.nproj != other.nproj:
+            logging.debug("nproj differs: %d != %d", self.nproj, other.nproj)
+            return False
+        if abs(self.debl - other.debl) >= ATOL:
+            logging.debug("debl differs: %f != %f", self.debl, other.debl)
+            return False
+        return True
+
+    @classmethod
+    def from_str(cls, s: str) -> "KBProjectorConfiguration":
+        """Create a KBProjectorConfiguration from a string.
+
+        Args:
+            s: String in the format "l nproj debl"
+
+        Returns:
+            KBProjectorConfiguration instance.
+        """
+        parts = s.split()
+        if len(parts) != 3:
+            raise ValueError(f"Invalid KB projector configuration: {s}")
+        l, nproj, debl = int(parts[0]), int(parts[1]), fort_float(parts[2])
+        return cls(l=l, nproj=nproj, debl=debl)
+
+
+@dataclass
+class ModelCoreChargeConfiguration:
+    """Configuration of the model core charge."""
+
+    "Model core charge type"
+    icmod: int
+    "Scaling factor for the model core charge"
+    fcfact: float | None = None
+    "Minimum scaling factor for the model core charge (for optimization)"
+    fcfact_min: float | None = None
+    "Maximum scaling factor for the model core charge (for optimization)"
+    fcfact_max: float | None = None
+    "Step size for the scaling factor for the model core charge (for optimization)"
+    fcfact_step: float | None = None
+    "Cutoff radius scaling factor"
+    rcfact: float | None = None
+    "Minimum cutoff radius scaling factor (for optimization)"
+    rcfact_min: float | None = None
+    "Maximum cutoff radius scaling factor (for optimization)"
+    rcfact_max: float | None = None
+    "Step size for the cutoff radius scaling factor (for optimization)"
+    rcfact_step: float | None = None
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, ModelCoreChargeConfiguration):
+            raise NotImplementedError(
+                f"Cannot compare ModelCoreChargeConfiguration with {type(other)}"
+            )
+        if self.icmod != other.icmod:
+            logging.debug("icmod differs: %d != %d", self.icmod, other.icmod)
+            return False
+        if (self.fcfact is None) != (other.fcfact is None):
+            logging.debug(
+                "fcfact presence differs: %s != %s", self.fcfact, other.fcfact
+            )
+            return False
+        elif self.fcfact is not None and other.fcfact is not None:
+            if abs(self.fcfact - other.fcfact) >= ATOL:
+                logging.debug("fcfact differs: %f != %f", self.fcfact, other.fcfact)
+                return False
+        if (self.fcfact_min is None) != (other.fcfact_min is None):
+            logging.debug(
+                "fcfact_min presence differs: %s != %s",
+                self.fcfact_min,
+                other.fcfact_min,
+            )
+            return False
+        elif self.fcfact_min is not None and other.fcfact_min is not None:
+            if abs(self.fcfact_min - other.fcfact_min) >= ATOL:
+                logging.debug(
+                    "fcfact_min differs: %f != %f", self.fcfact_min, other.fcfact_min
+                )
+                return False
+        if (self.fcfact_max is None) != (other.fcfact_max is None):
+            logging.debug(
+                "fcfact_max presence differs: %s != %s",
+                self.fcfact_max,
+                other.fcfact_max,
+            )
+            return False
+        elif self.fcfact_max is not None and other.fcfact_max is not None:
+            if abs(self.fcfact_max - other.fcfact_max) >= ATOL:
+                logging.debug(
+                    "fcfact_max differs: %f != %f", self.fcfact_max, other.fcfact_max
+                )
+                return False
+        if (self.fcfact_step is None) != (other.fcfact_step is None):
+            logging.debug(
+                "fcfact_step presence differs: %s != %s",
+                self.fcfact_step,
+                other.fcfact_step,
+            )
+            return False
+        elif self.fcfact_step is not None and other.fcfact_step is not None:
+            if abs(self.fcfact_step - other.fcfact_step) >= ATOL:
+                logging.debug(
+                    "fcfact_step differs: %f != %f", self.fcfact_step, other.fcfact_step
+                )
+                return False
+        if (self.rcfact is None) != (other.rcfact is None):
+            logging.debug(
+                "rcfact presence differs: %s != %s", self.rcfact, other.rcfact
+            )
+            return False
+        elif self.rcfact is not None and other.rcfact is not None:
+            if abs(self.rcfact - other.rcfact) >= ATOL:
+                logging.debug("rcfact differs: %f != %f", self.rcfact, other.rcfact)
+                return False
+        if (self.rcfact_min is None) != (other.rcfact_min is None):
+            logging.debug(
+                "rcfact_min presence differs: %s != %s",
+                self.rcfact_min,
+                other.rcfact_min,
+            )
+            return False
+        elif self.rcfact_min is not None and other.rcfact_min is not None:
+            if abs(self.rcfact_min - other.rcfact_min) >= ATOL:
+                logging.debug(
+                    "rcfact_min differs: %f != %f", self.rcfact_min, other.rcfact_min
+                )
+                return False
+        if (self.rcfact_max is None) != (other.rcfact_max is None):
+            logging.debug(
+                "rcfact_max presence differs: %s != %s",
+                self.rcfact_max,
+                other.rcfact_max,
+            )
+            return False
+        elif self.rcfact_max is not None and other.rcfact_max is not None:
+            if abs(self.rcfact_max - other.rcfact_max) >= ATOL:
+                logging.debug(
+                    "rcfact_max differs: %f != %f", self.rcfact_max, other.rcfact_max
+                )
+                return False
+        if (self.rcfact_step is None) != (other.rcfact_step is None):
+            logging.debug(
+                "rcfact_step presence differs: %s != %s",
+                self.rcfact_step,
+                other.rcfact_step,
+            )
+            return False
+        elif self.rcfact_step is not None and other.rcfact_step is not None:
+            if abs(self.rcfact_step - other.rcfact_step) >= ATOL:
+                logging.debug(
+                    "rcfact_step differs: %f != %f", self.rcfact_step, other.rcfact_step
+                )
+                return False
+        return True
+
+    @classmethod
+    def from_str(cls, s: str) -> "ModelCoreChargeConfiguration":
+        """Create a ModelCoreChargeConfiguration from a string.
+
+        Args:
+            s: String in the format
+               "icmod [fcfact [fcfact_min fcfact_max fcfact_step [rcfact [rcfact_min rcfact_max rcfact_step]]]]]"
+
+        Returns:
+            ModelCoreChargeConfiguration instance.
+        """
+        parts = s.split()
+        icmod = int(parts[0])
+        if icmod == 0:
+            return cls(icmod=icmod)
+        elif icmod == 1:
+            return cls(icmod=icmod, fcfact=fort_float(parts[1]))
+        elif icmod == 2:
+            return cls(
+                icmod=icmod,
+                fcfact=fort_float(parts[1]),
+            )
+        elif icmod == 3:
+            return cls(
+                icmod=icmod, fcfact=fort_float(parts[1]), rcfact=fort_float(parts[2])
+            )
+        elif icmod in (4, 5):
+            if len(parts) < 9:
+                return cls(icmod=icmod)
+            elif len(parts) == 9:
+                return cls(
+                    icmod=icmod,
+                    fcfact_min=fort_float(parts[2]),
+                    fcfact_max=fort_float(parts[3]),
+                    fcfact_step=fort_float(parts[4]),
+                    rcfact_min=fort_float(parts[6]),
+                    rcfact_max=fort_float(parts[7]),
+                    rcfact_step=fort_float(parts[8]),
+                )
+            else:
+                raise ValueError(f"Invalid model core charge configuration: {s}")
+        elif icmod == 6:
+            return cls(
+                icmod=icmod, rcfact=fort_float(parts[1]), fcfact=fort_float(parts[2])
+            )
+        else:
+            raise ValueError(f"Invalid model core charge configuration: {s}")
+
+
+@dataclass
+class LogDerivativeConfiguration:
+    """Configuration of the log-derivative grid."""
+
+    "Inner log-derivative boundary"
+    epsh1: float
+    "Outer log-derivative boundary"
+    epsh2: float
+    "Log-derivative step size"
+    depsh: float
+    "Exchange-correlation radius (if any)"
+    rxpsh: float | None = None
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, LogDerivativeConfiguration):
+            raise NotImplementedError(
+                f"Cannot compare LogDerivativeConfiguration with {type(other)}"
+            )
+        if (self.rxpsh is None) != (other.rxpsh is None):
+            logging.debug("rxpsh presence differs: %s != %s", self.rxpsh, other.rxpsh)
+            return False
+        if self.rxpsh is not None and other.rxpsh is not None:
+            if abs(self.rxpsh - other.rxpsh) >= ATOL:
+                logging.debug("rxpsh differs: %f != %f", self.rxpsh, other.rxpsh)
+                return False
+        if abs(self.epsh1 - other.epsh1) >= ATOL:
+            logging.debug("epsh1 differs: %f != %f", self.epsh1, other.epsh1)
+            return False
+        if abs(self.epsh2 - other.epsh2) >= ATOL:
+            logging.debug("epsh2 differs: %f != %f", self.epsh2, other.epsh2)
+            return False
+        if abs(self.depsh - other.depsh) >= ATOL:
+            logging.debug("depsh differs: %f != %f", self.depsh, other.depsh)
+            return False
+        return True
+
+    @classmethod
+    def from_str(cls, s: str) -> "LogDerivativeConfiguration":
+        """Create a LogDerivativeConfiguration from a string.
+
+        Args:
+            s: String in the format "epsh1 epsh2 depsh [rxpsh]"
+
+        Returns:
+            LogDerivativeConfiguration instance.
+        """
+        parts = s.split()
+        if len(parts) not in (3, 4):
+            raise ValueError(f"Invalid log-derivative configuration: {s}")
+        epsh1, epsh2, depsh = (
+            fort_float(parts[0]),
+            fort_float(parts[1]),
+            fort_float(parts[2]),
+        )
+        rxpsh = fort_float(parts[3]) if len(parts) == 4 else None
+        return cls(epsh1=epsh1, epsh2=epsh2, depsh=depsh, rxpsh=rxpsh)
+
+
+@dataclass
+class LinearMeshConfiguration:
+    """Configuration of the linear mesh for output."""
+
+    "Linear radial mesh step size"
+    drl: float
+    "Maximum radius for the linear mesh"
+    rlmax: float
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, LinearMeshConfiguration):
+            raise NotImplementedError(
+                f"Cannot compare LinearMeshConfiguration with {type(other)}"
+            )
+        if abs(self.drl - other.drl) >= ATOL:
+            logging.debug("drl differs: %f != %f", self.drl, other.drl)
+            return False
+        if abs(self.rlmax - other.rlmax) >= ATOL:
+            logging.debug("rlmax differs: %f != %f", self.rlmax, other.rlmax)
+            return False
+        return True
+
+    @classmethod
+    def from_str(cls, s: str) -> "LinearMeshConfiguration":
+        """Create a LinearMeshConfiguration from a string.
+
+        Args:
+            s: String in the format "drl rlmax"
+
+        Returns:
+            LinearMeshConfiguration instance.
+        """
+        parts = s.split()
+        if len(parts) != 2:
+            raise ValueError(f"Invalid linear mesh configuration: {s}")
+        rlmax, drl = fort_float(parts[0]), fort_float(parts[1])
+        return cls(drl=drl, rlmax=rlmax)
+
+
+@dataclass
+class OncvpspInput:
+    """Input parameters for ONCVPSP."""
+
+    atsym: str
+    zz: float
+    nc: int
+    nv: int
+    iexc: int
+    psfile: str
+    reference_configuration: list[StateConfiguration]
+    lmax: int
+    pseudopotentials: list[PseudopotentialConfiguration]
+    local_potential: LocalPotentialConfiguration
+    vkb_projectors: list[KBProjectorConfiguration]
+    model_core_charge: ModelCoreChargeConfiguration
+    log_derivative_analysis: LogDerivativeConfiguration
+    linear_mesh: LinearMeshConfiguration
+    test_configurations: list[list[StateConfiguration]]
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, OncvpspInput):
+            raise NotImplementedError(f"Cannot compare OncvpspInput with {type(other)}")
+        if self.atsym != other.atsym:
+            logging.debug("atsym differs: %s != %s", self.atsym, other.atsym)
+            return False
+        if abs(self.zz - other.zz) >= ATOL:
+            logging.debug("zz differs: %f != %f", self.zz, other.zz)
+            return False
+        if self.nc != other.nc:
+            logging.debug("nc differs: %d != %d", self.nc, other.nc)
+            return False
+        if self.nv != other.nv:
+            logging.debug("nv differs: %d != %d", self.nv, other.nv)
+            return False
+        if self.iexc != other.iexc:
+            logging.debug("iexc differs: %d != %d", self.iexc, other.iexc)
+            return False
+        if self.psfile != other.psfile:
+            logging.debug("psfile differs: %s != %s", self.psfile, other.psfile)
+            return False
+        if len(self.reference_configuration) != len(other.reference_configuration):
+            logging.debug(
+                "reference_configuration length differs: %d != %d",
+                len(self.reference_configuration),
+                len(other.reference_configuration),
+            )
+            return False
+        for i, (s1, s2) in enumerate(
+            zip(self.reference_configuration, other.reference_configuration)
+        ):
+            if s1 != s2:
+                logging.debug(
+                    "reference_configuration entry at index %d differs: %s != %s",
+                    i,
+                    s1,
+                    s2,
+                )
+                return False
+        if self.lmax != other.lmax:
+            logging.debug("lmax differs: %d != %d", self.lmax, other.lmax)
+            return False
+        if len(self.pseudopotentials) != len(other.pseudopotentials):
+            logging.debug(
+                "pseudopotentials length differs: %d != %d",
+                len(self.pseudopotentials),
+                len(other.pseudopotentials),
+            )
+            return False
+        for pp1, pp2 in zip(self.pseudopotentials, other.pseudopotentials):
+            if pp1 != pp2:
+                logging.debug("pseudopotentials entry differs: %s != %s", pp1, pp2)
+                return False
+        if self.local_potential != other.local_potential:
+            logging.debug(
+                "local_potential differs: %s != %s",
+                self.local_potential,
+                other.local_potential,
+            )
+            return False
+        if len(self.vkb_projectors) != len(other.vkb_projectors):
+            logging.debug(
+                "vkb_projectors length differs: %d != %d",
+                len(self.vkb_projectors),
+                len(other.vkb_projectors),
+            )
+            return False
+        for proj1, proj2 in zip(self.vkb_projectors, other.vkb_projectors):
+            if proj1 != proj2:
+                logging.debug("vkb_projectors entry differs: %s != %s", proj1, proj2)
+                return False
+        if self.model_core_charge != other.model_core_charge:
+            logging.debug(
+                "model_core_charge differs: %s != %s",
+                self.model_core_charge,
+                other.model_core_charge,
+            )
+            return False
+        if self.log_derivative_analysis != other.log_derivative_analysis:
+            logging.debug(
+                "log_derivative_analysis differs: %s != %s",
+                self.log_derivative_analysis,
+                other.log_derivative_analysis,
+            )
+            return False
+        if self.linear_mesh != other.linear_mesh:
+            logging.debug(
+                "linear_mesh differs: %s != %s",
+                self.linear_mesh,
+                other.linear_mesh,
+            )
+            return False
+        if len(self.test_configurations) != len(other.test_configurations):
+            logging.debug(
+                "test_configurations length differs: %d != %d",
+                len(self.test_configurations),
+                len(other.test_configurations),
+            )
+            return False
+        for cfg1, cfg2 in zip(self.test_configurations, other.test_configurations):
+            if len(cfg1) != len(cfg2):
+                logging.debug(
+                    "test_configurations entry length differs: %d != %d",
+                    len(cfg1),
+                    len(cfg2),
+                )
+                return False
+            for s1, s2 in zip(cfg1, cfg2):
+                if s1 != s2:
+                    logging.debug("test_configurations entry differs: %s != %s", s1, s2)
+                    return False
+        return True
+
+    @classmethod
+    def from_text_file(cls, file: ty.Any) -> "OncvpspInput":
+        """Create an OncvpspInput from a file-like object.
+
+        Args:
+            file: File-like object to read from.
+
+        Returns:
+            OncvpspInput instance.
+        """
+        if isinstance(file, (str, pl.Path)):
+            with open(file, "r", encoding="utf-8") as f:
+                return cls.from_lines(f.readlines())
+        else:
+            return cls.from_lines(file.readlines())
+
+    @classmethod
+    def from_str(cls, s: str) -> "OncvpspInput":
+        """Create an OncvpspInput from a string.
+
+        Args:
+            s: String to read from.
+
+        Returns:
+            OncvpspInput instance.
+        """
+        return cls.from_lines(s.splitlines())
+
+    @classmethod
+    def from_lines(cls, lines: list[str]) -> "OncvpspInput":
+        """Create an OncvpspInput from a list of lines.
+
+        Args:
+            lines: List of lines to read from.
+        Returns:
+            OncvpspInput instance.
+        """
+
+        def non_comment_lines(lines: list[str]) -> ty.Generator[str, None, None]:
+            for line in lines:
+                line = line.strip()
+                # Skip empty lines and full-line comments
+                if line and not line.startswith("#"):
+                    # Remove inline comments
+                    line = line.split("#", 1)[0].strip()
+                    yield line
+
+        lines = non_comment_lines(lines)
+
+        first_line = next(lines)
+        words = first_line.split()
+        atsym = words[0]
+        zz = fort_float(words[1])
+        nc = int(words[2])
+        nv = int(words[3])
+        iexc = int(words[4])
+        psfile = words[5]
+
+        reference_configuration = [
+            StateConfiguration.from_str(next(lines)) for _ in range(nc + nv)
+        ]
+
+        lmax = int(next(lines))
+
+        pseudopotentials = [
+            PseudopotentialConfiguration.from_str(next(lines)) for _ in range(lmax + 1)
+        ]
+
+        local_potential = LocalPotentialConfiguration.from_str(next(lines))
+
+        vkb_projectors = [
+            KBProjectorConfiguration.from_str(next(lines)) for _ in range(lmax + 1)
+        ]
+
+        model_core_charge = ModelCoreChargeConfiguration.from_str(next(lines))
+
+        log_derivative_analysis = LogDerivativeConfiguration.from_str(next(lines))
+
+        linear_mesh = LinearMeshConfiguration.from_str(next(lines))
+
+        ncnf = int(next(lines))
+        test_configurations = []
+        for _ in range(ncnf):
+            nvcnf = int(next(lines))
+            test_configurations.append(
+                [StateConfiguration.from_str(next(lines)) for _ in range(nvcnf)]
+            )
+
+        return cls(
+            atsym,
+            zz,
+            nc,
+            nv,
+            iexc,
+            psfile,
+            reference_configuration,
+            lmax,
+            pseudopotentials,
+            local_potential,
+            vkb_projectors,
+            model_core_charge,
+            log_derivative_analysis,
+            linear_mesh,
+            test_configurations,
+        )
+
+    @classmethod
+    def from_dict(cls, d: dict[str, ty.Any]) -> "OncvpspInput":
+        """Create an OncvpspInput from a dictionary.
+
+        Args:
+            d: Dictionary to read from.
+
+        Returns:
+            OncvpspInput instance.
+        """
+        return cls(
+            atsym=d["oncvpsp"]["atsym"],
+            zz=d["oncvpsp"]["z"],
+            nc=d["oncvpsp"]["nc"],
+            nv=d["oncvpsp"]["nv"],
+            iexc=d["oncvpsp"]["iexc"],
+            psfile=d["pp_output"]["psfile"],
+            reference_configuration=[
+                StateConfiguration(n=s[0], l=s[1], f=s[2])
+                for s in zip(
+                    d["reference_configuration"]["n"],
+                    d["reference_configuration"]["l"],
+                    d["reference_configuration"]["f"],
+                )
+            ],
+            lmax=d["pseudopotentials"]["lmax"],
+            pseudopotentials=[
+                PseudopotentialConfiguration(pp[0], pp[1], pp[2], pp[3], pp[4], pp[5])
+                for pp in zip(
+                    d["pseudopotentials"]["l"],
+                    d["pseudopotentials"]["rc"],
+                    d["pseudopotentials"]["ep"],
+                    d["pseudopotentials"]["ncon"],
+                    d["pseudopotentials"]["nbas"],
+                    d["pseudopotentials"]["qcut"],
+                )
+            ],
+            local_potential=LocalPotentialConfiguration(
+                lloc=d["local_potential"]["lloc"],
+                lpopt=d["local_potential"]["lpopt"],
+                rcloc=d["local_potential"]["rcloc"],
+                dvloc0=d["local_potential"]["dvloc0"],
+            ),
+            vkb_projectors=[
+                KBProjectorConfiguration(proj[0], proj[1], proj[2])
+                for proj in zip(
+                    d["vkb_projectors"]["l"],
+                    d["vkb_projectors"]["nproj"],
+                    d["vkb_projectors"]["debl"],
+                )
+            ],
+            model_core_charge=ModelCoreChargeConfiguration(
+                icmod=d["model_core_charge"]["icmod"],
+                fcfact=d["model_core_charge"].get("fcfact"),
+                fcfact_min=d["model_core_charge"].get("fcfact_min"),
+                fcfact_max=d["model_core_charge"].get("fcfact_max"),
+                fcfact_step=d["model_core_charge"].get("fcfact_step"),
+                rcfact=d["model_core_charge"].get("rcfact"),
+                rcfact_min=d["model_core_charge"].get("rcfact_min"),
+                rcfact_max=d["model_core_charge"].get("rcfact_max"),
+                rcfact_step=d["model_core_charge"].get("rcfact_step"),
+            ),
+            log_derivative_analysis=LogDerivativeConfiguration(
+                epsh1=d["log_derivative_analysis"]["epsh1"],
+                epsh2=d["log_derivative_analysis"]["epsh2"],
+                depsh=d["log_derivative_analysis"]["depsh"],
+                rxpsh=d["log_derivative_analysis"].get("rxpsh"),
+            ),
+            linear_mesh=LinearMeshConfiguration(
+                drl=d["linear_mesh"]["a"],
+                rlmax=d["linear_mesh"]["rmax"],
+            ),
+            test_configurations=[
+                [
+                    StateConfiguration(n=s[0], l=s[1], f=s[2])
+                    for s in zip(cfg["n"], cfg["l"], cfg["f"])
+                ]
+                for cfg in d["test_configurations"]
+            ],
+        )
+
+    def to_dict(self) -> dict[str, ty.Any]:
+        """Convert an OncvpspInput to a dictionary in the style of the TOML input.
+
+        Returns:
+            Dictionary representation of the OncvpspInput.
+        """
+        return {
+            "oncvpsp": {
+                "atsym": self.atsym,
+                "z": self.zz,
+                "nc": self.nc,
+                "nv": self.nv,
+                "iexc": self.iexc,
+            },
+            "linear_mesh": {
+                "a": self.linear_mesh.drl,
+                "rmax": self.linear_mesh.rlmax,
+            },
+            "reference_configuration": {
+                "n": [s.n for s in self.reference_configuration],
+                "l": [s.l for s in self.reference_configuration],
+                "f": [s.f for s in self.reference_configuration],
+            },
+            "pseudopotentials": {
+                "lmax": self.lmax,
+                "l": [pp.l for pp in self.pseudopotentials],
+                "rc": [pp.rc for pp in self.pseudopotentials],
+                "ep": [pp.ep for pp in self.pseudopotentials],
+                "ncon": [pp.ncon for pp in self.pseudopotentials],
+                "nbas": [pp.nbas for pp in self.pseudopotentials],
+                "qcut": [pp.qcut for pp in self.pseudopotentials],
+            },
+            "local_potential": {
+                "lloc": self.local_potential.lloc,
+                "lpopt": self.local_potential.lpopt,
+                "rcloc": self.local_potential.rcloc,
+                "dvloc0": self.local_potential.dvloc0,
+            },
+            "vkb_projectors": {
+                "l": [proj.l for proj in self.vkb_projectors],
+                "nproj": [proj.nproj for proj in self.vkb_projectors],
+                "debl": [proj.debl for proj in self.vkb_projectors],
+            },
+            "model_core_charge": {
+                "icmod": self.model_core_charge.icmod,
+                "fcfact": self.model_core_charge.fcfact,
+                "fcfact_min": self.model_core_charge.fcfact_min,
+                "fcfact_max": self.model_core_charge.fcfact_max,
+                "fcfact_step": self.model_core_charge.fcfact_step,
+                "rcfact": self.model_core_charge.rcfact,
+                "rcfact_min": self.model_core_charge.rcfact_min,
+                "rcfact_max": self.model_core_charge.rcfact_max,
+                "rcfact_step": self.model_core_charge.rcfact_step,
+            },
+            "log_derivative_analysis": {
+                "epsh1": self.log_derivative_analysis.epsh1,
+                "epsh2": self.log_derivative_analysis.epsh2,
+                "depsh": self.log_derivative_analysis.depsh,
+                "rxpsh": self.log_derivative_analysis.rxpsh,
+            },
+            "pp_output": {
+                "psfile": self.psfile,
+            },
+            "test_configurations": [
+                {
+                    "n": [s.n for s in cfg],
+                    "l": [s.l for s in cfg],
+                    "f": [s.f for s in cfg],
+                }
+                for cfg in self.test_configurations
+            ],
+        }
+
+
+# %%
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Convert ONCVPSP input file to TOML format."
+    )
+    parser.add_argument(
+        "-i",
+        "--input",
+        type=str,
+        required=True,
+        help="Input ONCVPSP text file (default: stdin)",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=str,
+        default=None,
+        help="Output TOML file (default: stdout)",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Check conversion by performing a round-trip",
+    )
+    args = parser.parse_args()
+
+    input_path = pl.Path(args.input)
+    if not input_path.is_file():
+        print(f"Error: Input file '{input_path}' does not exist.", file=sys.stderr)
+        sys.exit(1)
+
+    oncvpsp_input = OncvpspInput.from_text_file(input_path)
+    toml_dict = oncvpsp_input.to_dict()
+    toml_str = toml.dumps(toml_dict)
+
+    if args.output:
+        output_path = pl.Path(args.output)
+        with open(output_path, "w", encoding="utf-8") as f:
+            f.write(toml_str)
+    else:
+        print(toml_str)
+
+    if args.check:
+        toml_dict_loaded = toml.loads(toml_str)
+        oncvpsp_input_loaded = OncvpspInput.from_dict(toml_dict_loaded)
+        if oncvpsp_input != oncvpsp_input_loaded:
+            print("Error: Round-trip conversion check failed.", file=sys.stderr)
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,6 +49,8 @@ set(src_liboncvpsp
     vploc.f90
     vrel.f90
     wf_rc_der.f90
+    input_text_m.f90
+    input_toml_m.f90
 )
 if (Libxc_FOUND)
     list(APPEND src_liboncvpsp functionals.F90 exc_libxc.f90)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,12 +50,15 @@ set(src_liboncvpsp
     vrel.f90
     wf_rc_der.f90
     input_text_m.f90
-    input_toml_m.f90
 )
 if (Libxc_FOUND)
     list(APPEND src_liboncvpsp functionals.F90 exc_libxc.f90)
 else ()
     list(APPEND src_liboncvpsp exc_libxc_stub.f90)
+endif ()
+if (WITH_TOML)
+    add_compile_definitions(WITH_TOML)
+    list(APPEND src_liboncvpsp input_toml_m.f90)
 endif ()
 add_library(liboncvpsp STATIC ${src_liboncvpsp})
 add_dependencies(liboncvpsp wxml)
@@ -112,7 +115,7 @@ target_link_libraries(liboncvpsp_r liboncvpsp wxml ${COMMON_LIBRARIES})
 ###########################################################
 # oncvpsp.x
 ###########################################################
-add_executable(oncvpsp oncvpsp.f90)
+add_executable(oncvpsp oncvpsp.F90)
 add_dependencies(oncvpsp liboncvpsp_nr_sr)
 target_link_libraries(oncvpsp liboncvpsp_nr_sr)
 set_target_properties(oncvpsp
@@ -123,7 +126,7 @@ set_target_properties(oncvpsp
 ##########################################################
 # oncvpspnr.x
 ##########################################################
-add_executable(oncvpspnr oncvpsp_nr.f90)
+add_executable(oncvpspnr oncvpsp_nr.F90)
 add_dependencies(oncvpspnr liboncvpsp_nr_sr)
 target_link_libraries(oncvpspnr liboncvpsp_nr_sr)
 set_target_properties(oncvpspnr
@@ -134,7 +137,7 @@ set_target_properties(oncvpspnr
 ##########################################################
 # oncvpspr.x
 ##########################################################
-add_executable(oncvpspr oncvpsp_r.f90)
+add_executable(oncvpspr oncvpsp_r.F90)
 add_dependencies(oncvpspr liboncvpsp_r)
 target_link_libraries(oncvpspr liboncvpsp_r)
 set_target_properties(oncvpspr

--- a/src/input_text_m.f90
+++ b/src/input_text_m.f90
@@ -1,0 +1,502 @@
+module input_text_m
+   use, intrinsic :: iso_fortran_env, only: dp => real64, stdout => output_unit, stderr => error_unit
+   implicit none
+   private
+   public :: read_input_text, read_input_text_r
+contains
+
+   subroutine read_input_text(unit, inline, &
+                              atsym, zz, nc, nv, iexc, psfile, na, la, fa, &
+                              lmax, rc, ep, ncon, nbas, qcut, &
+                              lloc, lpopt, dvloc0, nproj, debl, &
+                              icmod, fcfact, rcfact, &
+                              fcfact_min, fcfact_max, fcfact_step, &
+                              rcfact_min, rcfact_max, rcfact_step, &
+                              epsh1, epsh2, depsh, rxpsh, &
+                              rlmax, drl, &
+                              ncnf, nvcnf, nacnf, lacnf, facnf)
+      !> File unit number for input
+      integer, intent(in) :: unit
+      !> Current line number in input file
+      integer, intent(out) :: inline
+      ! [Atom and reference configuration]
+      !> Atomic symbol
+      character(len=2), intent(out) :: atsym
+      !> Atomic number
+      real(dp), intent(out) :: zz
+      !> Number of core electrons
+      integer, intent(out) :: nc
+      !> Number of valence electrons
+      integer, intent(out) :: nv
+      !> Exchange-correlation functional code
+      integer, intent(out) :: iexc
+      !> Pseudopotential output file format flag
+      character(len=4), intent(out) :: psfile
+      !> Principal quantum number array
+      integer, intent(out) :: na(30)
+      !> Orbital angular momentum quantum number array
+      integer, intent(out) :: la(30)
+      !> Occupation number array
+      real(dp), intent(out) :: fa(30)
+      ! [Pseudopotential and optimization]
+      !> Maximum angular momentum
+      integer, intent(out) :: lmax
+      !> Core radii for pseudopotentials
+      real(dp), intent(out) :: rc(6)
+      !> Pseudopotential energies
+      real(dp), intent(out) :: ep(6)
+      !> Number of matching constraints for each pseudopotential
+      integer, intent(out) :: ncon(6)
+      !> Number of basis functions for each pseudopotential
+      integer, intent(out) :: nbas(6)
+      !> Maximum wave number for each pseudopotential
+      real(dp), intent(out) :: qcut(6)
+      ! [Local potential]
+      !> Angular momentum used for local potential
+      integer, intent(out) :: lloc
+      !>
+      integer, intent(out) :: lpopt
+      !> Local potential offset at origin
+      real(dp), intent(out) :: dvloc0
+      ! [Vanderbilt-Kleinman-Bylander projectors]
+      !> Number of projectors for each angular momentum
+      integer, intent(out) :: nproj(6)
+      !> Energy shift for unbound states
+      real(dp), intent(out) :: debl(6)
+      ! [Model core charge]
+      !> Model core charge flag
+      integer, intent(out) :: icmod
+      !> Scaling factor for core charge
+      real(dp), intent(out) :: fcfact
+      !> Scaling factor range minimum for optimization
+      real(dp), intent(out) :: fcfact_min
+      !> Scaling factor range maximum for optimization
+      real(dp), intent(out) :: fcfact_max
+      !> Scaling factor step size for optimization
+      real(dp), intent(out) :: fcfact_step
+      !> Core charge width factor
+      real(dp), intent(out) :: rcfact
+      !> Core charge width factor minimum for optimization
+      real(dp), intent(out) :: rcfact_min
+      !> Core charge width factor maximum for optimization
+      real(dp), intent(out) :: rcfact_max
+      !> Core charge width factor step size for optimization
+      real(dp), intent(out) :: rcfact_step
+      ! [Log derivative analysis]
+      !> Lower bound of energy range for log derivative analysis
+      real(dp), intent(out) :: epsh1
+      !> Upper bound of energy range for log derivative analysis
+      real(dp), intent(out) :: epsh2
+      !> Energy step size for log derivative analysis
+      real(dp), intent(out) :: depsh
+      !> Radius for log derivative analysis
+      real(dp), intent(out) :: rxpsh
+      ! [Output grid]
+      !> Maximum radius for output grid
+      real(dp), intent(out) :: rlmax
+      !> Grid spacing for output grid
+      real(dp), intent(out) :: drl
+      ! [Test configurations]
+      !> Number of test configurations
+      integer, intent(out) :: ncnf
+      !> Number of valence states in test configurations
+      integer, intent(out) :: nvcnf(5)
+      !> Principal quantum number array for test configurations
+      integer, intent(out) :: nacnf(30, 5)
+      !> Orbital angular momentum quantum number array for test configurations
+      integer, intent(out) :: lacnf(30, 5)
+      !> Occupation number array for test configurations
+      real(dp), intent(out) :: facnf(30, 5)
+
+      !Local variables
+      !> I/O status variable
+      integer :: ios
+      !> Loop indices
+      integer :: ii, jj
+      !> Angular momentum index (l+1)
+      integer :: l1
+      !> Temporary variable for reading angular momentum
+      integer :: lt
+      !> Temporary line string for reading model core charge, log derivative analysis parameters
+      character(len=2048) :: line
+
+      nproj(:) = 0
+      fcfact = 0.d0
+      rcfact = 0.d0
+      rc(:) = 0.d0
+      ep(:) = 0.d0
+      rxpsh = -1.d0  ! negative value for auto setting of radius
+      ! default values for icmod=4 optimization ranges
+      ! overriden by input values if icmod=5
+      fcfact_min = 1.5d0
+      fcfact_max = 6.0d0
+      fcfact_step = 0.5d0
+      rcfact_min = 1.0d0
+      rcfact_max = 1.9d0
+      rcfact_step = 0.1d0
+
+      ! read input data
+      inline = 0
+
+      ! atom and reference configuration
+      call cmtskp(unit, inline)
+      read (unit, *, iostat=ios) atsym, zz, nc, nv, iexc, psfile
+      call read_error(ios, inline)
+
+      call cmtskp(unit, inline)
+      do ii = 1, nc + nv
+         read (unit, *, iostat=ios) na(ii), la(ii), fa(ii)
+         call read_error(ios, inline)
+      end do
+
+      ! pseudopotential and optimization
+      call cmtskp(unit, inline)
+      read (unit, *, iostat=ios) lmax
+      call read_error(ios, inline)
+
+      call cmtskp(unit, inline)
+      do l1 = 1, lmax + 1
+         read (unit, *, iostat=ios) lt, rc(l1), ep(l1), ncon(l1), nbas(l1), qcut(l1)
+         if (lt /= l1 - 1) ios = 999
+         call read_error(ios, inline)
+      end do
+
+      ! local potential
+      call cmtskp(unit, inline)
+      read (unit, *, iostat=ios) lloc, lpopt, rc(5), dvloc0
+      call read_error(ios, inline)
+
+      ! Vanderbilt-Kleinman-Bylander projectors
+      call cmtskp(unit, inline)
+      do l1 = 1, lmax + 1
+         read (unit, *, iostat=ios) lt, nproj(l1), debl(l1)
+         if (lt /= l1 - 1) ios = 999
+         call read_error(ios, inline)
+      end do
+
+      ! model core charge
+      call cmtskp(unit, inline)
+      read (unit, '(a)', iostat=ios) line
+      ! icmod=0,1,2,4[default grid] : icmod, fcfact
+      read (line, *, iostat=ios) icmod, fcfact
+      ! icmod==3 : icmod, fcfact, rcfact
+      if (ios == 0 .and. icmod == 3) then
+         read (line, *, iostat=ios) icmod, fcfact, rcfact
+      end if
+      ! icmod==4[explicit grid]: icmod, fcfact(ignored), rcfact(ignored),
+      !   fcfact_min, fcfact_max, fcfact_step,
+      !   rcfact_min, rcfact_max, rcfact_step
+      if (ios == 0 .and. icmod >= 4) then
+         read (line, *, iostat=ios) icmod, fcfact, rcfact, &
+            fcfact_min, fcfact_max, fcfact_step, &
+            rcfact_min, rcfact_max, rcfact_step
+         ! icmod==4[implicit grid]: *_min, *_max, *_step not provided, fall back to defaults
+         if (ios /= 0) then
+            read (line, *, iostat=ios) icmod, fcfact
+            rcfact = 0.d0
+            fcfact_min = 1.5d0
+            fcfact_max = 6.0d0
+            fcfact_step = 0.5d0
+            rcfact_min = 1.0d0
+            rcfact_max = 1.9d0
+            rcfact_step = 0.1d0
+         end if
+      end if
+      call read_error(ios, inline)
+
+      ! log derivative analysis
+      call cmtskp(unit, inline)
+      read (unit, '(a)', iostat=ios) line
+      read (line, *, iostat=ios) epsh1, epsh2, depsh, rxpsh
+      if (ios /= 0) then
+         read (line, *, iostat=ios) epsh1, epsh2, depsh
+         rxpsh = -1.d0  ! negative value for auto setting of radius
+      end if
+      call read_error(ios, inline)
+
+      ! output grid
+      call cmtskp(unit, inline)
+      read (unit, *, iostat=ios) rlmax, drl
+      call read_error(ios, inline)
+
+      ! test configurations
+      call cmtskp(unit, inline)
+      read (unit, *, iostat=ios) ncnf
+      call read_error(ios, inline)
+
+      do jj = 2, ncnf + 1
+         call cmtskp(unit, inline)
+         read (unit, *, iostat=ios) nvcnf(jj)
+         call read_error(ios, inline)
+         do ii = nc + 1, nc + nvcnf(jj)
+            call cmtskp(unit, inline)
+            read (unit, *, iostat=ios) nacnf(ii, jj), lacnf(ii, jj), facnf(ii, jj)
+            call read_error(ios, inline)
+         end do
+      end do
+
+      ! end of reading input data
+   end subroutine read_input_text
+
+   subroutine read_input_text_r(unit, inline, &
+                                atsym, zz, nc, nv, iexc, psfile, na, la, fa, &
+                                lmax, rc, ep, ncon, nbas, qcut, &
+                                lloc, lpopt, dvloc0, nproj, debl, &
+                                icmod, fcfact, rcfact, fcfact_min, fcfact_max, fcfact_step, &
+                                rcfact_min, rcfact_max, rcfact_step, &
+                                epsh1, epsh2, depsh, rxpsh, &
+                                rlmax, drl, &
+                                ncnf, nvcnf, nacnf, lacnf, facnf)
+      !> File unit number for input
+      integer, intent(in) :: unit
+      !> Current line number in input file
+      integer, intent(out) :: inline
+      !> Atomic symbol
+      character(len=2), intent(out) :: atsym
+      !> Atomic number
+      real(dp), intent(out) :: zz
+      !> Number of core electrons
+      integer, intent(out) :: nc
+      !> Number of valence electrons
+      integer, intent(out) :: nv
+      !> Exchange-correlation functional code
+      integer, intent(out) :: iexc
+      !> Pseudopotential output file format flag
+      character(len=4), intent(out) :: psfile
+      !> Principal quantum number array
+      integer, intent(out) :: na(30)
+      !> Orbital angular momentum quantum number array
+      integer, intent(out) :: la(30)
+      !> Occupation number array
+      real(dp), intent(out) :: fa(30)
+      !> Maximum angular momentum
+      integer, intent(out) :: lmax
+      !> Pseudopotential cutoff radii
+      real(dp), intent(out) :: rc(6)
+      !> Pseudopotential energies
+      real(dp), intent(out) :: ep(6, 2)
+      !> Number of matching constraints for each pseudopotential
+      integer, intent(out) :: ncon(6)
+      !> Number of basis functions for each pseudopotential
+      integer, intent(out) :: nbas(6)
+      !> Maximum wave number for each pseudopotential
+      real(dp), intent(out) :: qcut(6)
+      !> Angular momentum used for local potential
+      integer, intent(out) :: lloc
+      !>
+      integer, intent(out) :: lpopt
+      !> Local potential offset at origin
+      real(dp), intent(out) :: dvloc0
+      !> Number of projectors for each angular momentum
+      integer, intent(out) :: nproj(6)
+      !> Energy shift for unbound states
+      real(dp), intent(out) :: debl(6)
+      !> Model core charge flag
+      integer, intent(out) :: icmod
+      !> Scaling factor for core charge
+      real(dp), intent(out) :: fcfact
+      !> Scaling factor range minimum for optimization
+      real(dp), intent(out) :: fcfact_min
+      !> Scaling factor range maximum for optimization
+      real(dp), intent(out) :: fcfact_max
+      !> Scaling factor step size for optimization
+      real(dp), intent(out) :: fcfact_step
+      !> Core charge width factor
+      real(dp), intent(out) :: rcfact
+      !> Core charge width factor minimum for optimization
+      real(dp), intent(out) :: rcfact_min
+      !> Core charge width factor maximum for optimization
+      real(dp), intent(out) :: rcfact_max
+      !> Core charge width factor step size for optimization
+      real(dp), intent(out) :: rcfact_step
+      !> Lower bound of energy range for log derivative analysis
+      real(dp), intent(out) :: epsh1
+      !> Upper bound of energy range for log derivative analysis
+      real(dp), intent(out) :: epsh2
+      !> Energy step size for log derivative analysis
+      real(dp), intent(out) :: depsh
+      !> Radius for log derivative analysis
+      real(dp), intent(out) :: rxpsh
+      !> Maximum radius for output grid
+      real(dp), intent(out) :: rlmax
+      !> Grid spacing for output grid
+      real(dp), intent(out) :: drl
+      !> Number of test configurations
+      integer, intent(out) :: ncnf
+      !> Number of valence states in test configurations
+      integer, intent(out) :: nvcnf(5)
+      !> Principal quantum number array for test configurations
+      integer, intent(out) :: nacnf(30, 5)
+      !> Orbital angular momentum quantum number array for test configurations
+      integer, intent(out) :: lacnf(30, 5)
+      !> Occupation number array for test configurations
+      real(dp), intent(out) :: facnf(30, 5)
+
+      !Local variables
+      !> I/O status variable
+      integer :: ios
+      !> Loop indices
+      integer :: ii, jj
+      !> Angular momentum index (l+1)
+      integer :: l1
+      !> Temporary variable for reading angular momentum
+      integer :: lt
+      !> Temporary line string for reading log derivative analysis
+      character(len=1024) :: line
+
+      nproj(:) = 0
+      fcfact = 0.d0
+      rcfact = 0.d0
+      rc(:) = 0.d0
+      ep(:, :) = 0.d0
+      rxpsh = -1.d0  ! negative value for auto setting of radius
+      ! default values for icmod=4 optimization ranges
+      fcfact_min = 1.5d0
+      fcfact_max = 6.0d0
+      fcfact_step = 0.5d0
+      rcfact_min = 1.0d0
+      rcfact_max = 1.9d0
+      rcfact_step = 0.1d0
+
+      ! read input data
+      inline = 0
+
+      ! atom and reference configuration
+      call cmtskp(unit, inline)
+      read (unit, *, iostat=ios) atsym, zz, nc, nv, iexc, psfile
+      call read_error(ios, inline)
+
+      call cmtskp(unit, inline)
+      do ii = 1, nc + nv
+         read (unit, *, iostat=ios) na(ii), la(ii), fa(ii)
+         call read_error(ios, inline)
+      end do
+
+      ! pseudopotential and optimization
+      call cmtskp(unit, inline)
+      read (unit, *, iostat=ios) lmax
+      call read_error(ios, inline)
+
+      call cmtskp(unit, inline)
+      do l1 = 1, lmax + 1
+         read (unit, *, iostat=ios) lt, rc(l1), ep(l1, 1), ncon(l1), nbas(l1), qcut(l1)
+         if (lt /= l1 - 1) ios = 999
+         call read_error(ios, inline)
+         ep(l1, 2) = ep(l1, 1)
+      end do
+
+      ! local potential
+      call cmtskp(unit, inline)
+      read (unit, *, iostat=ios) lloc, lpopt, rc(5), dvloc0
+      call read_error(ios, inline)
+
+      ! Vanderbilt-Kleinman-Bylander projectors
+      call cmtskp(unit, inline)
+      do l1 = 1, lmax + 1
+         read (unit, *, iostat=ios) lt, nproj(l1), debl(l1)
+         if (lt /= l1 - 1) ios = 999
+         call read_error(ios, inline)
+      end do
+
+      ! model core charge
+      call cmtskp(unit, inline)
+      read (unit, '(a)', iostat=ios) line
+      ! icmod=0,1,2,4[default grid] : icmod, fcfact
+      read (line, *, iostat=ios) icmod, fcfact
+      ! icmod==3 : icmod, fcfact, rcfact
+      if (ios == 0 .and. icmod == 3) then
+         read (line, *, iostat=ios) icmod, fcfact, rcfact
+      end if
+      ! icmod==4[explicit grid]: icmod, fcfact(ignored), rcfact(ignored),
+      !   fcfact_min, fcfact_max, fcfact_step,
+      !   rcfact_min, rcfact_max, rcfact_step
+      if (ios == 0 .and. icmod >= 4) then
+         read (line, *, iostat=ios) icmod, fcfact, rcfact, &
+            fcfact_min, fcfact_max, fcfact_step, &
+            rcfact_min, rcfact_max, rcfact_step
+         ! icmod==4[implicit grid]: *_min, *_max, *_step not provided, fall back to defaults
+         if (ios /= 0) then
+            read (line, *, iostat=ios) icmod, fcfact
+            rcfact = 0.d0
+            fcfact_min = 1.5d0
+            fcfact_max = 6.0d0
+            fcfact_step = 0.5d0
+            rcfact_min = 1.0d0
+            rcfact_max = 1.9d0
+            rcfact_step = 0.1d0
+         end if
+      end if
+      call read_error(ios, inline)
+
+      ! log derivative analysis
+      call cmtskp(unit, inline)
+      read (unit, '(a)', iostat=ios) line
+      read (line, *, iostat=ios) epsh1, epsh2, depsh, rxpsh
+      if (ios /= 0) then
+         read (line, *, iostat=ios) epsh1, epsh2, depsh
+         rxpsh = -1.d0  ! negative value for auto setting of radius
+      end if
+      call read_error(ios, inline)
+
+      ! output grid
+      call cmtskp(unit, inline)
+      read (unit, *, iostat=ios) rlmax, drl
+      call read_error(ios, inline)
+
+      ! test configurations
+      call cmtskp(unit, inline)
+      read (unit, *, iostat=ios) ncnf
+      call read_error(ios, inline)
+
+      do jj = 2, ncnf + 1
+         call cmtskp(unit, inline)
+         read (unit, *, iostat=ios) nvcnf(jj)
+         call read_error(ios, inline)
+         do ii = nc + 1, nc + nvcnf(jj)
+            call cmtskp(unit, inline)
+            read (unit, *, iostat=ios) nacnf(ii, jj), lacnf(ii, jj), facnf(ii, jj)
+            call read_error(ios, inline)
+         end do
+      end do
+
+      ! end of reading input data
+   end subroutine read_input_text_r
+
+   subroutine cmtskp(unit, inline)
+      ! skips lines of standard input (file 5) whose first character is #
+
+      !In/Out variable
+      integer :: inline
+      integer, intent(in) :: unit
+
+      !Local variable
+      character(len=1) :: tst
+
+      tst = '#'
+      do while (tst == '#')
+         read (unit, *) tst
+         inline = inline + 1
+      end do
+      backspace (unit)
+      inline = inline - 1
+
+      return
+   end subroutine cmtskp
+
+   subroutine read_error(ios, inline)
+      ! report data read error and stop
+
+      !Input variables
+      integer :: ios, inline
+
+      inline = inline + 1
+      if (ios /= 0) then
+         write (6, '(a,i4)') 'Read ERROR, input data file line', inline
+         write (6, '(a)') 'Program will stop'
+         stop
+      end if
+
+      return
+   end subroutine read_error
+
+end module input_text_m

--- a/src/input_toml_m.f90
+++ b/src/input_toml_m.f90
@@ -1,0 +1,816 @@
+module input_toml_m
+   use, intrinsic :: iso_fortran_env, only: dp => real64, stdout => output_unit, stderr => error_unit
+   use tomlf  ! TOML Fortran library: documentation at toml-f.readthedocs.io
+   implicit none
+   private
+   public :: read_input_toml, read_input_toml_r
+
+   interface check_associated
+      module procedure toml_table_check_associated
+      module procedure toml_array_check_associated
+   end interface check_associated
+   contains
+
+   subroutine read_input_toml(unit, &
+                              atsym, zz, nc, nv, iexc, psfile, na, la, fa, &
+                              lmax, rc, ep, ncon, nbas, qcut, &
+                              lloc, lpopt, dvloc0, nproj, debl, &
+                              icmod, fcfact, rcfact, &
+                              fcfact_min, fcfact_max, fcfact_step, &
+                              rcfact_min, rcfact_max, rcfact_step, &
+                              epsh1, epsh2, depsh, rxpsh, &
+                              rlmax, drl, &
+                              ncnf, nvcnf, nacnf, lacnf, facnf)
+      implicit none
+      ! Input variables
+      !> The Fortran unit number to read from
+      integer, intent(in) :: unit
+
+      ! Output variables
+      ! [Atom and reference configuration]
+      !> Atomic symbol
+      character(len=2), intent(out) :: atsym
+      !> Atomic number
+      real(dp), intent(out) :: zz
+      !> Number of core electrons
+      integer, intent(out) :: nc
+      !> Number of valence electrons
+      integer, intent(out) :: nv
+      !> Exchange-correlation functional code
+      integer, intent(out) :: iexc
+      !> Pseudopotential output file format flag
+      character(len=4), intent(out) :: psfile
+      !> Principal quantum number array
+      integer, intent(out) :: na(30)
+      !> Orbital angular momentum quantum number array
+      integer, intent(out) :: la(30)
+      !> Occupation number array
+      real(dp), intent(out) :: fa(30)
+      ! [Pseudopotential and optimization]
+      !> Maximum angular momentum
+      integer, intent(out) :: lmax
+      !> Core radii for pseudopotentials
+      real(dp), intent(out) :: rc(6)
+      !> Pseudopotential energies
+      real(dp), intent(out) :: ep(6)
+      !> Number of matching constraints for each pseudopotential
+      integer, intent(out) :: ncon(6)
+      !> Number of basis functions for each pseudopotential
+      integer, intent(out) :: nbas(6)
+      !> Maximum wave number for each pseudopotential
+      real(dp), intent(out) :: qcut(6)
+      ! [Local potential]
+      !> Angular momentum used for local potential
+      integer, intent(out) :: lloc
+      !>
+      integer, intent(out) :: lpopt
+      !> Local potential offset at origin
+      real(dp), intent(out) :: dvloc0
+      ! [Vanderbilt-Kleinman-Bylander projectors]
+      !> Number of projectors for each angular momentum
+      integer, intent(out) :: nproj(6)
+      !> Energy shift for unbound states
+      real(dp), intent(out) :: debl(6)
+      ! [Model core charge]
+      !> Model core charge flag
+      integer, intent(out) :: icmod
+      !> Scaling factor for core charge
+      real(dp), intent(out) :: fcfact
+      !> Scaling factor range minimum for optimization
+      real(dp), intent(out) :: fcfact_min
+      !> Scaling factor range maximum for optimization
+      real(dp), intent(out) :: fcfact_max
+      !> Scaling factor step size for optimization
+      real(dp), intent(out) :: fcfact_step
+      !> Core charge width factor
+      real(dp), intent(out) :: rcfact
+      !> Core charge width factor minimum for optimization
+      real(dp), intent(out) :: rcfact_min
+      !> Core charge width factor maximum for optimization
+      real(dp), intent(out) :: rcfact_max
+      !> Core charge width factor step size for optimization
+      real(dp), intent(out) :: rcfact_step
+      ! [Log derivative analysis]
+      !> Lower bound of energy range for log derivative analysis
+      real(dp), intent(out) :: epsh1
+      !> Upper bound of energy range for log derivative analysis
+      real(dp), intent(out) :: epsh2
+      !> Energy step size for log derivative analysis
+      real(dp), intent(out) :: depsh
+      !> Radius for log derivative analysis
+      real(dp), intent(out) :: rxpsh
+      ! [Output grid]
+      !> Maximum radius for output grid
+      real(dp), intent(out) :: rlmax
+      !> Grid spacing for output grid
+      real(dp), intent(out) :: drl
+      ! [Test configurations]
+      !> Number of test configurations
+      integer, intent(out) :: ncnf
+      !> Number of valence states in test configurations
+      integer, intent(out) :: nvcnf(5)
+      !> Principal quantum number array for test configurations
+      integer, intent(out) :: nacnf(30, 5)
+      !> Orbital angular momentum quantum number array for test configurations
+      integer, intent(out) :: lacnf(30, 5)
+      !> Occupation number array for test configurations
+      real(dp), intent(out) :: facnf(30, 5)
+
+      ! Local variables
+      !> The TOML table object
+      type(toml_table), allocatable :: table
+      !> A pointer to a child table
+      type(toml_table), pointer :: child
+      !> A pointer to a toml array
+      type(toml_array), pointer :: arr
+      !> Status variable for optional sections
+      integer :: stat
+      !> Iteration index
+      integer :: i
+      !> Temporary string
+      character(len=:), allocatable :: tmp_str
+
+      nproj(:) = 0
+      rc(:) = 0.0_dp
+      ep(:) = 0.0_dp
+      atsym(:) = '  '
+      psfile(:) = '    '
+
+      call toml_load(table, unit)
+      if (.not. allocated(table)) then
+         write (stderr, '(A)') 'Error: Failed to load TOML input file.'
+         stop 1
+      end if
+
+      !! oncvpsp section (required)
+      call get_value(table, "oncvpsp", child)
+      call check_associated(child, "[oncvpsp] section")
+      call get_value(child, "atsym", tmp_str)
+      if (len_trim(tmp_str) < 1 .or. len_trim(tmp_str) > 2) then
+         write (stderr, '(A)') 'Error: Invalid atomic symbol in [oncvpsp] section.'
+         stop 1
+      else
+         atsym(1:len_trim(tmp_str)) = tmp_str(1:len_trim(tmp_str))
+      end if
+      deallocate(tmp_str)
+      call get_value(child, "z", zz)
+      call get_value(child, "nc", nc)
+      call get_value(child, "nv", nv)
+      call get_value(child, "iexc", iexc)
+
+      !! Linear mesh section (required)
+      call get_value(table, "linear_mesh", child)
+      call check_associated(child, "[linear_mesh] section")
+      call get_value(child, "a", drl)
+      call get_value(child, "rmax", rlmax)
+
+      !! Reference configuration section (required)
+      call get_value(table, "reference_configuration", child)
+      call check_associated(child, '[reference_configuration] section')
+      ! n (required, length = nc + nv)
+      call get_value(child, "n", arr)
+      call check_associated(arr, 'n in [reference_configuration] section')
+      call check_len(arr, nc + nv, 'n')
+      do i = 1, len(arr)
+         call get_value(arr, i, na(i))
+      end do
+      ! l (required, length = nc + nv)
+      call get_value(child, "l", arr)
+      call check_associated(arr, 'l in [reference_configuration] section')
+      call check_len(arr, nc + nv, 'l')
+      do i = 1, len(arr)
+         call get_value(arr, i, la(i))
+      end do
+      ! f (required, length = nc + nv)
+      call get_value(child, "f", arr)
+      call check_associated(arr, 'f in [reference_configuration] section')
+      call check_len(arr, nc + nv, 'f')
+      do i = 1, len(arr)
+         call get_value(arr, i, fa(i))
+      end do
+
+      !! Pseudopotential section (required)
+      call get_value(table, "pseudopotentials", child)
+      call check_associated(child, "[pseudopotentials] section")
+      ! lmax (required)
+      call get_value(child, "lmax", lmax)
+      ! l (required, length = lmax + 1, must be in order from 0 to lmax)
+      call get_value(child, "l", arr)
+      call check_associated(arr, 'l in [pseudopotentials] section')
+      call check_len(arr, lmax + 1, 'l in [pseudopotentials] section')
+      pseudopotentials_l: block ! pseudopotentials.l
+         integer :: l
+         do i = 1, len(arr)
+               call get_value(arr, i, l)
+               if (i /= l + 1) then
+                  write (stderr, '(A,I0,A,I0)') 'Error: l values in [pseudopotentials] section must be in order ', &
+                     'starting from 0 to lmax without skipping any values. Expected ', i-1, ' but got ', l, '.'
+                  stop 1
+               end if
+         end do
+      end block pseudopotentials_l
+      ! rc (required, length = lmax + 1)
+      call get_value(child, "rc", arr)
+      call check_associated(arr, 'rc in [pseudopotentials] section')
+      call check_len(arr, lmax + 1, 'rc in [pseudopotentials] section')
+      do i = 1, lmax + 1
+         call get_value(arr, i, rc(i))
+      end do
+      ! ep (required, length = lmax + 1)
+      call get_value(child, "ep", arr)
+      call check_associated(arr, 'ep in [pseudopotentials] section')
+      call check_len(arr, lmax + 1, 'ep in [pseudopotentials] section')
+      do i = 1, lmax + 1
+         call get_value(arr, i, ep(i))
+      end do
+      ! ncon (required, length = lmax + 1)
+      call get_value(child, "ncon", arr)
+      call check_associated(arr, 'ncon in [pseudopotentials] section')
+      call check_len(arr, lmax + 1, 'ncon in [pseudopotentials] section')
+      do i = 1, lmax + 1
+         call get_value(arr, i, ncon(i))
+      end do
+      ! nbas (required, length = lmax + 1)
+      call get_value(child, "nbas", arr)
+      call check_associated(arr, 'nbas in [pseudopotentials] section')
+      call check_len(arr, lmax + 1, 'nbas in [pseudopotentials] section')
+      do i = 1, lmax + 1
+         call get_value(arr, i, nbas(i))
+      end do
+      ! qcut (required, length = lmax + 1)
+      call get_value(child, "qcut", arr)
+      call check_associated(arr, 'qcut in [pseudopotentials] section')
+      call check_len(arr, lmax + 1, 'qcut in [pseudopotentials] section')
+      do i = 1, lmax + 1
+         call get_value(arr, i, qcut(i))
+      end do
+
+      !! Local potential section (required)
+      call get_value(table, "local_potential", child)
+      call check_associated(child, "[local_potential] section")
+      call get_value(child, "lloc", lloc)
+      call get_value(child, "lpopt", lpopt)
+      call get_value(child, "rcloc", rc(5))
+      call get_value(child, "dvloc0", dvloc0)
+
+      !! VKB projectors section (required)
+      call get_value(table, "vkb_projectors", child)
+      call check_associated(child, "[vkb_projectors] section")
+      ! l (required, length = lmax + 1, must be in order from 0 to lmax)
+      call get_value(child, "l", arr)
+      call check_associated(arr, 'l in [vkb_projectors] section')
+      call check_len(arr, lmax + 1, 'l in [vkb_projectors] section')
+      vkb_projectors_l: block ! vkb_projectors.l
+         integer :: l
+         do i = 1, len(arr)
+               call get_value(arr, i, l)
+               if (i /= l + 1) then
+                  write (stderr, '(A,I0,A,I0)') 'Error: l values in [vkb_projectors] section must be in order ', &
+                     'starting from 0 to lmax without skipping any values. Expected ', i-1, ' but got ', l, '.'
+                  stop 1
+               end if
+         end do
+      end block vkb_projectors_l
+      ! nproj (required, length = lmax + 1)
+      call get_value(child, "nproj", arr)
+      call check_associated(arr, 'nproj in [vkb_projectors] section')
+      call check_len(arr, lmax + 1, 'nproj in [vkb_projectors] section')
+      do i = 1, lmax + 1
+         call get_value(arr, i, nproj(i))
+      end do
+      ! debl (required, length = lmax + 1)
+      call get_value(child, "debl", arr)
+      call check_associated(arr, 'debl in [vkb_projectors] section')
+      call check_len(arr, lmax + 1, 'debl in [vkb_projectors] section')
+      do i = 1, lmax + 1
+         call get_value(arr, i, debl(i))
+      end do
+
+      !! Model core charge (nlcc) section (required)
+      call get_value(table, "model_core_charge", child)
+      call check_associated(child, "[model_core_charge] section")
+      call get_value(child, "icmod", icmod)
+      call get_value(child, "fcfact", fcfact)
+      if (icmod >= 0 .and. icmod <= 2) then
+         rcfact = 0.0_dp
+      else if (icmod >= 3 .and. icmod <= 4) then
+         call get_value(child, "rcfact", rcfact)
+      else
+         write (stderr, '(A)') 'Error: Invalid icmod in [model_core_charge] section. Must be 0, 1, 2, 3, or 4.'
+         stop 1
+      end if
+
+      !! Log-derivative analysis section (required)
+      call get_value(table, "log_derivative_analysis", child)
+      call check_associated(child, "[log_derivative_analysis] section")
+      call get_value(child, "epsh1", epsh1)
+      call get_value(child, "epsh2", epsh2)
+      call get_value(child, "depsh", depsh)
+      call get_value(child, "rxpsh", rxpsh, -1.0_dp)
+
+      !! PP output section (required)
+      call get_value(table, "pp_output", child)
+      call check_associated(child, "[pp_output] section")
+      call get_value(child, "psfile", tmp_str)
+      if (len_trim(tmp_str) < 1 .or. len_trim(tmp_str) > 4) then
+         write (stderr, '(A)') 'Error: Invalid psfile in [pp_out] section.'
+         stop 1
+      else
+         psfile(1:len_trim(tmp_str)) = tmp_str(1:len_trim(tmp_str))
+      end if
+      deallocate(tmp_str)
+
+      !! Test configurations section (optional)
+      call get_value(table, "test_configurations", arr)
+      if (associated(arr)) then
+         test_configurations: block
+               ! Test configuration index
+               integer :: icnf
+               ! Valence state index within test configuration
+               integer :: iv
+               ! Core state index
+               integer :: ic
+               ! Core + valence state index
+               integer :: icv
+               ! Configuration sub-table
+               type(toml_table), pointer :: cnf_tbl
+               ! Array within test configuration (e.g. n, l, f)
+               type(toml_array), pointer :: cnf_arr
+               ncnf = len(arr)
+               nvcnf(1) = nv  ! First configuration is the reference configuration
+               ! Determine maximum number of valence states in test configurations
+               do icnf = 1, ncnf
+                  ! Get the configuration sub-table
+                  call get_value(arr, icnf, cnf_tbl)
+                  ! Get the n array to determine number of valence states in this configuration
+                  call get_value(cnf_tbl, "n", cnf_arr)
+                  call check_associated(cnf_arr, 'n in [[test_configurations]] section')
+                  nvcnf(icnf + 1) = len(cnf_arr)
+               end do
+               ! Read the test configurations
+               do icnf = 1, ncnf
+                  ! Get the configuration sub-table
+                  call get_value(arr, icnf, cnf_tbl)
+                  ! n
+                  call get_value(cnf_tbl, "n", cnf_arr)
+                  call check_associated(cnf_arr, 'n in [[test_configurations]] section')
+                  do iv = 1, nvcnf(icnf + 1)
+                     call get_value(cnf_arr, iv, nacnf(nc + iv, icnf + 1))
+                  end do
+                  ! l
+                  call get_value(cnf_tbl, "l", cnf_arr)
+                  call check_associated(cnf_arr, 'l in [[test_configurations]] section')
+                  do iv = 1, nvcnf(icnf + 1)
+                     call get_value(cnf_arr, iv, lacnf(nc + iv, icnf + 1))
+                  end do
+                  ! f
+                  call get_value(cnf_tbl, "f", cnf_arr)
+                  call check_associated(cnf_arr, 'f in [[test_configurations]] section')
+                  do iv = 1, nvcnf(icnf + 1)
+                     call get_value(cnf_arr, iv, facnf(nc + iv, icnf + 1))
+                  end do
+               end do
+               ! Add the reference configuration as the first configuration
+               do icv = 1, nc + nv
+                  nacnf(icv, 1) = na(icv)
+                  lacnf(icv, 1) = la(icv)
+                  facnf(icv, 1) = fa(icv)
+               end do
+               ! Add the reference core configuration to the test configurations
+               do icnf = 1, ncnf
+                  do ic = 1, nc
+                     nacnf(ic, icnf + 1) = na(ic)
+                     lacnf(ic, icnf + 1) = la(ic)
+                     facnf(ic, icnf + 1) = fa(ic)
+                  end do
+               end do
+         end block test_configurations
+      else
+         ncnf = 0
+         nvcnf(1) = nv  ! First configuration
+         do i = 1, nc + nv
+               nacnf(i, 1) = na(i)
+               lacnf(i, 1) = la(i)
+               facnf(i, 1) = fa(i)
+         end do
+      end if
+   end subroutine read_input_toml
+
+   subroutine read_input_toml_r(unit, &
+                                atsym, zz, nc, nv, iexc, psfile, na, la, fa, &
+                                lmax, rc, ep, ncon, nbas, qcut, &
+                                lloc, lpopt, dvloc0, nproj, debl, &
+                                icmod, fcfact, rcfact, fcfact_min, fcfact_max, fcfact_step, &
+                                rcfact_min, rcfact_max, rcfact_step, &
+                                epsh1, epsh2, depsh, rxpsh, &
+                                rlmax, drl, &
+                                ncnf, nvcnf, nacnf, lacnf, facnf)
+      implicit none
+      ! Input variables
+      !> The Fortran unit number to read from
+      integer, intent(in) :: unit
+
+      ! Output variables
+      ! [Atom and reference configuration]
+      !> Atomic symbol
+      character(len=2), intent(out) :: atsym
+      !> Atomic number
+      real(dp), intent(out) :: zz
+      !> Number of core electrons
+      integer, intent(out) :: nc
+      !> Number of valence electrons
+      integer, intent(out) :: nv
+      !> Exchange-correlation functional code
+      integer, intent(out) :: iexc
+      !> Pseudopotential output file format flag
+      character(len=4), intent(out) :: psfile
+      !> Principal quantum number array
+      integer, intent(out) :: na(30)
+      !> Orbital angular momentum quantum number array
+      integer, intent(out) :: la(30)
+      !> Occupation number array
+      real(dp), intent(out) :: fa(30)
+      ! [Pseudopotential and optimization]
+      !> Maximum angular momentum
+      integer, intent(out) :: lmax
+      !> Core radii for pseudopotentials
+      real(dp), intent(out) :: rc(6)
+      !> Pseudopotential energies
+      real(dp), intent(out) :: ep(6, 2)
+      !> Number of matching constraints for each pseudopotential
+      integer, intent(out) :: ncon(6)
+      !> Number of basis functions for each pseudopotential
+      integer, intent(out) :: nbas(6)
+      !> Maximum wave number for each pseudopotential
+      real(dp), intent(out) :: qcut(6)
+      ! [Local potential]
+      !> Angular momentum used for local potential
+      integer, intent(out) :: lloc
+      !>
+      integer, intent(out) :: lpopt
+      !> Local potential offset at origin
+      real(dp), intent(out) :: dvloc0
+      ! [Vanderbilt-Kleinman-Bylander projectors]
+      !> Number of projectors for each angular momentum
+      integer, intent(out) :: nproj(6)
+      !> Energy shift for unbound states
+      real(dp), intent(out) :: debl(6)
+      ! [Model core charge]
+      !> Model core charge flag
+      integer, intent(out) :: icmod
+      !> Scaling factor for core charge
+      real(dp), intent(out) :: fcfact
+      !> Scaling factor range minimum for optimization
+      real(dp), intent(out) :: fcfact_min
+      !> Scaling factor range maximum for optimization
+      real(dp), intent(out) :: fcfact_max
+      !> Scaling factor step size for optimization
+      real(dp), intent(out) :: fcfact_step
+      !> Core charge width factor
+      real(dp), intent(out) :: rcfact
+      !> Core charge width factor minimum for optimization
+      real(dp), intent(out) :: rcfact_min
+      !> Core charge width factor maximum for optimization
+      real(dp), intent(out) :: rcfact_max
+      !> Core charge width factor step size for optimization
+      real(dp), intent(out) :: rcfact_step
+      ! [Log derivative analysis]
+      !> Lower bound of energy range for log derivative analysis
+      real(dp), intent(out) :: epsh1
+      !> Upper bound of energy range for log derivative analysis
+      real(dp), intent(out) :: epsh2
+      !> Energy step size for log derivative analysis
+      real(dp), intent(out) :: depsh
+      !> Radius for log derivative analysis
+      real(dp), intent(out) :: rxpsh
+      ! [Output grid]
+      !> Maximum radius for output grid
+      real(dp), intent(out) :: rlmax
+      !> Grid spacing for output grid
+      real(dp), intent(out) :: drl
+      ! [Test configurations]
+      !> Number of test configurations
+      integer, intent(out) :: ncnf
+      !> Number of valence states in test configurations
+      integer, intent(out) :: nvcnf(5)
+      !> Principal quantum number array for test configurations
+      integer, intent(out) :: nacnf(30, 5)
+      !> Orbital angular momentum quantum number array for test configurations
+      integer, intent(out) :: lacnf(30, 5)
+      !> Occupation number array for test configurations
+      real(dp), intent(out) :: facnf(30, 5)
+
+      ! Local variables
+      !> The TOML table object
+      type(toml_table), allocatable :: table
+      !> A pointer to a child table
+      type(toml_table), pointer :: child
+      !> A pointer to a toml array
+      type(toml_array), pointer :: arr
+      !> Status variable for optional sections
+      integer :: stat
+      !> Iteration index
+      integer :: i
+      !> Temporary string
+      character(len=:), allocatable :: tmp_str
+
+      nproj(:) = 0
+      rc(:) = 0.0_dp
+      ep(:,:) = 0.0_dp
+      atsym(:) = '  '
+      psfile(:) = '    '
+
+      call toml_load(table, unit)
+      if (.not. allocated(table)) then
+         write (stderr, '(A)') 'Error: Failed to load TOML input file.'
+         stop 1
+      end if
+
+      !! oncvpsp section (required)
+      call get_value(table, "oncvpsp", child)
+      call check_associated(child, "[oncvpsp] section")
+      call get_value(child, "atsym", tmp_str)
+      if (len_trim(tmp_str) < 1 .or. len_trim(tmp_str) > 2) then
+         write (stderr, '(A)') 'Error: Invalid atomic symbol in [oncvpsp] section.'
+         stop 1
+      else
+         atsym(1:len_trim(tmp_str)) = tmp_str(1:len_trim(tmp_str))
+      end if
+      deallocate(tmp_str)
+      call get_value(child, "z", zz)
+      call get_value(child, "nc", nc)
+      call get_value(child, "nv", nv)
+      call get_value(child, "iexc", iexc)
+
+      !! Linear mesh section (required)
+      call get_value(table, "linear_mesh", child)
+      call check_associated(child, "[linear_mesh] section")
+      call get_value(child, "a", drl)
+      call get_value(child, "rmax", rlmax)
+
+      !! Reference configuration section (required)
+      call get_value(table, "reference_configuration", child)
+      call check_associated(child, '[reference_configuration] section')
+      ! n (required, length = nc + nv)
+      call get_value(child, "n", arr)
+      call check_associated(arr, 'n in [reference_configuration] section')
+      call check_len(arr, nc + nv, 'n')
+      do i = 1, len(arr)
+         call get_value(arr, i, na(i))
+      end do
+      ! l (required, length = nc + nv)
+      call get_value(child, "l", arr)
+      call check_associated(arr, 'l in [reference_configuration] section')
+      call check_len(arr, nc + nv, 'l')
+      do i = 1, len(arr)
+         call get_value(arr, i, la(i))
+      end do
+      ! f (required, length = nc + nv)
+      call get_value(child, "f", arr)
+      call check_associated(arr, 'f in [reference_configuration] section')
+      call check_len(arr, nc + nv, 'f')
+      do i = 1, len(arr)
+         call get_value(arr, i, fa(i))
+      end do
+
+      !! Pseudopotential section (required)
+      call get_value(table, "pseudopotentials", child)
+      call check_associated(child, "[pseudopotentials] section")
+      ! lmax (required)
+      call get_value(child, "lmax", lmax)
+      ! l (required, length = lmax + 1, must be in order from 0 to lmax)
+      call get_value(child, "l", arr)
+      call check_associated(arr, 'l in [pseudopotentials] section')
+      call check_len(arr, lmax + 1, 'l in [pseudopotentials] section')
+      pseudopotentials_l: block ! pseudopotentials.l
+         integer :: l
+         do i = 1, len(arr)
+               call get_value(arr, i, l)
+               if (i /= l + 1) then
+                  write (stderr, '(A,I0,A,I0)') 'Error: l values in [pseudopotentials] section must be in order ', &
+                     'starting from 0 to lmax without skipping any values. Expected ', i-1, ' but got ', l, '.'
+                  stop 1
+               end if
+         end do
+      end block pseudopotentials_l
+      ! rc (required, length = lmax + 1)
+      call get_value(child, "rc", arr)
+      call check_associated(arr, 'rc in [pseudopotentials] section')
+      call check_len(arr, lmax + 1, 'rc in [pseudopotentials] section')
+      do i = 1, lmax + 1
+         call get_value(arr, i, rc(i))
+      end do
+      ! ep (required, length = lmax + 1)
+      call get_value(child, "ep", arr)
+      call check_associated(arr, 'ep in [pseudopotentials] section')
+      call check_len(arr, lmax + 1, 'ep in [pseudopotentials] section')
+      do i = 1, lmax + 1
+         call get_value(arr, i, ep(i, 1))
+         ep(i, 2) = ep(i, 1)
+      end do
+      ! ncon (required, length = lmax + 1)
+      call get_value(child, "ncon", arr)
+      call check_associated(arr, 'ncon in [pseudopotentials] section')
+      call check_len(arr, lmax + 1, 'ncon in [pseudopotentials] section')
+      do i = 1, lmax + 1
+         call get_value(arr, i, ncon(i))
+      end do
+      ! nbas (required, length = lmax + 1)
+      call get_value(child, "nbas", arr)
+      call check_associated(arr, 'nbas in [pseudopotentials] section')
+      call check_len(arr, lmax + 1, 'nbas in [pseudopotentials] section')
+      do i = 1, lmax + 1
+         call get_value(arr, i, nbas(i))
+      end do
+      ! qcut (required, length = lmax + 1)
+      call get_value(child, "qcut", arr)
+      call check_associated(arr, 'qcut in [pseudopotentials] section')
+      call check_len(arr, lmax + 1, 'qcut in [pseudopotentials] section')
+      do i = 1, lmax + 1
+         call get_value(arr, i, qcut(i))
+      end do
+
+      !! Local potential section (required)
+      call get_value(table, "local_potential", child)
+      call check_associated(child, "[local_potential] section")
+      call get_value(child, "lloc", lloc)
+      call get_value(child, "lpopt", lpopt)
+      call get_value(child, "rcloc", rc(5))
+      call get_value(child, "dvloc0", dvloc0)
+
+      !! VKB projectors section (required)
+      call get_value(table, "vkb_projectors", child)
+      call check_associated(child, "[vkb_projectors] section")
+      ! l (required, length = lmax + 1, must be in order from 0 to lmax)
+      call get_value(child, "l", arr)
+      call check_associated(arr, 'l in [vkb_projectors] section')
+      call check_len(arr, lmax + 1, 'l in [vkb_projectors] section')
+      vkb_projectors_l: block ! vkb_projectors.l
+         integer :: l
+         do i = 1, len(arr)
+               call get_value(arr, i, l)
+               if (i /= l + 1) then
+                  write (stderr, '(A,I0,A,I0)') 'Error: l values in [vkb_projectors] section must be in order ', &
+                     'starting from 0 to lmax without skipping any values. Expected ', i-1, ' but got ', l, '.'
+                  stop 1
+               end if
+         end do
+      end block vkb_projectors_l
+      ! nproj (required, length = lmax + 1)
+      call get_value(child, "nproj", arr)
+      call check_associated(arr, 'nproj in [vkb_projectors] section')
+      call check_len(arr, lmax + 1, 'nproj in [vkb_projectors] section')
+      do i = 1, lmax + 1
+         call get_value(arr, i, nproj(i))
+      end do
+      ! debl (required, length = lmax + 1)
+      call get_value(child, "debl", arr)
+      call check_associated(arr, 'debl in [vkb_projectors] section')
+      call check_len(arr, lmax + 1, 'debl in [vkb_projectors] section')
+      do i = 1, lmax + 1
+         call get_value(arr, i, debl(i))
+      end do
+
+      !! model_core_charge section (required)
+      call get_value(table, "model_core_charge", child)
+      call check_associated(child, "[model_core_charge] section")
+      call get_value(child, "icmod", icmod)
+      call get_value(child, "fcfact", fcfact)
+      if (icmod >= 0 .and. icmod <= 2) then
+         rcfact = 0.0_dp
+      else if (icmod >= 3 .and. icmod <= 4) then
+         call get_value(child, "rcfact", rcfact)
+      else
+         write (stderr, '(A)') 'Error: Invalid icmod in [model_core_charge] section. Must be 0, 1, 2, 3, or 4.'
+         stop 1
+      end if
+
+      !! Log-derivative analysis section (required)
+      call get_value(table, "log_derivative_analysis", child)
+      call check_associated(child, "[log_derivative_analysis] section")
+      call get_value(child, "epsh1", epsh1)
+      call get_value(child, "epsh2", epsh2)
+      call get_value(child, "depsh", depsh)
+      call get_value(child, "rxpsh", rxpsh, -1.0_dp)
+
+      !! PP output section (required)
+      call get_value(table, "pp_output", child)
+      call check_associated(child, "[pp_output] section")
+      call get_value(child, "psfile", tmp_str)
+      if (len_trim(tmp_str) < 1 .or. len_trim(tmp_str) > 4) then
+         write (stderr, '(A)') 'Error: Invalid psfile in [pp_out] section.'
+         stop 1
+      else
+         psfile(1:len_trim(tmp_str)) = tmp_str(1:len_trim(tmp_str))
+      end if
+      deallocate(tmp_str)
+
+      !! Test configurations section (optional)
+      call get_value(table, "test_configurations", arr)
+      if (associated(arr)) then
+         test_configurations: block
+               ! Test configuration index
+               integer :: icnf
+               ! Valence state index within test configuration
+               integer :: iv
+               ! Core state index
+               integer :: ic
+               ! Core + valence state index
+               integer :: icv
+               ! Configuration sub-table
+               type(toml_table), pointer :: cnf_tbl
+               ! Array within test configuration (e.g. n, l, f)
+               type(toml_array), pointer :: cnf_arr
+               ncnf = len(arr)
+               nvcnf(1) = nv  ! First configuration is the reference configuration
+               ! Determine maximum number of valence states in test configurations
+               do icnf = 1, ncnf
+                  ! Get the configuration sub-table
+                  call get_value(arr, icnf, cnf_tbl)
+                  ! Get the n array to determine number of valence states in this configuration
+                  call get_value(cnf_tbl, "n", cnf_arr)
+                  call check_associated(cnf_arr, 'n in [[test_configurations]] section')
+                  nvcnf(icnf + 1) = len(cnf_arr)
+               end do
+               ! Read the test configurations
+               do icnf = 1, ncnf
+                  ! Get the configuration sub-table
+                  call get_value(arr, icnf, cnf_tbl)
+                  ! n
+                  call get_value(cnf_tbl, "n", cnf_arr)
+                  call check_associated(cnf_arr, 'n in [[test_configurations]] section')
+                  do iv = 1, nvcnf(icnf + 1)
+                     call get_value(cnf_arr, iv, nacnf(nc + iv, icnf + 1))
+                  end do
+                  ! l
+                  call get_value(cnf_tbl, "l", cnf_arr)
+                  call check_associated(cnf_arr, 'l in [[test_configurations]] section')
+                  do iv = 1, nvcnf(icnf + 1)
+                     call get_value(cnf_arr, iv, lacnf(nc + iv, icnf + 1))
+                  end do
+                  ! f
+                  call get_value(cnf_tbl, "f", cnf_arr)
+                  call check_associated(cnf_arr, 'f in [[test_configurations]] section')
+                  do iv = 1, nvcnf(icnf + 1)
+                     call get_value(cnf_arr, iv, facnf(nc + iv, icnf + 1))
+                  end do
+               end do
+               ! Add the reference configuration as the first configuration
+               do icv = 1, nc + nv
+                  nacnf(icv, 1) = na(icv)
+                  lacnf(icv, 1) = la(icv)
+                  facnf(icv, 1) = fa(icv)
+               end do
+               ! Add the reference core configuration to the test configurations
+               do icnf = 1, ncnf
+                  do ic = 1, nc
+                     nacnf(ic, icnf + 1) = na(ic)
+                     lacnf(ic, icnf + 1) = la(ic)
+                     facnf(ic, icnf + 1) = fa(ic)
+                  end do
+               end do
+         end block test_configurations
+      else
+         ncnf = 0
+         nvcnf(1) = nv  ! First configuration
+         do i = 1, nc + nv
+               nacnf(i, 1) = na(i)
+               lacnf(i, 1) = la(i)
+               facnf(i, 1) = fa(i)
+         end do
+      end if
+   end subroutine read_input_toml_r
+
+   subroutine toml_table_check_associated(ptr, name)
+      implicit none
+      type(toml_table), pointer :: ptr
+      character(len=*), intent(in) :: name
+      if (.not. associated(ptr)) then
+         write (stderr, '(A,A)') 'Error: Missing or invalid table', trim(name)
+         stop 1
+      end if
+   end
+
+   subroutine toml_array_check_associated(ptr, name)
+      implicit none
+      type(toml_array), pointer :: ptr
+      character(len=*), intent(in) :: name
+      if (.not. associated(ptr)) then
+         write (stderr, '(A,A)') 'Error: Missing or invalid array', trim(name)
+         stop 1
+      end if
+   end
+
+   subroutine check_len(arr, expected_len, name)
+      implicit none
+      type(toml_array), pointer :: arr
+      integer, intent(in) :: expected_len
+      character(len=*), intent(in) :: name
+      if (len(arr) /= expected_len) then
+         write (stderr, '(A,A,A,A,I0,A,I0)') 'Error: Length of', ' ', trim(name), '(len=', len(arr), &
+                                             ') must be equal to ', expected_len
+         stop 1
+      end if
+   end subroutine check_len
+
+end module input_toml_m

--- a/src/oncvpsp.f90
+++ b/src/oncvpsp.f90
@@ -35,7 +35,9 @@
  use, intrinsic :: iso_fortran_env, only: stdin => input_unit, stdout => output_unit, stderr => error_unit
  use m_psmlout, only: psmlout
  use input_text_m, only: read_input_text
+#if (defined WITH_TOML)
  use input_toml_m, only: read_input_toml
+#endif
  implicit none
  integer, parameter :: dp=kind(1.0d0)
 
@@ -135,6 +137,7 @@
          end if
          call get_command_argument(i + 1, input_filename)
          input_mode = INPUT_TEXT
+#if (defined WITH_TOML)
        case('-t', '--toml-input')
          if (i + 1 > command_argument_count()) then
             write (stderr, '(a)') 'Error: --toml-input requires a filename argument'
@@ -142,6 +145,10 @@
          end if
          call get_command_argument(i + 1, input_filename)
          input_mode = INPUT_TOML
+#else
+        case('-t', '--toml-input')
+          error stop 'Error: TOML input support not enabled in this build.'
+#endif
        case default
        end select
     end do
@@ -173,6 +180,7 @@
                             rlmax, drl, &
                             ncnf, nvcnf, nacnf, lacnf, facnf)
        close(unit)
+#if (defined WITH_TOML)
     case(INPUT_TOML)
        open(newunit=unit, file=input_filename, status='old', action='read', iostat=ios)
        call read_input_toml(unit, &
@@ -186,6 +194,7 @@
                             rlmax, drl, &
                             ncnf, nvcnf, nacnf, lacnf, facnf)
         close(unit)
+#endif
     case default
         write (stderr, '(a,i2)') 'Error: Unknown input mode =', input_mode
         stop 1
@@ -647,3 +656,8 @@
 
  stop
  end program oncvpsp
+
+!! Local Variables:
+!! mode: f90
+!! coding: utf-8
+!! End:

--- a/src/oncvpsp.f90
+++ b/src/oncvpsp.f90
@@ -2,17 +2,17 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
@@ -32,7 +32,10 @@
 !
 !   Output format for ABINIT pspcod=8 and upf format for quantumespresso
 !
+ use, intrinsic :: iso_fortran_env, only: stdin => input_unit, stdout => output_unit, stderr => error_unit
  use m_psmlout, only: psmlout
+ use input_text_m, only: read_input_text
+ use input_toml_m, only: read_input_toml
  implicit none
  integer, parameter :: dp=kind(1.0d0)
 
@@ -53,9 +56,11 @@
 
  real(dp) :: al,amesh,csc,csc1,deblt,depsh,depsht,drl,eeel
  real(dp) :: eeig,eexc
- real(dp) :: emax,epsh1,epsh1t,epsh2,epsh2t
+ real(dp) :: emax,epsh1,epsh1t,epsh2,epsh2t,rxpsh
  real(dp) :: et,etest,emin,sls
  real(dp) :: fcfact,rcfact,dvloc0
+ real(dp) :: fcfact_min,fcfact_max,fcfact_step
+ real(dp) :: rcfact_min,rcfact_max,rcfact_step
  real(dp) :: rr1,rcion,rciont,rcmax,rct,rlmax,rpkt
  real(dp) :: sf,zz,zion,zval,etot
  real(dp) :: xdummy
@@ -88,6 +93,13 @@
 
  logical :: srel,cset
 
+ integer, parameter :: INPUT_STDIN=1, INPUT_TEXT=2, INPUT_TOML=3
+ integer :: input_mode
+ integer :: unit
+ character(len=1024) :: input_filename
+
+ input_mode = INPUT_STDIN
+
  write(6,'(a/a//)') &
 &      'ONCVPSP  (Optimized Norm-Conservinng Vanderbilt PSeudopotential)', &
 &      'scalar-relativistic version 4.0.1 03/01/2019'
@@ -100,87 +112,89 @@
  srel=.true.
 !srel=.false.
 
- nproj(:)=0
- fcfact=0.0d0
- rcfact=0.0d0
- rc(:)=0.0d0
- ep(:)=0.0d0
+ parse_args: block
+    integer :: i
+    character(len=256) :: arg
+    do i = 1, command_argument_count()
+       call get_command_argument(i, arg)
+       select case(arg)
+       case('-h', '--help')
+          write (stdout, '(a)') 'Usage: oncvpsp.x [options]'
+          write (stdout, '(a)') 'Options:'
+          write (stdout, '(a)') '  -h, --help       Show this help message and exit'
+          write (stdout, '(a)') '  -v, --version    Show version information and exit'
+          write (stdout, '(a)') '  -i, --input      Specify input file (TOML). For legacy input, use stdin.'
+          stop 0
+       case('-v', '--version')
+          write (stdout, '(a)') 'ONCVPSP (scalar-realtivistic) version 4.0.1'
+          stop 0
+       case('-i', '--input')
+         if (i + 1 > command_argument_count()) then
+            write (stderr, '(a)') 'Error: --input requires a filename argument'
+            stop 1
+         end if
+         call get_command_argument(i + 1, input_filename)
+         input_mode = INPUT_TEXT
+       case('-t', '--toml-input')
+         if (i + 1 > command_argument_count()) then
+            write (stderr, '(a)') 'Error: --toml-input requires a filename argument'
+            stop 1
+         end if
+         call get_command_argument(i + 1, input_filename)
+         input_mode = INPUT_TOML
+       case default
+       end select
+    end do
+ end block parse_args
 
-! read input data
- inline=0
+ ios = 0
+ select case(input_mode)
+    case(INPUT_STDIN)
+       call read_input_text(stdin, inline, &
+                            atsym, zz, nc, nv, iexc, psfile, na, la, fa, &
+                            lmax, rc, ep, ncon, nbas, qcut, &
+                            lloc, lpopt, dvloc0, nproj, debl, &
+                            icmod, fcfact, rcfact, &
+                            fcfact_min, fcfact_max, fcfact_step, &
+                            rcfact_min, rcfact_max, rcfact_step, &
+                            epsh1, epsh2, depsh, rxpsh, &
+                            rlmax, drl, &
+                            ncnf, nvcnf, nacnf, lacnf, facnf)
+    case(INPUT_TEXT)
+       open(newunit=unit, file=input_filename, status='old', action='read', iostat=ios)
+       call read_input_text(unit, inline, &
+                            atsym, zz, nc, nv, iexc, psfile, na, la, fa, &
+                            lmax, rc, ep, ncon, nbas, qcut, &
+                            lloc, lpopt, dvloc0, nproj, debl, &
+                            icmod, fcfact, rcfact, &
+                            fcfact_min, fcfact_max, fcfact_step, &
+                            rcfact_min, rcfact_max, rcfact_step, &
+                            epsh1, epsh2, depsh, rxpsh, &
+                            rlmax, drl, &
+                            ncnf, nvcnf, nacnf, lacnf, facnf)
+       close(unit)
+    case(INPUT_TOML)
+       open(newunit=unit, file=input_filename, status='old', action='read', iostat=ios)
+       call read_input_toml(unit, &
+                            atsym, zz, nc, nv, iexc, psfile, na, la, fa, &
+                            lmax, rc, ep, ncon, nbas, qcut, &
+                            lloc, lpopt, dvloc0, nproj, debl, &
+                            icmod, fcfact, rcfact, &
+                            fcfact_min, fcfact_max, fcfact_step, &
+                            rcfact_min, rcfact_max, rcfact_step, &
+                            epsh1, epsh2, depsh, rxpsh, &
+                            rlmax, drl, &
+                            ncnf, nvcnf, nacnf, lacnf, facnf)
+        close(unit)
+    case default
+        write (stderr, '(a,i2)') 'Error: Unknown input mode =', input_mode
+        stop 1
+ end select
 
-! atom and reference configuration
- call cmtskp(inline)
- read(5,*,iostat=ios) atsym,zz,nc,nv,iexc,psfile
- call read_error(ios,inline)
-
- call cmtskp(inline)
- do ii=1,nc+nv
-   read(5,*,iostat=ios) na(ii),la(ii),fa(ii)
-   call read_error(ios,inline)
- end do
-
-! pseudopotential and optimization
- call cmtskp(inline)
- read(5,*,iostat=ios) lmax
- call read_error(ios,inline)
-
- call cmtskp(inline)
- do l1=1,lmax+1
-   read(5,*,iostat=ios) lt,rc(l1),ep(l1),ncon(l1),nbas(l1),qcut(l1)
-   if(lt/=l1-1) ios=999
-   call read_error(ios,inline)
- end do
-
-! local potential
- call cmtskp(inline)
- read(5,*, iostat=ios) lloc,lpopt,rc(5),dvloc0
- call read_error(ios,inline)
-
-! Vanderbilt-Kleinman-Bylander projectors
- call cmtskp(inline)
- do l1=1,lmax+1
-   read(5,*,iostat=ios) lt,nproj(l1),debl(l1)
-   if(lt/=l1-1) ios=999
-   call read_error(ios,inline)
- end do
-
-! model core charge
- call cmtskp(inline)
- read(5,*, iostat=ios) icmod, fcfact
- if(ios==0 .and. icmod==3) then
-  backspace(5)
-  read(5,*, iostat=ios) icmod, fcfact, rcfact
+ if(ios /= 0) then
+    write(6,'(a)') 'oncvpsp: ERROR reading input file'
+    stop
  end if
- call read_error(ios,inline)
-
-! log derivative analysis
- call cmtskp(inline)
- read(5,*,iostat=ios) epsh1, epsh2, depsh
- call read_error(ios,inline)
-
-! output grid
- call cmtskp(inline)
- read(5,*,iostat=ios) rlmax,drl
- call read_error(ios,inline)
-
-! test configurations
- call cmtskp(inline)
- read(5,*,iostat=ios) ncnf
- call read_error(ios,inline)
-
- do jj=2,ncnf+1
-   call cmtskp(inline)
-   read(5,*,iostat=ios) nvcnf(jj)
-   call read_error(ios,inline)
-   do ii=nc+1,nc+nvcnf(jj)
-     call cmtskp(inline)
-     read(5,*,iostat=ios) nacnf(ii,jj),lacnf(ii,jj),facnf(ii,jj)
-     call read_error(ios,inline)
-   end do
- end do
-
-! end of reading input data
 
  nvcnf(1)=nv
  do ii=1,nc+nv
@@ -339,7 +353,7 @@
   stop
  end if
  write(6,'(a,1p,d18.8)') '  all-electron total energy (Ha)',etot
-  
+
 !find log mesh point nearest input rc
  rcmax=0.0d0
  irc(:)=0
@@ -497,7 +511,7 @@
 &                rr,vp(1,lloc+1),vkb(1,1,l1),evkb(1,l1), &
 &                uu,up,mmax,mch)
 
-   if(ierr/=0) then 
+   if(ierr/=0) then
      write(6,'(a,3i4)') 'oncvpsp: lschvkbb ERROR',ll+nodes(l1)+1,ll,ierr
      flush(6)
      stop
@@ -559,7 +573,7 @@
 
 !fix unscreening error due to greater range of all-electron charge
  do ii=mmax,1,-1
-   if(rho(ii)==0.0d0) then 
+   if(rho(ii)==0.0d0) then
      do l1=1,max(lmax+1,lloc+1)
        vpuns(ii,l1)=-zion/rr(ii)
      end do
@@ -596,7 +610,7 @@
 
  call run_phsft(lmax,lloc,nproj,epa,epsh1,epsh2,depsh,vkb,evkb, &
 &               rr,vfull,vp,zz,mmax,mxprj,irc,srel)
- 
+
  call gnu_script(epa,evkb,lmax,lloc,mxprj,nproj)
 
  if(trim(psfile)=='psp8' .or. trim(psfile)=='both') then
@@ -633,42 +647,3 @@
 
  stop
  end program oncvpsp
-
-
- subroutine cmtskp(inline)
-! skips lines of standard input (file 5) whose first character is #
- implicit none
-
-!In/Out variable
- integer :: inline
-
-!Local variable
- character*1 tst
-
- tst='#'
- do while (tst=='#')
-  read(5,*) tst
-  inline=inline+1
- end do
- backspace(5)
- inline=inline-1
-
- return
- end subroutine cmtskp
-
- subroutine read_error(ios,inline)
-! report data read error and stop
- implicit none
-
-!Input variables
- integer :: ios,inline
-
- inline=inline+1
- if(ios/=0) then
-  write(6,'(a,i4)') 'Read ERROR, input data file line',inline
-  write(6,'(a)') 'Program will stop'
-  stop
- end if
-
- return
- end subroutine read_error

--- a/src/oncvpsp_nr.f90
+++ b/src/oncvpsp_nr.f90
@@ -35,7 +35,9 @@
  use, intrinsic :: iso_fortran_env, only: stdin => input_unit, stdout => output_unit, stderr => error_unit
  use m_psmlout, only: psmlout
  use input_text_m, only: read_input_text
+#if (defined WITH_TOML)
  use input_toml_m, only: read_input_toml
+#endif
  implicit none
  integer, parameter :: dp=kind(1.0d0)
 
@@ -135,6 +137,7 @@
          end if
          call get_command_argument(i + 1, input_filename)
          input_mode = INPUT_TEXT
+#if (defined WITH_TOML)
        case('-t', '--toml-input')
          if (i + 1 > command_argument_count()) then
             write (stderr, '(a)') 'Error: --toml-input requires a filename argument'
@@ -142,6 +145,10 @@
          end if
          call get_command_argument(i + 1, input_filename)
          input_mode = INPUT_TOML
+#else
+        case('-t', '--toml-input')
+          error stop 'Error: TOML input support not enabled in this build.'
+#endif
        case default
        end select
     end do
@@ -173,6 +180,7 @@
                             rlmax, drl, &
                             ncnf, nvcnf, nacnf, lacnf, facnf)
        close(unit)
+#if (defined WITH_TOML)
     case(INPUT_TOML)
        open(newunit=unit, file=input_filename, status='old', action='read', iostat=ios)
        call read_input_toml(unit, &
@@ -186,6 +194,7 @@
                             rlmax, drl, &
                             ncnf, nvcnf, nacnf, lacnf, facnf)
         close(unit)
+#endif
     case default
         write (stderr, '(a,i2)') 'Error: Unknown input mode =', input_mode
         stop 1
@@ -685,3 +694,8 @@
 
  return
  end subroutine read_error
+
+!! Local Variables:
+!! mode: f90
+!! coding: utf-8
+!! End:

--- a/src/oncvpsp_nr.f90
+++ b/src/oncvpsp_nr.f90
@@ -2,17 +2,17 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
@@ -32,7 +32,10 @@
 !
 !   Output format for ABINIT pspcod=8 and upf format for quantumespresso
 !
+ use, intrinsic :: iso_fortran_env, only: stdin => input_unit, stdout => output_unit, stderr => error_unit
  use m_psmlout, only: psmlout
+ use input_text_m, only: read_input_text
+ use input_toml_m, only: read_input_toml
  implicit none
  integer, parameter :: dp=kind(1.0d0)
 
@@ -53,9 +56,11 @@
 
  real(dp) :: al,amesh,csc,csc1,deblt,depsh,depsht,drl,eeel
  real(dp) :: eeig,eexc
- real(dp) :: emax,epsh1,epsh1t,epsh2,epsh2t
+ real(dp) :: emax,epsh1,epsh1t,epsh2,epsh2t,rxpsh
  real(dp) :: et,etest,emin,sls
  real(dp) :: fcfact,rcfact,dvloc0
+ real(dp) :: fcfact_min,fcfact_max,fcfact_step
+ real(dp) :: rcfact_min,rcfact_max,rcfact_step
  real(dp) :: rr1,rcion,rciont,rcmax,rct,rlmax,rpkt
  real(dp) :: sf,zz,zion,zval,etot
  real(dp) :: xdummy
@@ -88,6 +93,13 @@
 
  logical :: srel,cset
 
+ integer, parameter :: INPUT_STDIN=1, INPUT_TEXT=2, INPUT_TOML=3
+ integer :: input_mode
+ integer :: unit
+ character(len=1024) :: input_filename
+
+ input_mode = INPUT_STDIN
+
  write(6,'(a/a//)') &
 &      'ONCVPSP  (Optimized Norm-Conservinng Vanderbilt PSeudopotential)', &
 &      'scalar-relativistic version 4.0.1 03/01/2019'
@@ -100,87 +112,89 @@
 !srel=.true.
  srel=.false.
 
- nproj(:)=0
- fcfact=0.0d0
- rcfact=0.0d0
- rc(:)=0.0d0
- ep(:)=0.0d0
+ parse_args: block
+    integer :: i
+    character(len=256) :: arg
+    do i = 1, command_argument_count()
+       call get_command_argument(i, arg)
+       select case(arg)
+       case('-h', '--help')
+          write (stdout, '(a)') 'Usage: oncvpspnr.x [options]'
+          write (stdout, '(a)') 'Options:'
+          write (stdout, '(a)') '  -h, --help       Show this help message and exit'
+          write (stdout, '(a)') '  -v, --version    Show version information and exit'
+          write (stdout, '(a)') '  -i, --input      Specify input file (TOML). For legacy input, use stdin.'
+          stop 0
+       case('-v', '--version')
+          write (stdout, '(a)') 'ONCVPSP (non-realtivistic) version 4.0.1'
+          stop 0
+       case('-i', '--input')
+         if (i + 1 > command_argument_count()) then
+            write (stderr, '(a)') 'Error: --input requires a filename argument'
+            stop 1
+         end if
+         call get_command_argument(i + 1, input_filename)
+         input_mode = INPUT_TEXT
+       case('-t', '--toml-input')
+         if (i + 1 > command_argument_count()) then
+            write (stderr, '(a)') 'Error: --toml-input requires a filename argument'
+            stop 1
+         end if
+         call get_command_argument(i + 1, input_filename)
+         input_mode = INPUT_TOML
+       case default
+       end select
+    end do
+ end block parse_args
 
-! read input data
- inline=0
+ ios = 0
+ select case(input_mode)
+    case(INPUT_STDIN)
+       call read_input_text(stdin, inline, &
+                            atsym, zz, nc, nv, iexc, psfile, na, la, fa, &
+                            lmax, rc, ep, ncon, nbas, qcut, &
+                            lloc, lpopt, dvloc0, nproj, debl, &
+                            icmod, fcfact, rcfact, &
+                            fcfact_min, fcfact_max, fcfact_step, &
+                            rcfact_min, rcfact_max, rcfact_step, &
+                            epsh1, epsh2, depsh, rxpsh, &
+                            rlmax, drl, &
+                            ncnf, nvcnf, nacnf, lacnf, facnf)
+    case(INPUT_TEXT)
+       open(newunit=unit, file=input_filename, status='old', action='read', iostat=ios)
+       call read_input_text(unit, inline, &
+                            atsym, zz, nc, nv, iexc, psfile, na, la, fa, &
+                            lmax, rc, ep, ncon, nbas, qcut, &
+                            lloc, lpopt, dvloc0, nproj, debl, &
+                            icmod, fcfact, rcfact, &
+                            fcfact_min, fcfact_max, fcfact_step, &
+                            rcfact_min, rcfact_max, rcfact_step, &
+                            epsh1, epsh2, depsh, rxpsh, &
+                            rlmax, drl, &
+                            ncnf, nvcnf, nacnf, lacnf, facnf)
+       close(unit)
+    case(INPUT_TOML)
+       open(newunit=unit, file=input_filename, status='old', action='read', iostat=ios)
+       call read_input_toml(unit, &
+                            atsym, zz, nc, nv, iexc, psfile, na, la, fa, &
+                            lmax, rc, ep, ncon, nbas, qcut, &
+                            lloc, lpopt, dvloc0, nproj, debl, &
+                            icmod, fcfact, rcfact, &
+                            fcfact_min, fcfact_max, fcfact_step, &
+                            rcfact_min, rcfact_max, rcfact_step, &
+                            epsh1, epsh2, depsh, rxpsh, &
+                            rlmax, drl, &
+                            ncnf, nvcnf, nacnf, lacnf, facnf)
+        close(unit)
+    case default
+        write (stderr, '(a,i2)') 'Error: Unknown input mode =', input_mode
+        stop 1
+ end select
 
-! atom and reference configuration
- call cmtskp(inline)
- read(5,*,iostat=ios) atsym,zz,nc,nv,iexc,psfile
- call read_error(ios,inline)
-
- call cmtskp(inline)
- do ii=1,nc+nv
-   read(5,*,iostat=ios) na(ii),la(ii),fa(ii)
-   call read_error(ios,inline)
- end do
-
-! pseudopotential and optimization
- call cmtskp(inline)
- read(5,*,iostat=ios) lmax
- call read_error(ios,inline)
-
- call cmtskp(inline)
- do l1=1,lmax+1
-   read(5,*,iostat=ios) lt,rc(l1),ep(l1),ncon(l1),nbas(l1),qcut(l1)
-   if(lt/=l1-1) ios=999
-   call read_error(ios,inline)
- end do
-
-! local potential
- call cmtskp(inline)
- read(5,*, iostat=ios) lloc,lpopt,rc(5),dvloc0
- call read_error(ios,inline)
-
-! Vanderbilt-Kleinman-Bylander projectors
- call cmtskp(inline)
- do l1=1,lmax+1
-   read(5,*,iostat=ios) lt,nproj(l1),debl(l1)
-   if(lt/=l1-1) ios=999
-   call read_error(ios,inline)
- end do
-
-! model core charge
- call cmtskp(inline)
- read(5,*, iostat=ios) icmod, fcfact
- if(ios==0 .and. icmod==3) then
-  backspace(5)
-  read(5,*, iostat=ios) icmod, fcfact, rcfact
+ if(ios /= 0) then
+    write(6,'(a)') 'oncvpsp: ERROR reading input file'
+    stop
  end if
- call read_error(ios,inline)
-
-! log derivative analysis
- call cmtskp(inline)
- read(5,*,iostat=ios) epsh1, epsh2, depsh
- call read_error(ios,inline)
-
-! output grid
- call cmtskp(inline)
- read(5,*,iostat=ios) rlmax,drl
- call read_error(ios,inline)
-
-! test configurations
- call cmtskp(inline)
- read(5,*,iostat=ios) ncnf
- call read_error(ios,inline)
-
- do jj=2,ncnf+1
-   call cmtskp(inline)
-   read(5,*,iostat=ios) nvcnf(jj)
-   call read_error(ios,inline)
-   do ii=nc+1,nc+nvcnf(jj)
-     call cmtskp(inline)
-     read(5,*,iostat=ios) nacnf(ii,jj),lacnf(ii,jj),facnf(ii,jj)
-     call read_error(ios,inline)
-   end do
- end do
-
-! end of reading input data
 
  nvcnf(1)=nv
  do ii=1,nc+nv
@@ -339,7 +353,7 @@
   stop
  end if
  write(6,'(a,1p,d18.8)') '  all-electron total energy (Ha)',etot
-  
+
 !find log mesh point nearest input rc
  rcmax=0.0d0
  irc(:)=0
@@ -497,7 +511,7 @@
 &                rr,vp(1,lloc+1),vkb(1,1,l1),evkb(1,l1), &
 &                uu,up,mmax,mch)
 
-   if(ierr/=0) then 
+   if(ierr/=0) then
      write(6,'(a,3i4)') 'oncvpsp: lschvkbb ERROR',ll+nodes(l1)+1,ll,ierr
      flush(6)
      stop
@@ -559,7 +573,7 @@
 
 !fix unscreening error due to greater range of all-electron charge
  do ii=mmax,1,-1
-   if(rho(ii)==0.0d0) then 
+   if(rho(ii)==0.0d0) then
      do l1=1,max(lmax+1,lloc+1)
        vpuns(ii,l1)=-zion/rr(ii)
      end do
@@ -596,7 +610,7 @@
 
  call run_phsft(lmax,lloc,nproj,epa,epsh1,epsh2,depsh,vkb,evkb, &
 &               rr,vfull,vp,zz,mmax,mxprj,irc,srel)
- 
+
  call gnu_script(epa,evkb,lmax,lloc,mxprj,nproj)
 
  if(trim(psfile)=='psp8' .or. trim(psfile)=='both') then

--- a/src/oncvpsp_r.f90
+++ b/src/oncvpsp_r.f90
@@ -2,17 +2,17 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
@@ -32,7 +32,10 @@
 !
 !   Output format for ABINIT pspcod=8 and upf format for quantumespresso
 !
+ use, intrinsic :: iso_fortran_env, only: stdin => input_unit, stdout => output_unit, stderr => error_unit
  use m_psmlout, only: psmlout_r
+ use input_text_m, only: read_input_text_r
+ use input_toml_m, only: read_input_toml_r
  implicit none
  integer, parameter :: dp=kind(1.0d0)
 
@@ -54,9 +57,11 @@
 
  real(dp) :: al,amesh,csc,csc1,depsh,depsht,drl,eeel,fj
  real(dp) :: eeig,eexc
- real(dp) :: emax,epsh1,epsh1t,epsh2,epsh2t
+ real(dp) :: emax,epsh1,epsh1t,epsh2,epsh2t,rxpsh
  real(dp) :: et,etest,emin,sls
  real(dp) :: fcfact,rcfact,dvloc0,soscale
+ real(dp) :: fcfact_min,fcfact_max,fcfact_step
+ real(dp) :: rcfact_min,rcfact_max,rcfact_step
  real(dp) :: rr1,rcion,rciont,rcmax,rct,rlmax,rpkt
  real(dp) :: sf,zz,zion,zval,etot
  real(dp) :: cnorm,ebar,eprmin
@@ -89,6 +94,13 @@
 
  logical :: srel,cset
 
+ integer, parameter :: INPUT_STDIN=1, INPUT_TEXT=2, INPUT_TOML=3
+ integer :: input_mode
+ integer :: unit
+ character(len=1024) :: input_filename
+
+ input_mode = INPUT_STDIN
+
  write(6,'(a/a//)') &
 &      'ONCVPSP  (Optimized Norm-Conservinng Vanderbilt PSeudopotential)', &
 &      'relativistic version 4.0.1 03/01/2019'
@@ -101,88 +113,86 @@
  srel=.true.
 !srel=.false.
 
- nproj(:)=0
- fcfact=0.0d0
- rcfact=0.0d0
- rc(:)=0.0d0
- ep(:,:)=0.0d0
+ parse_args: block
+    integer :: i
+    character(len=256) :: arg
+    do i = 1, command_argument_count()
+       call get_command_argument(i, arg)
+       select case(arg)
+       case('-h', '--help')
+          write (stdout, '(a)') 'Usage: oncvpspr.x [options]'
+          write (stdout, '(a)') 'Options:'
+          write (stdout, '(a)') '  -h, --help       Show this help message and exit'
+          write (stdout, '(a)') '  -v, --version    Show version information and exit'
+          write (stdout, '(a)') '  -i, --input      Specify input file (TOML). For legacy input, use stdin.'
+          stop 0
+       case('-v', '--version')
+          write (stdout, '(a)') 'ONCVPSP (fully-realtivistic) version 4.0.1'
+          stop 0
+       case('-i', '--input')
+         if (i + 1 > command_argument_count()) then
+            write (stderr, '(a)') 'Error: --input requires a filename argument'
+            stop 1
+         end if
+         call get_command_argument(i + 1, input_filename)
+         input_mode = INPUT_TEXT
+       case('-t', '--toml-input')
+         if (i + 1 > command_argument_count()) then
+            write (stderr, '(a)') 'Error: --toml-input requires a filename argument'
+            stop 1
+         end if
+         call get_command_argument(i + 1, input_filename)
+         input_mode = INPUT_TOML
+       case default
+       end select
+    end do
+ end block parse_args
 
-! read input data
- inline=0
+ ios = 0
+ select case(input_mode)
+    case(INPUT_STDIN)
+       call read_input_text_r(stdin, inline, &
+                              atsym, zz, nc, nv, iexc, psfile, na, la, fa, &
+                              lmax, rc, ep, ncon, nbas, qcut, &
+                              lloc, lpopt, dvloc0, nproj, debl, &
+                              icmod, fcfact, rcfact, fcfact_min, fcfact_max, fcfact_step, &
+                              rcfact_min, rcfact_max, rcfact_step, &
+                              epsh1, epsh2, depsh, rxpsh, &
+                              rlmax, drl, &
+                              ncnf, nvcnf, nacnf, lacnf, facnf)
+    case(INPUT_TEXT)
+       open(newunit=unit, file=input_filename, status='old', action='read', iostat=ios)
+       call read_input_text_r(unit, inline, &
+                              atsym, zz, nc, nv, iexc, psfile, na, la, fa, &
+                              lmax, rc, ep, ncon, nbas, qcut, &
+                              lloc, lpopt, dvloc0, nproj, debl, &
+                              icmod, fcfact, rcfact, fcfact_min, fcfact_max, fcfact_step, &
+                              rcfact_min, rcfact_max, rcfact_step, &
+                              epsh1, epsh2, depsh, rxpsh, &
+                              rlmax, drl, &
+                              ncnf, nvcnf, nacnf, lacnf, facnf)
+       close(unit)
+    case(INPUT_TOML)
+       open(newunit=unit, file=input_filename, status='old', action='read', iostat=ios)
+       call read_input_toml_r(unit, &
+                              atsym, zz, nc, nv, iexc, psfile, na, la, fa, &
+                              lmax, rc, ep, ncon, nbas, qcut, &
+                              lloc, lpopt, dvloc0, nproj, debl, &
+                              icmod, fcfact, rcfact, fcfact_min, fcfact_max, fcfact_step, &
+                              rcfact_min, rcfact_max, rcfact_step, &
+                              epsh1, epsh2, depsh, rxpsh, &
+                              rlmax, drl, &
+                              ncnf, nvcnf, nacnf, lacnf, facnf)
+        close(unit)
+    case default
+        write (stderr, '(a,i2)') 'Error: Unknown input mode =', input_mode
+        stop 1
+ end select
 
-! atom and reference configuration
- call cmtskp(inline)
- read(5,*,iostat=ios) atsym,zz,nc,nv,iexc,psfile
- call read_error(ios,inline)
-
- call cmtskp(inline)
- do ii=1,nc+nv
-   read(5,*,iostat=ios) na(ii),la(ii),fa(ii)
-   call read_error(ios,inline)
- end do
-
-! pseudopotential and optimization
- call cmtskp(inline)
- read(5,*,iostat=ios) lmax
- call read_error(ios,inline)
-
- call cmtskp(inline)
- do l1=1,lmax+1
-   read(5,*,iostat=ios) lt,rc(l1),ep(l1,1),ncon(l1),nbas(l1),qcut(l1)
-   if(lt/=l1-1) ios=999
-   call read_error(ios,inline)
-   ep(l1,2)=ep(l1,1)
- end do
-
-! local potential
- call cmtskp(inline)
- read(5,*, iostat=ios) lloc,lpopt,rc(5),dvloc0
- call read_error(ios,inline)
-
-! Vanderbilt-Kleinman-Bylander projectors
- call cmtskp(inline)
- do l1=1,lmax+1
-   read(5,*,iostat=ios) lt,nproj(l1),debl(l1)
-   if(lt/=l1-1) ios=999
-   call read_error(ios,inline)
- end do
-
-! model core charge
- call cmtskp(inline)
- read(5,*, iostat=ios) icmod, fcfact
- if(ios==0 .and. icmod==3) then
-  backspace(5)
-  read(5,*, iostat=ios) icmod, fcfact, rcfact
+ if(ios /= 0) then
+    write(6,'(a)') 'oncvpsp: ERROR reading input file'
+    stop
  end if
- call read_error(ios,inline)
-
-! log derivative analysis
- call cmtskp(inline)
- read(5,*,iostat=ios) epsh1, epsh2, depsh
- call read_error(ios,inline)
-
-! output grid
- call cmtskp(inline)
- read(5,*,iostat=ios) rlmax,drl
- call read_error(ios,inline)
-
-! test configurations
- call cmtskp(inline)
- read(5,*,iostat=ios) ncnf
- call read_error(ios,inline)
-
- do jj=2,ncnf+1
-   call cmtskp(inline)
-   read(5,*,iostat=ios) nvcnf(jj)
-   call read_error(ios,inline)
-   do ii=nc+1,nc+nvcnf(jj)
-     call cmtskp(inline)
-     read(5,*,iostat=ios) nacnf(ii,jj),lacnf(ii,jj),facnf(ii,jj)
-     call read_error(ios,inline)
-   end do
- end do
-
-! end of reading input data
 
  nvcnf(1)=nv
  do ii=1,nc+nv
@@ -401,7 +411,7 @@
        if(la(kk)==l1-1) npa(1,l1)=na(kk)+1
      end do !kk
    end if
-   
+
 !get all-electron bound states for projectors
    if(nv/=0) then
      do kk=nc+1,nc+nv
@@ -655,7 +665,7 @@
   call run_diag_sr_so_r(lmax,npa,epa,lloc,irc, &
 &                       vsr,esr,vso,eso,nproj,rr,vfull,vp,zz,mmax,mxprj)
 
-! save full info for psml 
+! save full info for psml
  allocate(vpsml(mmax,5,2))
  do l1=1,max(lmax+1,lloc+1)
     ll=l1-1
@@ -693,7 +703,7 @@
 
 ! fix unscreening error due to greater range of all-electron charge
  do ii=mmax,1,-1
- if(rho(ii)==0.0d0) then 
+ if(rho(ii)==0.0d0) then
      do l1=1,max(lmax+1,lloc+1)
        vpuns(ii,l1)=-zion/rr(ii)
      end do

--- a/src/oncvpsp_r.f90
+++ b/src/oncvpsp_r.f90
@@ -35,7 +35,9 @@
  use, intrinsic :: iso_fortran_env, only: stdin => input_unit, stdout => output_unit, stderr => error_unit
  use m_psmlout, only: psmlout_r
  use input_text_m, only: read_input_text_r
+#if (defined WITH_TOML)
  use input_toml_m, only: read_input_toml_r
+#endif
  implicit none
  integer, parameter :: dp=kind(1.0d0)
 
@@ -136,6 +138,7 @@
          end if
          call get_command_argument(i + 1, input_filename)
          input_mode = INPUT_TEXT
+#if (defined WITH_TOML)
        case('-t', '--toml-input')
          if (i + 1 > command_argument_count()) then
             write (stderr, '(a)') 'Error: --toml-input requires a filename argument'
@@ -143,6 +146,10 @@
          end if
          call get_command_argument(i + 1, input_filename)
          input_mode = INPUT_TOML
+#else
+        case('-t', '--toml-input')
+          error stop 'Error: TOML input support not enabled in this build.'
+#endif
        case default
        end select
     end do
@@ -172,6 +179,7 @@
                               rlmax, drl, &
                               ncnf, nvcnf, nacnf, lacnf, facnf)
        close(unit)
+#if (defined WITH_TOML)
     case(INPUT_TOML)
        open(newunit=unit, file=input_filename, status='old', action='read', iostat=ios)
        call read_input_toml_r(unit, &
@@ -184,6 +192,7 @@
                               rlmax, drl, &
                               ncnf, nvcnf, nacnf, lacnf, facnf)
         close(unit)
+#endif
     case default
         write (stderr, '(a,i2)') 'Error: Unknown input mode =', input_mode
         stop 1
@@ -811,3 +820,8 @@
 
  return
  end subroutine read_error
+
+!! Local Variables:
+!! mode: f90
+!! coding: utf-8
+!! End:

--- a/src/run_phsft.f90
+++ b/src/run_phsft.f90
@@ -2,17 +2,17 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
@@ -68,7 +68,7 @@
 
 ! loop for phase shift calculation -- full, then local or Kleinman-
 ! Bylander / Vanderbilt
- 
+
  do l1 = 1, 4
 
    ll = l1 - 1
@@ -79,7 +79,7 @@
    end if
 
    call fphsft(ll,epsh2,depsh,pshf,rr,vfull,zz,mmax,irphs,npsh,srel)
-   if(ll .eq. lloc) then  
+   if(ll .eq. lloc) then
      call  vkbphsft(ll,0,epsh2,depsh,epa(1,l1),pshf,pshp, &
 &                   rr,vp(1,lloc+1),vkb(1,1,l1),evkb(1,l1), &
 &                   mmax,irphs,npsh)

--- a/src/upfout.f90
+++ b/src/upfout.f90
@@ -2,17 +2,17 @@
 ! Copyright (c) 1989-2019 by D. R. Hamann, Mat-Sim Research LLC and Rutgers
 ! University
 !
-! 
+!
 ! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
-! 
+!
 ! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
-! 
+!
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
@@ -33,7 +33,7 @@
 !evkb  coefficients of VKB projectors
 !nproj  number of vkb projectors for each l
 !rr  log radial grid
-!vpuns  unscreened semi-local pseudopotentials (vp(:,5) is local potential 
+!vpuns  unscreened semi-local pseudopotentials (vp(:,5) is local potential
 !  if linear combination is used)
 !rho  valence pseudocharge
 !rhomod  model core charge
@@ -103,7 +103,7 @@
        exit  ! Cutoff radius such that uu norm accurate to 10^-6
      end if
    end do
-   if (rr(jj) > uurcut) uurcut = rr(jj)  
+   if (rr(jj) > uurcut) uurcut = rr(jj)
  end do
  if (uurcut > drl*dble(nrl-1)) then
    nrl = 1 + uurcut/drl
@@ -179,7 +179,7 @@
  write(6,'(t2,a/t2,a/t2,a/t2,a//)') &
 &      'While it is not required under the terms of the GNU GPL, it is',&
 &      'suggested that you cite D. R. Hamann, Phys. Rev. B 88, 085117 (2013)',&
-&      'in any publication using these pseudopotentials.' 
+&      'in any publication using these pseudopotentials.'
 
  write(6,'(a)') &
 &      '    <PP_INPUTFILE>'
@@ -281,7 +281,11 @@
 &        'core_correction="F"'
    end if
 
-   if(iexc==3 .or. iexc==-001009) then
+   if(iexc==2 .or. iexc==-000004) then
+     write(6,'(t8,a)') &
+&        'functional="NOX+HL"'
+
+   else if(iexc==3 .or. iexc==-001009) then
      write(6,'(t8,a)') &
 &        'functional="PZ"'
 
@@ -480,9 +484,9 @@
 &       'label="',na(nc+ii),lnames(l1+1:l1+1),'"'
      write(6,'(t8,a,i1,a)') &
 &          'l="',l1,'" >'
-  
+
   write(6,'(1p,4e20.10)') (uual(jj,ii),jj=1,nrl)
-  
+
   write(6,'(t4,a,i1,a)') &
 &       '</PP_CHI.',ii,'>'
 
@@ -511,7 +515,7 @@
  write(6,'(a)') &
 &      '</UPF>'
 
-  
+
  deallocate(rhol,rl,vkbl,vpl,rhomodl,dmat)
 
 ! write termination flag

--- a/tests/data/TEST.sh
+++ b/tests/data/TEST.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #runs all test data and compares with reference out files
 
-sr_tests="03_Li 07_N 07_N_dl 08_O 14_Si 14_Si_st 14_Si_UPF 17_Cl 19_K 19_K_st 20_Ca 22_Ti 29_Cu 32_Ge 34_Se 38_Sr_lxc 40_Zr 40_Zr_icmod3 40_Zr_icmod5 56_Ba 57_La 60_Nd_GHOST 73_Ta 79_Au_lxc 83_Bi"
+sr_tests="03_Li 07_N 07_N_dl 08_O 14_Si 14_Si_st 14_Si_UPF 17_Cl 19_K 19_K_st 20_Ca 22_Ti 29_Cu 32_Ge 34_Se 38_Sr_lxc 40_Zr 56_Ba 57_La 60_Nd_GHOST 73_Ta 79_Au_lxc 83_Bi"
 r_tests="52_Te 74_W 80_Hg"
 
 for test in $sr_tests; do

--- a/tests/data/TEST.sh
+++ b/tests/data/TEST.sh
@@ -1,32 +1,25 @@
 #!/bin/bash
 #runs all test data and compares with reference out files
 
-../run.sh 03_Li -np	; 	../compare.sh 03_Li
-../run.sh 07_N -np	; 	../compare.sh 07_N
-../run.sh 07_N_dl -np	; 	../compare.sh 07_N_dl
-../run.sh 08_O -np	; 	../compare.sh 08_O
-../run.sh 14_Si -np	; 	../compare.sh 14_Si
-../run.sh 14_Si_st -np	; 	../compare.sh 14_Si_st
-../run.sh 14_Si_UPF -np	; 	../compare.sh 14_Si_UPF
-../run.sh 17_Cl -np	; 	../compare.sh 17_Cl
-../run.sh 19_K -np	; 	../compare.sh 19_K
-../run.sh 19_K_st -np	; 	../compare.sh 19_K_st
-../run.sh 20_Ca -np	; 	../compare.sh 20_Ca
-../run.sh 22_Ti -np	; 	../compare.sh 22_Ti
-../run.sh 29_Cu -np	; 	../compare.sh 29_Cu
-../run.sh 32_Ge -np	; 	../compare.sh 32_Ge
-../run.sh 34_Se -np	; 	../compare.sh 34_Se
-../run.sh 38_Sr_lxc -np	; 	../compare.sh 38_Sr_lxc
-../run.sh 40_Zr -np	; 	../compare.sh 40_Zr
-../run_r.sh 52_Te -np	; 	../compare.sh 52_Te_r
-../run.sh 56_Ba -np	; 	../compare.sh 56_Ba
-../run.sh 57_La -np	; 	../compare.sh 57_La
-../run.sh 60_Nd_GHOST -np	; 	../compare.sh 60_Nd_GHOST
-../run.sh 73_Ta -np	; 	../compare.sh 73_Ta
-../run_r.sh 74_W -np	; 	../compare.sh 74_W_r
-../run.sh 79_Au_lxc -np	; 	../compare.sh 79_Au_lxc
+sr_tests="03_Li 07_N 07_N_dl 08_O 14_Si 14_Si_st 14_Si_UPF 17_Cl 19_K 19_K_st 20_Ca 22_Ti 29_Cu 32_Ge 34_Se 38_Sr_lxc 40_Zr 40_Zr_icmod3 40_Zr_icmod5 56_Ba 57_La 60_Nd_GHOST 73_Ta 79_Au_lxc 83_Bi"
+r_tests="52_Te 74_W 80_Hg"
+
+for test in $sr_tests; do
+    echo "[oncvpsp.x | $test]"
+    ../run.sh $test -np;
+    ../compare.sh $test;
+    summary=$(grep "Summary" $test.diff);
+    echo "    $summary";
+done
+
+for test in $r_tests; do
+    echo "[oncvpspr.x | $test]"
+    ../run_r.sh $test -np;
+    ../compare.sh ${test}_r;
+    summary=$(grep "Summary" ${test}_r.diff);
+    echo "    $summary";
+done
 # this also produces a psml example file for Hg
-../run_r.sh 80_Hg -np	; 	../compare.sh 80_Hg_r; ../extract.sh 80_Hg_r $(pwd); ../compare_psml.sh 80_Hg_r $(pwd)
-../run.sh 83_Bi -np	; 	../compare.sh 83_Bi
+../extract.sh 80_Hg_r $(pwd); ../compare_psml.sh 80_Hg_r $(pwd)
 
 grep Summary *.diff | sed -e /diff/s/^/\\\n/ >TEST.report


### PR DESCRIPTION
This PR (continuing from #17) adds support for TOML-format input in addition to the normal text-based input.

Structured file formats like TOML allow for easily adding features without breaking the backward compatability of the inputs (new fields are simply not parsed by old versions of the code).

Support for the TOML input is enabled by the `-DWITH_TOML` CMake flag which in turn defines the `WITH_TOML` compiler directive which controls pre-processing statements in the `program` files `oncvpsp.F90`, `oncvpsp_nr.F90`, and `oncvpsp_r.F90`.
Using CPM, the `toml-f` library is automatically downloaded and built as a CMake submodule.

There is also a new python script in the scripts directory which converts from the text format to the TOML format.