### PR TITLE
Fix non-rel UPF VKB projector output when nproj(l) > 2

### DIFF
--- a/src/upfout.f90
+++ b/src/upfout.f90
@@ -124,10 +124,9 @@
 ! override dpnint extrapolation to zero for vpl
    vpl(1,l1)=vpuns(1,l1)
    if(l1 .ne. lloc + 1) then
-
-     call dpnint(rr,vkb(1,1,l1),mmax,rl,vkbl(1,1,l1),nrl)
-     call dpnint(rr,vkb(1,2,l1),mmax,rl,vkbl(1,2,l1),nrl)
-
+      do iproj=1,nproj(l1)
+        call dpnint(rr,vkb(1,iproj,l1),mmax,rl,vkbl(1,iproj,l1),nrl)
+      end do
    end if
  end do
 


### PR DESCRIPTION
Only the first 2 projectors for any angular momentum channel were being interpolated onto the linear output mesh for writing.
When any `nproj(l)>2`, this lead to garbage (usually but not always zeros) being written to the the UPF file for higher-index projectors.
Notably, this affects some of the potentials in the PseudoDojo v0.5, which should be regenerated and updated.

Thanks @Technici4n for pointing out some inconsistencies in the PseudoDojo v0.5b UPF vs. PSP8 pseudos.