### PR TITLE
Remove incorrect warning message about Libxc < v5

### DIFF
--- a/src/functionals.F90
+++ b/src/functionals.F90
@@ -174,10 +174,6 @@ contains
     real(8)   :: parameters(2)
     logical :: ok, lb94_modified
 
-#if XC_MAJOR_VERSION<5
-    call messages_input_error('LibXC version', 'at least v5 is now required')
-#endif
-
     ! initialize structure
     call xc_functl_init(functl, nspin, deriv_method)
 


### PR DESCRIPTION
#18 added back support for older versions of Libxc and enabled support for v7.
I didn't notice this warning line being printed at the time, so getting rid of it now.